### PR TITLE
feat(plugins): add Snyk security scanning plugin

### DIFF
--- a/plugins/snyk/context.md
+++ b/plugins/snyk/context.md
@@ -1,0 +1,53 @@
+# Snyk Plugin Context
+
+## Tool Usage Guidelines
+
+### Discovery Flow
+
+Every Snyk session starts with discovering the org ID:
+
+1. Call `snyk_list_orgs` (no args) to get available organizations
+2. Use the org `id` from the result in all subsequent calls
+3. Call `snyk_list_projects` with `org_id` to browse projects
+
+### Issue Identifiers
+
+Each issue has two identifiers — using the wrong one for ignores
+will silently fail:
+
+- `id` — global issue ID, use with `snyk_get_issue`
+- `key` — project-scoped finding ID, use with `snyk_ignore_issue` / `snyk_delete_ignore`
+
+### Triage Workflow
+
+1. List issues: `snyk_list_issues` with `org_id` and optionally `project_id`
+   - Filter by `severity`: critical, high, medium, low
+   - Filter by `issue_type`: package_vulnerability, code, license, cloud, custom
+2. Prioritize critical and high severity first
+3. Check the `ignored` field to skip already-suppressed issues
+4. Get details: `snyk_get_issue` for remediation info
+5. Present findings grouped by severity
+
+### Write Operations
+
+Ignore tools default to `dry_run=true`. Always preview before applying:
+
+1. Call `snyk_ignore_issue` with `dry_run: true` (default)
+2. Show the preview to the user
+3. Only set `dry_run: false` after explicit approval
+
+Ignore reason types:
+- `not-vulnerable` — false positive, the finding does not apply
+- `wont-fix` — accepted risk, acknowledged but won't be fixed
+- `temporary-ignore` — deferred, will be addressed later
+
+### Reviewing Ignores
+
+- `snyk_list_ignores` returns all suppressed issues for a project
+- Use this to audit existing ignores or check for duplicates before adding
+
+### API Notes
+
+- REST API (`/rest/`) is used for read operations (orgs, projects, issues)
+- V1 API (`/v1/`) is used for ignore management (deprecated but no REST replacement yet)
+- Snyk API requires an Enterprise plan for full access

--- a/plugins/snyk/handler.py
+++ b/plugins/snyk/handler.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Snyk plugin handler.
+
+Persistent handler with init/shutdown lifecycle. All HTTP calls go
+through the core proxy. Auth is handled by the core via the bearer
+provider with prefix "token".
+
+Zero dependencies beyond Python stdlib.
+"""
+
+import json
+import sys
+
+_next_id = 0
+config = {}
+
+REST_VERSION = "2024-10-15"
+
+
+def _send(msg):
+    print(json.dumps(msg, separators=(",", ":")), flush=True)
+
+
+def _gen_id(prefix="svc"):
+    global _next_id
+    _next_id += 1
+    return f"{prefix}-{_next_id}"
+
+
+def _recv():
+    line = sys.stdin.readline()
+    if not line:
+        sys.exit(0)
+    return json.loads(line.strip())
+
+
+def log(message):
+    print(f"snyk: {message}", file=sys.stderr)
+
+
+def http(method, path, query=None, body=None, headers=None, url=None):
+    """Make an HTTP request via the core proxy."""
+    msg = {
+        "id": _gen_id("http"),
+        "type": "http_request",
+        "method": method,
+        "path": path,
+    }
+    if url:
+        msg["url"] = url
+    if query:
+        msg["query"] = query
+    if body is not None:
+        msg["body"] = body
+    if headers:
+        msg["headers"] = headers
+    _send(msg)
+    resp = _recv()
+    status = resp.get("status", 0)
+    if status == 0:
+        return 0, {"error": resp.get("error", "request failed")}, {}
+    body = resp.get("body", {})
+    if resp.get("body_encoding") == "base64" and isinstance(body, str):
+        import base64
+        body = json.loads(base64.b64decode(body))
+    elif isinstance(body, str):
+        try:
+            body = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return status, body, resp.get("headers", {})
+
+
+# ---------- REST API helpers ----------
+
+def _rest_get(path, params=None):
+    """GET from the Snyk REST API with versioning."""
+    query = {"version": REST_VERSION}
+    if params:
+        query.update(params)
+    full_path = f"/rest/{path}" if not path.startswith("/rest/") else path
+    status, body, _ = http("GET", full_path, query=query)
+    if status < 200 or status >= 300:
+        err = body if isinstance(body, dict) else {"status": status}
+        raise RuntimeError(f"REST API error ({status}): {json.dumps(err)}")
+    return body
+
+
+def _rest_get_paginated(path, params=None):
+    """GET all pages from a Snyk REST API endpoint."""
+    items = []
+    query = dict(params) if params else {}
+    query.setdefault("limit", "100")
+
+    data = _rest_get(path, query)
+    items.extend(data.get("data", []))
+
+    while True:
+        next_link = (data.get("links") or {}).get("next")
+        if not next_link:
+            break
+        next_url = next_link if next_link.startswith("http") else None
+        if next_url:
+            status, data, _ = http("GET", "", url=next_url)
+            if status < 200 or status >= 300:
+                break
+        else:
+            data = _rest_get(next_link)
+        items.extend(data.get("data", []))
+
+    return items
+
+
+def _v1_request(method, path, body=None):
+    """Make a request to the Snyk V1 API."""
+    full_path = f"/v1/{path}" if not path.startswith("/v1/") else path
+    headers = {"Content-Type": "application/json"}
+    status, resp_body, _ = http(method, full_path, body=body, headers=headers)
+    if status < 200 or status >= 300:
+        err = resp_body if isinstance(resp_body, dict) else {"status": status}
+        raise RuntimeError(f"V1 API error ({status}): {json.dumps(err)}")
+    return resp_body
+
+
+# ---------- Tool implementations ----------
+
+def snyk_list_orgs(params):
+    items = _rest_get_paginated("orgs")
+    orgs = [
+        {
+            "id": o.get("id"),
+            "name": (o.get("attributes") or {}).get("name"),
+            "slug": (o.get("attributes") or {}).get("slug"),
+        }
+        for o in items
+    ]
+    return {"count": len(orgs), "orgs": orgs}
+
+
+def snyk_list_projects(params):
+    org_id = params["org_id"]
+    query = {}
+    name_filter = params.get("name_filter")
+    if name_filter:
+        query["names"] = name_filter
+
+    items = _rest_get_paginated(f"orgs/{org_id}/projects", query)
+    projects = [
+        {
+            "id": p.get("id"),
+            "name": (p.get("attributes") or {}).get("name"),
+            "type": (p.get("attributes") or {}).get("type"),
+            "origin": (p.get("attributes") or {}).get("origin"),
+            "status": (p.get("attributes") or {}).get("status"),
+        }
+        for p in items
+    ]
+
+    if name_filter:
+        lower_filter = name_filter.lower()
+        projects = [p for p in projects if lower_filter in (p.get("name") or "").lower()]
+
+    return {"count": len(projects), "projects": projects}
+
+
+def snyk_list_issues(params):
+    org_id = params["org_id"]
+    query = {}
+    if params.get("project_id"):
+        query["scan_item.id"] = params["project_id"]
+        query["scan_item.type"] = "project"
+    if params.get("severity"):
+        query["severity"] = params["severity"]
+    if params.get("issue_type"):
+        query["type"] = params["issue_type"]
+
+    items = _rest_get_paginated(f"orgs/{org_id}/issues", query)
+    issues = []
+    for i in items:
+        attrs = i.get("attributes") or {}
+        issues.append({
+            "id": i.get("id"),
+            "title": attrs.get("title"),
+            "severity": attrs.get("effective_severity_level") or attrs.get("severity"),
+            "status": attrs.get("status"),
+            "type": attrs.get("type"),
+            "ignored": attrs.get("ignored"),
+            "key": attrs.get("key"),
+        })
+
+    return {"count": len(issues), "issues": issues}
+
+
+def snyk_get_issue(params):
+    org_id = params["org_id"]
+    issue_id = params["issue_id"]
+    data = _rest_get(f"orgs/{org_id}/issues/{issue_id}")
+    return data.get("data", data)
+
+
+def snyk_list_ignores(params):
+    org_id = params["org_id"]
+    project_id = params["project_id"]
+    return _v1_request("GET", f"org/{org_id}/project/{project_id}/ignores")
+
+
+def snyk_ignore_issue(params):
+    org_id = params["org_id"]
+    project_id = params["project_id"]
+    issue_id = params["issue_id"]
+    reason = params["reason"]
+    reason_type = params.get("reason_type", "not-vulnerable")
+    dry_run = params.get("dry_run", True)
+
+    valid_types = ("not-vulnerable", "wont-fix", "temporary-ignore")
+    if reason_type not in valid_types:
+        raise ValueError(f"Invalid reason_type '{reason_type}'. Must be one of: {', '.join(valid_types)}")
+
+    body = {
+        "ignorePath": "*",
+        "reason": reason,
+        "reasonType": reason_type,
+        "disregardIfFixable": False,
+    }
+
+    if dry_run:
+        return {
+            "dry_run": True,
+            "action": "snyk_ignore_issue",
+            "org_id": org_id,
+            "project_id": project_id,
+            "issue_id": issue_id,
+            "body": body,
+        }
+
+    data = _v1_request("POST", f"org/{org_id}/project/{project_id}/ignore/{issue_id}", body)
+    return {"success": True, "issue_id": issue_id, "response": data}
+
+
+def snyk_delete_ignore(params):
+    org_id = params["org_id"]
+    project_id = params["project_id"]
+    issue_id = params["issue_id"]
+    dry_run = params.get("dry_run", True)
+
+    if dry_run:
+        return {
+            "dry_run": True,
+            "action": "snyk_delete_ignore",
+            "org_id": org_id,
+            "project_id": project_id,
+            "issue_id": issue_id,
+        }
+
+    _v1_request("DELETE", f"org/{org_id}/project/{project_id}/ignore/{issue_id}")
+    return {"success": True, "issue_id": issue_id}
+
+
+# ---------- Tool registry ----------
+
+TOOLS = {
+    "snyk_list_orgs": snyk_list_orgs,
+    "snyk_list_projects": snyk_list_projects,
+    "snyk_list_issues": snyk_list_issues,
+    "snyk_get_issue": snyk_get_issue,
+    "snyk_list_ignores": snyk_list_ignores,
+    "snyk_ignore_issue": snyk_ignore_issue,
+    "snyk_delete_ignore": snyk_delete_ignore,
+}
+
+
+# ---------- Main loop ----------
+
+def _init(msg):
+    global config
+    config = msg.get("config", {})
+    log(f"init: api_version={config.get('api_version', REST_VERSION)}")
+
+
+def main():
+    log("handler starting")
+
+    while True:
+        msg = _recv()
+        msg_id = msg.get("id")
+        msg_type = msg.get("type")
+
+        if msg_type == "init":
+            _init(msg)
+            _send({"id": msg_id, "type": "init_ok"})
+            continue
+
+        if msg_type == "shutdown":
+            log("shutting down")
+            _send({"id": msg_id, "type": "shutdown_ok"})
+            break
+
+        if msg_type == "tool_call":
+            tool = msg.get("tool")
+            handler_fn = TOOLS.get(tool)
+            if not handler_fn:
+                _send({
+                    "id": msg_id,
+                    "type": "tool_result",
+                    "error": {"code": "unknown_tool", "message": f"Unknown: {tool}"},
+                })
+                continue
+
+            try:
+                result = handler_fn(msg.get("params", {}))
+                _send({"id": msg_id, "type": "tool_result", "result": result})
+            except Exception as e:
+                log(f"error in {tool}: {e}")
+                _send({
+                    "id": msg_id,
+                    "type": "tool_result",
+                    "error": {"code": "handler_error", "message": str(e)},
+                })
+            continue
+
+        log(f"unknown message type: {msg_type}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/snyk/plugin.yaml
+++ b/plugins/snyk/plugin.yaml
@@ -1,0 +1,182 @@
+name: snyk
+version: "0.1.0"
+description: "Snyk integration for browsing security issues and managing ignores"
+
+execution: persistent
+handler: ./handler.py
+credential_group: snyk
+
+context_files:
+  - context.md
+
+services:
+  auth:
+    type: bearer
+    token: "${SNYK_TOKEN}"
+    prefix: "token"
+  http:
+    base_url: "${SNYK_API_URL:-https://api.snyk.io}"
+
+config:
+  api_version: "2024-10-15"
+
+tools:
+  # --- Read Tools (REST API) ---
+
+  - name: snyk_list_orgs
+    access: read
+    visibility: primary
+    description: >
+      List all Snyk organizations accessible with the configured token.
+      Returns id, name, and slug for each org.
+    params: {}
+
+  - name: snyk_list_projects
+    access: read
+    visibility: primary
+    description: >
+      List projects in a Snyk organization. Optionally filter by name.
+    params:
+      org_id:
+        type: string
+        required: true
+        description: "Organization ID (use snyk_list_orgs to discover)"
+      name_filter:
+        type: string
+        description: "Substring to filter project names"
+
+  - name: snyk_list_issues
+    access: read
+    visibility: primary
+    description: >
+      List issues for a Snyk organization, optionally filtered by project,
+      severity, or type. Each issue has two identifiers: "id" (global,
+      use with snyk_get_issue) and "key" (project-scoped, use with
+      snyk_ignore_issue / snyk_delete_ignore).
+    params:
+      org_id:
+        type: string
+        required: true
+        description: "Organization ID"
+      project_id:
+        type: string
+        description: "Filter by a specific project ID"
+      severity:
+        type: string
+        description: "Filter by severity: critical, high, medium, low"
+      issue_type:
+        type: string
+        description: "Filter by scan type: package_vulnerability, code, license, cloud, custom"
+
+  - name: snyk_get_issue
+    access: read
+    description: >
+      Get full details of a specific Snyk issue including remediation info.
+    params:
+      org_id:
+        type: string
+        required: true
+        description: "Organization ID"
+      issue_id:
+        type: string
+        required: true
+        description: "The issue ID (the 'id' field from snyk_list_issues)"
+
+  # --- Ignore Tools (V1 API) ---
+
+  - name: snyk_list_ignores
+    access: read
+    description: >
+      List all ignored issues for a Snyk project. Returns a map of
+      issue keys (project-scoped finding IDs) to their ignore details.
+    params:
+      org_id:
+        type: string
+        required: true
+        description: "Organization ID"
+      project_id:
+        type: string
+        required: true
+        description: "The project ID"
+
+  - name: snyk_ignore_issue
+    access: write
+    description: >
+      Ignore (suppress) an issue in a Snyk project. Use this to mark
+      findings as false positive, won't fix, or temporary ignore.
+      IMPORTANT: issue_id must be the "key" field from snyk_list_issues
+      (the project-scoped finding ID), NOT the "id" field.
+      Defaults to dry_run=true.
+    params:
+      org_id:
+        type: string
+        required: true
+        description: "Organization ID"
+      project_id:
+        type: string
+        required: true
+        description: "The project ID"
+      issue_id:
+        type: string
+        required: true
+        description: "The issue 'key' (project-scoped finding ID) from snyk_list_issues"
+      reason:
+        type: string
+        required: true
+        description: "Free-text explanation for the ignore"
+      reason_type:
+        type: string
+        default: "not-vulnerable"
+        description: "One of: not-vulnerable (false positive), wont-fix, temporary-ignore"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview only (true) or apply for real (false)"
+
+  - name: snyk_delete_ignore
+    access: write
+    description: >
+      Remove an ignore from an issue in a Snyk project.
+      IMPORTANT: issue_id must be the "key" field from snyk_list_issues.
+      Defaults to dry_run=true.
+    params:
+      org_id:
+        type: string
+        required: true
+        description: "Organization ID"
+      project_id:
+        type: string
+        required: true
+        description: "The project ID"
+      issue_id:
+        type: string
+        required: true
+        description: "The issue 'key' (project-scoped finding ID) to un-ignore"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview only (true) or apply for real (false)"
+
+setup:
+  credentials:
+    SNYK_TOKEN:
+      description: "Snyk Personal Access Token (PAT) or API token"
+      help_url: "https://app.snyk.io/account"
+      instructions: >
+        Log in to Snyk, go to Account Settings > General > Auth Token.
+        Click Generate or copy your existing token.
+      secret: true
+    SNYK_API_URL:
+      description: "Snyk API base URL (default: https://api.snyk.io)"
+      example: "https://api.snyk.io"
+      secret: false
+  variants:
+    default:
+      label: "Snyk (PAT authentication)"
+      description: "For Snyk Enterprise with Personal Access Token"
+      required: [SNYK_TOKEN]
+  validation_tool: snyk_list_orgs
+  post_setup_message: "Restart the MCP server for changes to take effect."
+
+enabled: true
+priority: 50


### PR DESCRIPTION
## Summary

- Add Snyk plugin for browsing security issues and managing ignores via the Snyk API
- 7 tools: `snyk_list_orgs`, `snyk_list_projects`, `snyk_list_issues`, `snyk_get_issue`, `snyk_list_ignores`, `snyk_ignore_issue`, `snyk_delete_ignore`
- Uses **bearer auth with `prefix: "token"`** for Snyk's custom `Authorization: token <PAT>` header format
- Handler decodes base64-encoded response bodies from the core proxy
- Includes `context.md` with discovery flow, id vs key clarification, and triage workflow guidelines

### API strategy

- **REST API** (`/rest/`) for all read operations (orgs, projects, issues) — current GA API
- **V1 API** (`/v1/`) for ignore management — no REST replacement exists yet; will be migrated when Snyk ships one

### Auth

Uses `type: bearer` with `prefix: "token"` in `plugin.yaml`, which maps to the existing `BearerProvider` with custom prefix support. Token is provided via `credential_group: snyk` (`~/.config/wtmcp/env.d/snyk.env`).

### Write safety

All ignore tools (`snyk_ignore_issue`, `snyk_delete_ignore`) default to `dry_run: true` — users must explicitly set `dry_run: false` to apply changes.

## Test plan

- [x] `snyk_list_orgs` — returns 6 orgs
- [x] `snyk_list_projects` — returns projects with id, name, type, origin
- [x] `snyk_list_issues` — returns issues with id, key, severity, ignored status
- [x] `snyk_get_issue` — returns full issue details including remediation info
- [x] `snyk_list_ignores` — returns project ignore map
- [x] `snyk_ignore_issue` — dry run preview + live ignore creation confirmed
- [x] `snyk_delete_ignore` — live ignore removal confirmed