### PR TITLE
feat: add plugins.disabled config option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type PluginsConfig struct {
 	ShutdownTimeout   time.Duration `yaml:"shutdown_timeout"`
 	ShutdownKillAfter time.Duration `yaml:"shutdown_kill_after"`
 	UserPlugins       bool          `yaml:"user_plugins"`
+	Disabled          []string      `yaml:"disabled"`
 }
 
 // OutputConfig controls tool result encoding.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -221,6 +221,40 @@ tools:
 	}
 }
 
+func TestLoadConfigDisabledPlugins(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	cfgYAML := `
+plugins:
+  disabled:
+    - testing-farm
+    - gitlab
+`
+	if err := os.WriteFile(cfgFile, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgFile, dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Plugins.Disabled) != 2 {
+		t.Fatalf("Disabled = %v, want 2 entries", cfg.Plugins.Disabled)
+	}
+	if cfg.Plugins.Disabled[0] != "testing-farm" {
+		t.Errorf("Disabled[0] = %q, want testing-farm", cfg.Plugins.Disabled[0])
+	}
+	if cfg.Plugins.Disabled[1] != "gitlab" {
+		t.Errorf("Disabled[1] = %q, want gitlab", cfg.Plugins.Disabled[1])
+	}
+}
+
+func TestLoadConfigDisabledPluginsDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Plugins.Disabled != nil {
+		t.Errorf("Disabled should default to nil, got %v", cfg.Plugins.Disabled)
+	}
+}
+
 func TestDefaultPluginDirs(t *testing.T) {
 	userDir := "/tmp/test-user-plugins"
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -103,6 +104,10 @@ func (m *Manager) Discover(dirs []string, userDir string) error {
 			}
 			if !manifest.IsEnabled() {
 				log.Printf("plugin %s is disabled", manifest.Name)
+				continue
+			}
+			if slices.Contains(m.cfg.Plugins.Disabled, manifest.Name) {
+				log.Printf("plugin %s is disabled via config", manifest.Name)
 				continue
 			}
 			if existing, ok := m.manifests[manifest.Name]; ok {

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -92,6 +92,26 @@ func TestManagerDiscover(t *testing.T) {
 	}
 }
 
+func TestManagerDiscoverSkipsConfigDisabled(t *testing.T) {
+	dir := setupTestPlugin(t, "hello", echoScript)
+
+	cfg := config.DefaultConfig()
+	cfg.Plugins.Disabled = []string{"hello"}
+	authReg := auth.NewRegistry()
+	cacheStore := cache.NewMemoryStore()
+	p := proxy.New(nil, cfg.Plugins.MaxMessageSize)
+	m := NewManager(authReg, p, cacheStore, cfg, nil, nil, "")
+
+	if err := m.Discover([]string{dir}, ""); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	manifests := m.Manifests()
+	if len(manifests) != 0 {
+		t.Errorf("got %d manifests, want 0 (plugin should be disabled via config)", len(manifests))
+	}
+}
+
 func TestManagerDiscoverSkipsNonexistentDir(t *testing.T) {
 	m := newTestManager(t)
 	if err := m.Discover([]string{"/nonexistent/path"}, ""); err != nil {


### PR DESCRIPTION
## Summary

- Add plugins.disabled list to config.yaml so plugins can be disabled without modifying plugin source files
- Plugins listed in plugins.disabled are skipped during discovery and do not register any tools
- Fully backwards compatible — empty/missing list means all plugins load as before

## Usage

plugins:
  disabled:
    - testing-farm
    - gitlab

## Changes

- internal/config/config.go — add Disabled []string field to PluginsConfig
- internal/plugin/manager.go — check disabled list during Discover()
- Tests for both config loading and plugin discovery skipping