### PR TITLE
feat(jira): support custom fields in create_issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ CLAUDE.md
 
 # Staging area for temp files
 staging/
+
+.serena/

--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -175,6 +175,8 @@ def resolve_field_value(value, field_type, is_cloud=False):
 
     Handles type conversion for custom fields based on field_type:
     text, number, select, multi-select, version, user, or auto.
+
+    Returns (converted_value, resolved_field_type).
     """
     if field_type == "auto":
         if isinstance(value, (int, float)):
@@ -185,16 +187,16 @@ def resolve_field_value(value, field_type, is_cloud=False):
             field_type = "text"
 
     if field_type == "number":
-        return float(value)
+        return float(value), field_type
     elif field_type == "select":
-        return {"value": value}
+        return {"value": value}, field_type
     elif field_type == "multi-select":
         values = value if isinstance(value, list) else [value]
-        return [{"value": v} for v in values]
+        return [{"value": v} for v in values], field_type
     elif field_type == "version":
         values = value if isinstance(value, list) else [value]
-        return [{"name": v} for v in values]
+        return [{"name": v} for v in values], field_type
     elif field_type == "user":
-        return {"accountId": value} if is_cloud else {"name": value}
+        return ({"accountId": value} if is_cloud else {"name": value}), field_type
     else:
-        return value
+        return value, field_type

--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -168,3 +168,33 @@ def extract_user_fields(user):
         "active": user.get("active"),
         "timeZone": user.get("timeZone"),
     }
+
+
+def resolve_field_value(value, field_type, is_cloud=False):
+    """Convert a value to the appropriate Jira field format.
+
+    Handles type conversion for custom fields based on field_type:
+    text, number, select, multi-select, version, user, or auto.
+    """
+    if field_type == "auto":
+        if isinstance(value, (int, float)):
+            field_type = "number"
+        elif isinstance(value, list):
+            field_type = "multi-select"
+        else:
+            field_type = "text"
+
+    if field_type == "number":
+        return float(value)
+    elif field_type == "select":
+        return {"value": value}
+    elif field_type == "multi-select":
+        values = value if isinstance(value, list) else [value]
+        return [{"value": v} for v in values]
+    elif field_type == "version":
+        values = value if isinstance(value, list) else [value]
+        return [{"name": v} for v in values]
+    elif field_type == "user":
+        return {"accountId": value} if is_cloud else {"name": value}
+    else:
+        return value

--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -155,6 +155,11 @@ tools:
         items:
           type: string
         description: "List of component names"
+      custom_fields:
+        type: array
+        description: "List of custom field objects: [{field_id, value, field_type}]. field_type is optional (auto, text, number, select, multi-select, version, user)"
+        items:
+          type: object
       dry_run:
         type: boolean
         default: true

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -45,9 +45,13 @@ def create_issue(params):
         fields["components"] = normalize_components(comp_list)
 
     for cf in params.get("custom_fields", []):
-        fields[cf["field_id"]], _ = resolve_field_value(
-            cf["value"], cf.get("field_type", "auto"), is_cloud=handler.is_cloud
-        )
+        cf_id = cf["field_id"]
+        if not cf_id.startswith("customfield_"):
+            raise ValueError(
+                f"Invalid custom field ID: '{cf_id}' (must start with 'customfield_'). "
+                "Use the standard parameters for built-in fields."
+            )
+        fields[cf_id], _ = resolve_field_value(cf["value"], cf.get("field_type", "auto"), is_cloud=handler.is_cloud)
 
     if dry_run:
         return {"dry_run": True, "action": "jira_create_issue", "fields": fields}

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -45,7 +45,7 @@ def create_issue(params):
         fields["components"] = normalize_components(comp_list)
 
     for cf in params.get("custom_fields", []):
-        fields[cf["field_id"]] = resolve_field_value(
+        fields[cf["field_id"]], _ = resolve_field_value(
             cf["value"], cf.get("field_type", "auto"), is_cloud=handler.is_cloud
         )
 
@@ -249,7 +249,7 @@ def set_custom_field(params):
     field_type = params.get("field_type", "auto")
     dry_run = params.get("dry_run", True)
 
-    field_value = resolve_field_value(value, field_type, is_cloud=handler.is_cloud)
+    field_value, field_type = resolve_field_value(value, field_type, is_cloud=handler.is_cloud)
 
     if dry_run:
         return {

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -4,7 +4,7 @@ All write tools default to dry_run=true for safety.
 """
 
 import handler
-from helpers import normalize_components, text_to_adf, validate_issue_key
+from helpers import normalize_components, resolve_field_value, text_to_adf, validate_issue_key
 
 
 def create_issue(params):
@@ -43,6 +43,11 @@ def create_issue(params):
     if components:
         comp_list = components if isinstance(components, list) else [components]
         fields["components"] = normalize_components(comp_list)
+
+    for cf in params.get("custom_fields", []):
+        fields[cf["field_id"]] = resolve_field_value(
+            cf["value"], cf.get("field_type", "auto"), is_cloud=handler.is_cloud
+        )
 
     if dry_run:
         return {"dry_run": True, "action": "jira_create_issue", "fields": fields}
@@ -244,29 +249,7 @@ def set_custom_field(params):
     field_type = params.get("field_type", "auto")
     dry_run = params.get("dry_run", True)
 
-    # Type conversion
-    if field_type == "auto":
-        if isinstance(value, (int, float)):
-            field_type = "number"
-        elif isinstance(value, list):
-            field_type = "multi-select"
-        else:
-            field_type = "text"
-
-    if field_type == "number":
-        field_value = float(value)
-    elif field_type == "select":
-        field_value = {"value": value}
-    elif field_type == "multi-select":
-        values = value if isinstance(value, list) else [value]
-        field_value = [{"value": v} for v in values]
-    elif field_type == "version":
-        values = value if isinstance(value, list) else [value]
-        field_value = [{"name": v} for v in values]
-    elif field_type == "user":
-        field_value = {"accountId": value} if handler.is_cloud else {"name": value}
-    else:
-        field_value = value
+    field_value = resolve_field_value(value, field_type, is_cloud=handler.is_cloud)
 
     if dry_run:
         return {


### PR DESCRIPTION
## Summary

- Extract type conversion logic from `set_custom_field` into a shared `resolve_field_value()` helper in `helpers.py`
- Add `custom_fields` parameter to `jira_create_issue` for setting custom fields at creation time
- Refactor `set_custom_field` to use the shared helper, eliminating duplicate code

### Usage

```json
{
  "project": "PROJ",
  "issue_type": "Task",
  "summary": "My new task",
  "custom_fields": [
    {"field_id": "customfield_12345", "value": "rhel-10", "field_type": "version"},
    {"field_id": "customfield_99999", "value": 5.0, "field_type": "number"},
    {"field_id": "customfield_11111", "value": "High", "field_type": "select"}
  ]
}
```

Supported `field_type` values: `auto`, `text`, `number`, `select`, `multi-select`, `version`, `user`

## Test plan

- [ ] Verify `jira_create_issue` with `custom_fields` in dry_run mode returns correct field values
- [ ] Verify `jira_create_issue` with `custom_fields` creates issue with custom fields set
- [ ] Verify `jira_set_custom_field` still works correctly with the refactored helper
- [ ] Verify `create_issue` without `custom_fields` is unchanged (backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)