### PR TITLE
feat(jira): add set_parent and clear_parent tools

### DIFF
--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -514,6 +514,43 @@ tools:
         type: boolean
         default: true
 
+  - name: jira_set_parent
+    access: write
+    visibility: primary
+    description: >
+      Set the parent of one or more issues. Works for any hierarchy
+      level: Outcome → Feature, Feature → Epic, Epic → Story/Task, etc.
+      First tries the standard REST API; if that fails due to screen
+      restrictions, automatically falls back to the Agile API (for epic
+      parents). Defaults to dry_run=true.
+    params:
+      parent_key:
+        type: string
+        required: true
+        description: "Parent issue key (e.g. PROJ-100). Can be an Outcome, Feature, Epic, or any issue type."
+      issue_keys:
+        type: string
+        required: true
+        description: "Comma-separated child issue keys to add under the parent (e.g. PROJ-101,PROJ-102)"
+      dry_run:
+        type: boolean
+        default: true
+
+  - name: jira_clear_parent
+    access: write
+    description: >
+      Remove the parent from one or more issues (unlink from any
+      parent). First tries the standard REST API; falls back to the
+      Agile API "none" epic endpoint if needed. Defaults to dry_run=true.
+    params:
+      issue_keys:
+        type: string
+        required: true
+        description: "Comma-separated issue keys to unlink from their parent"
+      dry_run:
+        type: boolean
+        default: true
+
   # --- Phase 3: Sprint Tools ---
 
   - name: jira_list_available_sprints

--- a/plugins/jira/tests/test_tools_write.py
+++ b/plugins/jira/tests/test_tools_write.py
@@ -578,3 +578,150 @@ class TestSprintOps:
                 }
             )
             assert result["success"] is True
+
+
+# --- jira_set_parent / jira_clear_parent ---
+
+
+class TestSetParent:
+    def test_dry_run(self):
+        result = tools_write.set_parent(
+            {
+                "parent_key": "PROJ-100",
+                "issue_keys": "PROJ-101,PROJ-102",
+                "dry_run": True,
+            }
+        )
+        assert result["dry_run"] is True
+        assert result["parent_key"] == "PROJ-100"
+        assert result["issue_keys"] == ["PROJ-101", "PROJ-102"]
+
+    def test_dry_run_list_input(self):
+        result = tools_write.set_parent(
+            {
+                "parent_key": "PROJ-100",
+                "issue_keys": ["PROJ-101"],
+                "dry_run": True,
+            }
+        )
+        assert result["issue_keys"] == ["PROJ-101"]
+
+    def test_empty_issue_keys_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="at least one issue key"):
+            tools_write.set_parent({"parent_key": "PROJ-100", "issue_keys": [], "dry_run": True})
+
+    def test_success_via_rest_api(self):
+        with _mock_http(204, {}) as mock_http:
+            result = tools_write.set_parent(
+                {
+                    "parent_key": "PROJ-100",
+                    "issue_keys": "PROJ-101",
+                    "dry_run": False,
+                }
+            )
+            assert result["success"] is True
+            assert result["parent_key"] == "PROJ-100"
+            call_args = mock_http.call_args
+            assert "/rest/api/2/issue/PROJ-101" in call_args[0][1]
+            call_body = call_args[1].get("body") or call_args[0][2]
+            assert call_body == {"fields": {"parent": {"key": "PROJ-100"}}}
+
+    def test_fallback_to_agile_api(self):
+        responses = [
+            (400, {"errors": {"parent": "not on screen"}}, {}),
+            (204, {}, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses) as mock_http:
+            result = tools_write.set_parent(
+                {
+                    "parent_key": "PROJ-100",
+                    "issue_keys": "PROJ-101",
+                    "dry_run": False,
+                }
+            )
+            assert result["success"] is True
+            agile_call = mock_http.call_args_list[1]
+            assert "/rest/agile/1.0/epic/PROJ-100/issue" in agile_call[0][1]
+
+    def test_multiple_issues_partial_fallback(self):
+        responses = [
+            (204, {}, {}),
+            (400, {"errors": {"parent": "not on screen"}}, {}),
+            (204, {}, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses) as mock_http:
+            result = tools_write.set_parent(
+                {
+                    "parent_key": "PROJ-100",
+                    "issue_keys": "PROJ-101,PROJ-102",
+                    "dry_run": False,
+                }
+            )
+            assert result["success"] is True
+            assert mock_http.call_count == 3
+            agile_call = mock_http.call_args_list[2]
+            agile_body = agile_call[1].get("body") or agile_call[0][2]
+            assert agile_body == {"issues": ["PROJ-102"]}
+
+    def test_agile_fallback_error(self):
+        responses = [
+            (400, {}, {}),
+            (500, {"errorMessages": ["Server error"]}, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses):
+            result = tools_write.set_parent(
+                {
+                    "parent_key": "PROJ-100",
+                    "issue_keys": "PROJ-101",
+                    "dry_run": False,
+                }
+            )
+            assert "error" in result
+
+
+class TestClearParent:
+    def test_dry_run(self):
+        result = tools_write.clear_parent(
+            {
+                "issue_keys": "PROJ-101,PROJ-102",
+                "dry_run": True,
+            }
+        )
+        assert result["dry_run"] is True
+        assert result["issue_keys"] == ["PROJ-101", "PROJ-102"]
+
+    def test_empty_issue_keys_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="at least one issue key"):
+            tools_write.clear_parent({"issue_keys": [], "dry_run": True})
+
+    def test_success_via_rest_api(self):
+        with _mock_http(204, {}) as mock_http:
+            result = tools_write.clear_parent(
+                {
+                    "issue_keys": "PROJ-101",
+                    "dry_run": False,
+                }
+            )
+            assert result["success"] is True
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][2]
+            assert call_body == {"fields": {"parent": {"key": None}}}
+
+    def test_fallback_to_agile_none_epic(self):
+        responses = [
+            (400, {}, {}),
+            (204, {}, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses) as mock_http:
+            result = tools_write.clear_parent(
+                {
+                    "issue_keys": "PROJ-101",
+                    "dry_run": False,
+                }
+            )
+            assert result["success"] is True
+            agile_call = mock_http.call_args_list[1]
+            assert "/rest/agile/1.0/epic/none/issue" in agile_call[0][1]

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -443,6 +443,99 @@ def add_issues_to_backlog(params):
     return {"success": True, "issue_keys": issue_keys}
 
 
+def set_parent(params):
+    """Set the parent of one or more issues.
+
+    Works for any hierarchy level: Outcome → Feature → Epic → Story/Task.
+    Tries the standard REST API first; if that fails (screen restrictions),
+    falls back to the Agile API (epic-level parents only).
+    """
+    parent_key = validate_issue_key(params.get("parent_key", ""))
+    issue_keys = params.get("issue_keys", [])
+    dry_run = params.get("dry_run", True)
+
+    if isinstance(issue_keys, str):
+        issue_keys = [k.strip() for k in issue_keys.split(",") if k.strip()]
+
+    if not issue_keys:
+        raise ValueError("issue_keys must contain at least one issue key")
+
+    if dry_run:
+        return {
+            "dry_run": True,
+            "action": "jira_set_parent",
+            "parent_key": parent_key,
+            "issue_keys": issue_keys,
+        }
+
+    # Try standard REST API (works for all hierarchy levels)
+    rest_failed = []
+    for key in issue_keys:
+        status, body, _ = handler.http(
+            "PUT", f"/rest/api/2/issue/{key}",
+            body={"fields": {"parent": {"key": parent_key}}},
+        )
+        if status < 200 or status >= 300:
+            rest_failed.append(key)
+
+    if not rest_failed:
+        return {"success": True, "parent_key": parent_key, "issue_keys": issue_keys}
+
+    # Fallback: Agile API for issues that failed (handles epic screen restrictions)
+    status, body, _ = handler.http(
+        "POST", f"/rest/agile/1.0/epic/{parent_key}/issue",
+        body={"issues": rest_failed},
+    )
+    if status < 200 or status >= 300:
+        return http_error(status, body)
+    return {"success": True, "parent_key": parent_key, "issue_keys": issue_keys}
+
+
+def clear_parent(params):
+    """Remove the parent from one or more issues.
+
+    Tries the standard REST API first; if that fails, falls back to the
+    Agile API "none" epic endpoint.
+    """
+    issue_keys = params.get("issue_keys", [])
+    dry_run = params.get("dry_run", True)
+
+    if isinstance(issue_keys, str):
+        issue_keys = [k.strip() for k in issue_keys.split(",") if k.strip()]
+
+    if not issue_keys:
+        raise ValueError("issue_keys must contain at least one issue key")
+
+    if dry_run:
+        return {
+            "dry_run": True,
+            "action": "jira_clear_parent",
+            "issue_keys": issue_keys,
+        }
+
+    # Try standard REST API ({"key": null} clears the parent on Cloud)
+    rest_failed = []
+    for key in issue_keys:
+        status, body, _ = handler.http(
+            "PUT", f"/rest/api/2/issue/{key}",
+            body={"fields": {"parent": {"key": None}}},
+        )
+        if status < 200 or status >= 300:
+            rest_failed.append(key)
+
+    if not rest_failed:
+        return {"success": True, "issue_keys": issue_keys}
+
+    # Fallback: Agile API moves issues out of any epic
+    status, body, _ = handler.http(
+        "POST", "/rest/agile/1.0/epic/none/issue",
+        body={"issues": rest_failed},
+    )
+    if status < 200 or status >= 300:
+        return http_error(status, body)
+    return {"success": True, "issue_keys": issue_keys}
+
+
 TOOLS = {
     "jira_create_issue": create_issue,
     "jira_add_comment": add_comment,
@@ -462,4 +555,6 @@ TOOLS = {
     "jira_issue_worklog": issue_worklog,
     "jira_add_issues_to_sprint": add_issues_to_sprint,
     "jira_add_issues_to_backlog": add_issues_to_backlog,
+    "jira_set_parent": set_parent,
+    "jira_clear_parent": clear_parent,
 }


### PR DESCRIPTION
## Summary

- Add `jira_set_parent` tool: set the parent of one or more issues across any hierarchy level (Outcome → Feature → Epic → Story/Task). Tries the standard REST API first; if screen restrictions prevent it, automatically falls back to the Jira Agile API (`POST /rest/agile/1.0/epic/{key}/issue`).
- Add `jira_clear_parent` tool: remove the parent from one or more issues using the same dual-strategy approach (REST API + Agile "none" epic fallback).
- Both tools follow the existing `dry_run=true` default pattern and comma-separated `issue_keys` input format.

## Motivation

Setting parent/epic links via `jira_set_custom_field` fails on many Jira Cloud instances because the Parent Link field (`customfield_10018`) is not on the issue edit screen. The Agile API endpoint bypasses these screen restrictions entirely, making it the reliable way to manage epic-child relationships.

## Changes

| File | Change |
|------|--------|
| `plugins/jira/tools_write.py` | Add `set_parent()` and `clear_parent()` functions + register in `TOOLS` dict |
| `plugins/jira/plugin.yaml` | Add tool definitions with params and descriptions |
| `plugins/jira/tests/test_tools_write.py` | Add 11 unit tests (dry runs, REST success, Agile fallback, partial failures, validation) |

## Test plan

- [x] All 60 unit tests pass (`pytest tests/test_tools_write.py` — 60 passed)
- [ ] Manual test: `jira_set_parent` with dry_run=true returns preview
- [ ] Manual test: `jira_set_parent` with dry_run=false links child to epic
- [ ] Manual test: `jira_clear_parent` removes parent link