### PR TITLE
chore: update .gitignore for build and runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Binaries
 /wtmcp
 /wtmcpctl
-plugins/google-*/handler
+plugins/*/handler
 
 # Test/coverage
 coverage.out
@@ -20,6 +20,10 @@ Thumbs.db
 # Python
 .venv/
 __pycache__/
+uv.lock
+
+# Plugin runtime artifacts
+control/
 
 # Environment
 .env


### PR DESCRIPTION
## Summary

- Generalize plugin binary pattern from `plugins/google-*/handler` to `plugins/*/handler` — covers all plugin compiled binaries (gitlab, jira, future plugins), not just Google ones
- Add `uv.lock` (generated by `uv run pytest`)
- Add `control/` (MCP runtime control directory with commands/results)

## Test plan

- [x] Verified no tracked files were removed (`git diff --name-status HEAD` shows only `.gitignore` modified)
- [x] All previously untracked build artifacts now properly ignored