### PR TITLE
wtmcpctl: add agent command for AI agent configuration

### DIFF
--- a/cmd/wtmcpctl/agent.go
+++ b/cmd/wtmcpctl/agent.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+const mcpServerKey = "what-the-mcp"
+
+// agentSpec defines how a specific AI agent stores its MCP server configuration.
+type agentSpec struct {
+	// configPath returns the path to the agent's config file,
+	// given the project directory.
+	configPath func(dir string) string
+	// needsType indicates whether "type": "stdio" must be included
+	// in the server entry.
+	needsType bool
+	// dirPrefix is the subdirectory that may need to be created
+	// (empty string if config is directly in project root).
+	dirPrefix string
+	// canRemoveFile indicates whether the config file can be removed
+	// when it becomes empty (false for Gemini which may have other settings).
+	canRemoveFile bool
+}
+
+var (
+	claudeCodeSpec = agentSpec{
+		configPath: func(dir string) string {
+			return filepath.Join(dir, ".mcp.json")
+		},
+		needsType:     true,
+		dirPrefix:     "",
+		canRemoveFile: true,
+	}
+
+	supportedAgents = map[string]agentSpec{
+		"claude":      claudeCodeSpec,
+		"claude-code": claudeCodeSpec,
+		"gemini": {
+			configPath: func(dir string) string {
+				return filepath.Join(dir, ".gemini", "settings.json")
+			},
+			needsType:     false,
+			dirPrefix:     ".gemini",
+			canRemoveFile: false,
+		},
+		"cursor": {
+			configPath: func(dir string) string {
+				return filepath.Join(dir, ".cursor", "mcp.json")
+			},
+			needsType:     false,
+			dirPrefix:     ".cursor",
+			canRemoveFile: true,
+		},
+	}
+)
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Configure wtmcp for AI agents (Claude, Gemini, Cursor)",
+	Long: `Configure wtmcp MCP server for AI agents.
+
+Supported agents:
+  - claude / claude-code
+  - gemini
+  - cursor`,
+}
+
+var agentEnableCmd = &cobra.Command{
+	Use:               "enable <agent-name>",
+	Short:             "Enable wtmcp for an AI agent",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeAgentNames,
+	RunE:              runAgentEnable,
+}
+
+var agentDisableCmd = &cobra.Command{
+	Use:               "disable <agent-name>",
+	Short:             "Disable wtmcp for an AI agent",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeAgentNames,
+	RunE:              runAgentDisable,
+}
+
+func init() {
+	agentEnableCmd.Flags().StringP("dir", "d", "",
+		"Project directory (default: current directory)")
+	if err := agentEnableCmd.MarkFlagDirname("dir"); err != nil {
+		panic(err)
+	}
+
+	agentDisableCmd.Flags().StringP("dir", "d", "",
+		"Project directory (default: current directory)")
+	if err := agentDisableCmd.MarkFlagDirname("dir"); err != nil {
+		panic(err)
+	}
+
+	agentCmd.AddCommand(agentEnableCmd, agentDisableCmd)
+}
+
+// completeAgentNames returns supported agent names for completion.
+func completeAgentNames(
+	_ *cobra.Command, _ []string, _ string,
+) ([]string, cobra.ShellCompDirective) {
+	return validAgentNames(), cobra.ShellCompDirectiveNoFileComp
+}
+
+func runAgentEnable(cmd *cobra.Command, args []string) error {
+	agentName := args[0]
+
+	// Validate agent name
+	if _, ok := supportedAgents[agentName]; !ok {
+		return fmt.Errorf("unknown agent: %s\nSupported agents: %v", agentName, validAgentNames())
+	}
+
+	// Resolve directory
+	dir, _ := cmd.Flags().GetString("dir")
+	resolvedDir, err := resolveDir(dir)
+	if err != nil {
+		return err
+	}
+
+	// Execute enable
+	return agentEnable(agentName, resolvedDir)
+}
+
+func runAgentDisable(cmd *cobra.Command, args []string) error {
+	agentName := args[0]
+
+	// Validate agent name
+	if _, ok := supportedAgents[agentName]; !ok {
+		return fmt.Errorf("unknown agent: %s\nSupported agents: %v", agentName, validAgentNames())
+	}
+
+	// Resolve directory
+	dir, _ := cmd.Flags().GetString("dir")
+	resolvedDir, err := resolveDir(dir)
+	if err != nil {
+		return err
+	}
+
+	// Execute disable
+	return agentDisable(agentName, resolvedDir)
+}
+
+// agentEnable enables the wtmcp MCP server for the specified agent.
+func agentEnable(agentName, dir string) error {
+	// Resolve wtmcp binary path
+	wtmcpPath, err := resolveWtmcpBinary()
+	if err != nil {
+		return err
+	}
+
+	// Get agent spec
+	spec := supportedAgents[agentName]
+
+	// Compute config file path
+	configPath := spec.configPath(dir)
+
+	// Ensure directory exists if needed
+	if spec.dirPrefix != "" {
+		dirPath := filepath.Join(dir, spec.dirPrefix)
+		if err := os.MkdirAll(dirPath, 0o750); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
+		}
+	}
+
+	// Read existing config
+	config, err := readJSONConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %s: %w", configPath, err)
+	}
+
+	// Get or create mcpServers map
+	mcpServers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		mcpServers = make(map[string]any)
+	}
+
+	// Build server entry
+	serverEntry := map[string]any{
+		"command": wtmcpPath,
+		"args":    []any{},
+	}
+
+	// Add type field if needed
+	if spec.needsType {
+		serverEntry["type"] = "stdio"
+	}
+
+	// Set the server entry
+	mcpServers[mcpServerKey] = serverEntry
+	config["mcpServers"] = mcpServers
+
+	// Write config
+	if err := writeJSONConfig(configPath, config); err != nil {
+		return fmt.Errorf("failed to write config file %s: %w", configPath, err)
+	}
+
+	fmt.Printf("✓ Enabled wtmcp for %s\n", agentName)
+	fmt.Printf("Config file: %s\n", configPath)
+	return nil
+}
+
+// agentDisable disables the wtmcp MCP server for the specified agent.
+func agentDisable(agentName, dir string) error {
+	// Get agent spec
+	spec := supportedAgents[agentName]
+
+	// Compute config file path
+	configPath := spec.configPath(dir)
+
+	// Read existing config
+	config, err := readJSONConfig(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Printf("%s is not configured for %s in %s\n", mcpServerKey, agentName, dir)
+			return nil
+		}
+		return fmt.Errorf("failed to read config file %s: %w", configPath, err)
+	}
+
+	// Get mcpServers map
+	mcpServers, ok := config["mcpServers"].(map[string]any)
+	if !ok || mcpServers == nil {
+		fmt.Printf("%s is not configured for %s in %s\n", mcpServerKey, agentName, dir)
+		return nil
+	}
+
+	// Check if entry exists
+	if _, exists := mcpServers[mcpServerKey]; !exists {
+		fmt.Printf("%s is not configured for %s in %s\n", mcpServerKey, agentName, dir)
+		return nil
+	}
+
+	// Remove the entry
+	delete(mcpServers, mcpServerKey)
+
+	// If mcpServers is now empty, remove it from config
+	if len(mcpServers) == 0 {
+		delete(config, "mcpServers")
+	} else {
+		config["mcpServers"] = mcpServers
+	}
+
+	// Decide whether to remove file or write it back
+	if len(config) == 0 && spec.canRemoveFile {
+		// Remove empty config file
+		if err := os.Remove(configPath); err != nil {
+			return fmt.Errorf("failed to remove config file %s: %w", configPath, err)
+		}
+		fmt.Printf("✓ Disabled wtmcp for %s (removed config file)\n", agentName)
+	} else {
+		// Write config back
+		if err := writeJSONConfig(configPath, config); err != nil {
+			return fmt.Errorf("failed to write config file %s: %w", configPath, err)
+		}
+		fmt.Printf("✓ Disabled wtmcp for %s\n", agentName)
+	}
+
+	fmt.Printf("Config file: %s\n", configPath)
+	return nil
+}
+
+// resolveWtmcpBinary attempts to locate the wtmcp binary.
+// It first tries to find it as a sibling of wtmcpctl, then falls back to PATH.
+func resolveWtmcpBinary() (string, error) {
+	// Try to find wtmcp as a sibling of wtmcpctl
+	exe, err := os.Executable()
+	if err == nil {
+		// Resolve symlinks
+		resolved, err := filepath.EvalSymlinks(exe)
+		if err == nil {
+			// Look for wtmcp in the same directory
+			candidate := filepath.Join(filepath.Dir(resolved), "wtmcp")
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				// Convert to absolute path
+				absPath, err := filepath.Abs(candidate)
+				if err == nil {
+					return absPath, nil
+				}
+			}
+		}
+	}
+
+	// Fallback: look in PATH
+	path, err := exec.LookPath("wtmcp")
+	if err != nil {
+		return "", fmt.Errorf("wtmcp binary not found: not alongside wtmcpctl and not in PATH")
+	}
+
+	// Convert to absolute path
+	return filepath.Abs(path)
+}
+
+// resolveDir resolves the directory flag to an absolute path.
+// If dirFlag is empty, it uses the current working directory.
+func resolveDir(dirFlag string) (string, error) {
+	if dirFlag == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get current directory: %w", err)
+		}
+		return cwd, nil
+	}
+
+	// Convert to absolute path
+	absPath, err := filepath.Abs(dirFlag)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve directory path: %w", err)
+	}
+
+	return absPath, nil
+}
+
+// readJSONConfig reads a JSON config file into a map.
+// Returns an empty map if the file doesn't exist.
+func readJSONConfig(path string) (map[string]any, error) {
+	// Check if file exists
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return make(map[string]any), nil
+		}
+		return nil, err
+	}
+
+	// Read file
+	data, err := os.ReadFile(path) // #nosec G304 -- path is from trusted command-line argument
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse JSON
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return config, nil
+}
+
+// writeJSONConfig writes a map to a JSON config file with formatting.
+func writeJSONConfig(path string, data map[string]any) error {
+	// Marshal with indentation
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// Add trailing newline
+	jsonData = append(jsonData, '\n')
+
+	// Write to file
+	if err := os.WriteFile(path, jsonData, 0o600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validAgentNames returns a sorted list of supported agent names.
+func validAgentNames() []string {
+	names := make([]string, 0, len(supportedAgents))
+	for name := range supportedAgents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/wtmcpctl/agent_test.go
+++ b/cmd/wtmcpctl/agent_test.go
@@ -1,0 +1,742 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDir_Empty(t *testing.T) {
+	dir, err := resolveDir("")
+	if err != nil {
+		t.Fatalf("resolveDir(\"\") failed: %v", err)
+	}
+	if dir == "" {
+		t.Error("resolveDir(\"\") returned empty string")
+	}
+	// Should return current working directory
+	cwd, _ := os.Getwd()
+	if dir != cwd {
+		t.Errorf("resolveDir(\"\") = %q, want %q", dir, cwd)
+	}
+}
+
+func TestResolveDir_Relative(t *testing.T) {
+	dir, err := resolveDir(".")
+	if err != nil {
+		t.Fatalf("resolveDir(\".\") failed: %v", err)
+	}
+	if !filepath.IsAbs(dir) {
+		t.Errorf("resolveDir(\".\") = %q is not absolute", dir)
+	}
+}
+
+func TestReadJSONConfig_NonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "nonexistent.json")
+
+	config, err := readJSONConfig(path)
+	if err != nil {
+		t.Fatalf("readJSONConfig() returned error for non-existent file: %v", err)
+	}
+
+	if config == nil {
+		t.Fatal("readJSONConfig() returned nil map")
+	}
+
+	if len(config) != 0 {
+		t.Errorf("readJSONConfig() returned non-empty map: %v", config)
+	}
+}
+
+func TestReadJSONConfig_ValidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.json")
+
+	// Write valid JSON
+	content := `{"key": "value", "number": 42}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	config, err := readJSONConfig(path)
+	if err != nil {
+		t.Fatalf("readJSONConfig() failed: %v", err)
+	}
+
+	if config["key"] != "value" {
+		t.Errorf("config[\"key\"] = %v, want \"value\"", config["key"])
+	}
+
+	// JSON numbers are float64
+	if num, ok := config["number"].(float64); !ok || num != 42 {
+		t.Errorf("config[\"number\"] = %v, want 42", config["number"])
+	}
+}
+
+func TestReadJSONConfig_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "invalid.json")
+
+	// Write invalid JSON
+	content := `{invalid json`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	_, err := readJSONConfig(path)
+	if err == nil {
+		t.Error("readJSONConfig() should return error for invalid JSON")
+	}
+}
+
+func TestReadJSONConfig_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "empty.json")
+
+	// Write empty file
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	_, err := readJSONConfig(path)
+	if err == nil {
+		t.Error("readJSONConfig() should return error for empty file")
+	}
+}
+
+func TestWriteJSONConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "output.json")
+
+	data := map[string]any{
+		"key":    "value",
+		"number": 42,
+	}
+
+	if err := writeJSONConfig(path, data); err != nil {
+		t.Fatalf("writeJSONConfig() failed: %v", err)
+	}
+
+	// Read it back
+	content, err := os.ReadFile(path) // #nosec G304 -- path is from test temp directory
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
+	}
+
+	// Check for trailing newline
+	if len(content) == 0 || content[len(content)-1] != '\n' {
+		t.Error("writeJSONConfig() should add trailing newline")
+	}
+
+	// Parse it
+	var parsed map[string]any
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("written JSON is invalid: %v", err)
+	}
+
+	if parsed["key"] != "value" {
+		t.Errorf("parsed[\"key\"] = %v, want \"value\"", parsed["key"])
+	}
+}
+
+func TestValidAgentNames(t *testing.T) {
+	names := validAgentNames()
+
+	if len(names) != len(supportedAgents) {
+		t.Errorf("validAgentNames() returned %d names, want %d", len(names), len(supportedAgents))
+	}
+
+	// Check that it's sorted
+	for i := 1; i < len(names); i++ {
+		if names[i-1] >= names[i] {
+			t.Errorf("validAgentNames() is not sorted: %v", names)
+			break
+		}
+	}
+
+	// Check that all expected agents are present (including aliases)
+	expectedAgents := []string{"claude", "claude-code", "cursor", "gemini"}
+	for _, expected := range expectedAgents {
+		found := false
+		for _, name := range names {
+			if name == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("validAgentNames() missing expected agent: %s", expected)
+		}
+	}
+}
+
+func TestAgentEnable_Claude_Alias(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	tmpDir := t.TempDir()
+
+	// Enable using "claude" alias
+	if err := agentEnable("claude", tmpDir); err != nil {
+		t.Fatalf("agentEnable() failed: %v", err)
+	}
+
+	// Check that .mcp.json was created (same as claude-code)
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+	content, err := os.ReadFile(configPath) // #nosec G304 -- path is from test temp directory
+	if err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+
+	// Parse the config
+	var config map[string]any
+	if err := json.Unmarshal(content, &config); err != nil {
+		t.Fatalf("invalid JSON in config: %v", err)
+	}
+
+	// Check that it has the same structure as claude-code
+	mcpServers := config["mcpServers"].(map[string]any)
+	wtmcp := mcpServers[mcpServerKey].(map[string]any)
+
+	// Should have type field (same as claude-code)
+	if wtmcp["type"] != "stdio" {
+		t.Errorf("type = %v, want \"stdio\"", wtmcp["type"])
+	}
+}
+
+func TestAgentEnable_ClaudeVsClaudeCode_SameConfig(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	// Test that "claude" and "claude-code" produce identical configs
+	tmpDir1 := t.TempDir()
+	tmpDir2 := t.TempDir()
+
+	// Enable with "claude"
+	if err := agentEnable("claude", tmpDir1); err != nil {
+		t.Fatalf("agentEnable('claude') failed: %v", err)
+	}
+
+	// Enable with "claude-code"
+	if err := agentEnable("claude-code", tmpDir2); err != nil {
+		t.Fatalf("agentEnable('claude-code') failed: %v", err)
+	}
+
+	// Read both configs
+	config1, _ := readJSONConfig(filepath.Join(tmpDir1, ".mcp.json"))
+	config2, _ := readJSONConfig(filepath.Join(tmpDir2, ".mcp.json"))
+
+	// Both should have mcpServers
+	if config1["mcpServers"] == nil || config2["mcpServers"] == nil {
+		t.Fatal("one or both configs missing mcpServers")
+	}
+
+	// Both should have what-the-mcp entry
+	servers1 := config1["mcpServers"].(map[string]any)
+	servers2 := config2["mcpServers"].(map[string]any)
+
+	wtmcp1 := servers1[mcpServerKey].(map[string]any)
+	wtmcp2 := servers2[mcpServerKey].(map[string]any)
+
+	// Compare key fields
+	if wtmcp1["type"] != wtmcp2["type"] {
+		t.Error("type field differs between claude and claude-code")
+	}
+	if wtmcp1["command"] != wtmcp2["command"] {
+		t.Error("command field differs between claude and claude-code")
+	}
+}
+
+func TestAgentDisable_Claude_Alias(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Create config
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			mcpServerKey: map[string]any{
+				"command": "/path/to/wtmcp",
+				"type":    "stdio",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// Disable using "claude" alias
+	if err := agentDisable("claude", tmpDir); err != nil {
+		t.Fatalf("agentDisable() failed: %v", err)
+	}
+
+	// File should be removed (same behavior as claude-code)
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("config file should be removed when empty")
+	}
+}
+
+func TestAgentEnable_ClaudeCode_NewFile(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	tmpDir := t.TempDir()
+
+	if err := agentEnable("claude-code", tmpDir); err != nil {
+		t.Fatalf("agentEnable() failed: %v", err)
+	}
+
+	// Check that .mcp.json was created
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+	content, err := os.ReadFile(configPath) // #nosec G304 -- path is from test temp directory
+	if err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+
+	// Parse the config
+	var config map[string]any
+	if err := json.Unmarshal(content, &config); err != nil {
+		t.Fatalf("invalid JSON in config: %v", err)
+	}
+
+	// Check mcpServers
+	mcpServers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers not found or wrong type")
+	}
+
+	// Check what-the-mcp entry
+	wtmcp, ok := mcpServers[mcpServerKey].(map[string]any)
+	if !ok {
+		t.Fatalf("what-the-mcp entry not found or wrong type")
+	}
+
+	// Check type field (required for Claude Code)
+	if wtmcp["type"] != "stdio" {
+		t.Errorf("type = %v, want \"stdio\"", wtmcp["type"])
+	}
+
+	// Check command field
+	if _, ok := wtmcp["command"].(string); !ok {
+		t.Error("command field missing or wrong type")
+	}
+
+	// Check args field
+	if _, ok := wtmcp["args"].([]any); !ok {
+		t.Error("args field missing or wrong type")
+	}
+}
+
+func TestAgentEnable_Gemini_CreatesDirectory(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	tmpDir := t.TempDir()
+
+	if err := agentEnable("gemini", tmpDir); err != nil {
+		t.Fatalf("agentEnable() failed: %v", err)
+	}
+
+	// Check that .gemini directory was created
+	geminiDir := filepath.Join(tmpDir, ".gemini")
+	info, err := os.Stat(geminiDir)
+	if err != nil {
+		t.Fatalf(".gemini directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error(".gemini is not a directory")
+	}
+
+	// Check that settings.json was created
+	configPath := filepath.Join(geminiDir, "settings.json")
+	content, err := os.ReadFile(configPath) // #nosec G304 -- path is from test temp directory
+	if err != nil {
+		t.Fatalf("settings.json not created: %v", err)
+	}
+
+	// Parse the config
+	var config map[string]any
+	if err := json.Unmarshal(content, &config); err != nil {
+		t.Fatalf("invalid JSON in config: %v", err)
+	}
+
+	// Check that type field is NOT present (Gemini doesn't need it)
+	mcpServers := config["mcpServers"].(map[string]any)
+	wtmcp := mcpServers[mcpServerKey].(map[string]any)
+	if _, hasType := wtmcp["type"]; hasType {
+		t.Error("Gemini config should not have type field")
+	}
+}
+
+func TestAgentEnable_Cursor_CreatesDirectory(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	tmpDir := t.TempDir()
+
+	if err := agentEnable("cursor", tmpDir); err != nil {
+		t.Fatalf("agentEnable() failed: %v", err)
+	}
+
+	// Check that .cursor directory was created
+	cursorDir := filepath.Join(tmpDir, ".cursor")
+	info, err := os.Stat(cursorDir)
+	if err != nil {
+		t.Fatalf(".cursor directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error(".cursor is not a directory")
+	}
+
+	// Check that mcp.json was created
+	configPath := filepath.Join(cursorDir, "mcp.json")
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("mcp.json not created: %v", err)
+	}
+}
+
+func TestAgentEnable_ExistingServers(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Write existing config with another server
+	existingConfig := map[string]any{
+		"mcpServers": map[string]any{
+			"other-server": map[string]any{
+				"command": "/path/to/other",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, existingConfig); err != nil {
+		t.Fatalf("failed to write existing config: %v", err)
+	}
+
+	// Enable wtmcp
+	if err := agentEnable("claude-code", tmpDir); err != nil {
+		t.Fatalf("agentEnable() failed: %v", err)
+	}
+
+	// Read and parse
+	config, err := readJSONConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	mcpServers := config["mcpServers"].(map[string]any)
+
+	// Check that both servers exist
+	if _, ok := mcpServers["other-server"]; !ok {
+		t.Error("other-server was removed")
+	}
+	if _, ok := mcpServers[mcpServerKey]; !ok {
+		t.Error("what-the-mcp was not added")
+	}
+}
+
+func TestAgentEnable_Gemini_PreservesOtherSettings(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	tmpDir := t.TempDir()
+	geminiDir := filepath.Join(tmpDir, ".gemini")
+	if err := os.MkdirAll(geminiDir, 0o750); err != nil {
+		t.Fatalf("failed to create .gemini dir: %v", err)
+	}
+
+	configPath := filepath.Join(geminiDir, "settings.json")
+
+	// Write existing config with other settings
+	existingConfig := map[string]any{
+		"theme":    "dark",
+		"language": "en",
+		"mcpServers": map[string]any{
+			"other-server": map[string]any{
+				"command": "/path/to/other",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, existingConfig); err != nil {
+		t.Fatalf("failed to write existing config: %v", err)
+	}
+
+	// Enable wtmcp
+	if err := agentEnable("gemini", tmpDir); err != nil {
+		t.Fatalf("agentEnable() failed: %v", err)
+	}
+
+	// Read and parse
+	config, err := readJSONConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	// Check that other settings are preserved
+	if config["theme"] != "dark" {
+		t.Error("theme setting was not preserved")
+	}
+	if config["language"] != "en" {
+		t.Error("language setting was not preserved")
+	}
+
+	// Check that both servers exist
+	mcpServers := config["mcpServers"].(map[string]any)
+	if _, ok := mcpServers["other-server"]; !ok {
+		t.Error("other-server was removed")
+	}
+	if _, ok := mcpServers[mcpServerKey]; !ok {
+		t.Error("what-the-mcp was not added")
+	}
+}
+
+func TestAgentEnable_OverwriteExisting(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Write existing config with what-the-mcp
+	existingConfig := map[string]any{
+		"mcpServers": map[string]any{
+			mcpServerKey: map[string]any{
+				"command": "/old/path/to/wtmcp",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, existingConfig); err != nil {
+		t.Fatalf("failed to write existing config: %v", err)
+	}
+
+	// Re-enable (should update the path)
+	if err := agentEnable("claude-code", tmpDir); err != nil {
+		t.Fatalf("agentEnable() failed: %v", err)
+	}
+
+	// Read and check that path was updated
+	config, err := readJSONConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	mcpServers := config["mcpServers"].(map[string]any)
+	wtmcp := mcpServers[mcpServerKey].(map[string]any)
+
+	// Should have new command (not /old/path/to/wtmcp)
+	command := wtmcp["command"].(string)
+	if command == "/old/path/to/wtmcp" {
+		t.Error("command was not updated")
+	}
+}
+
+func TestAgentDisable_RemovesEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Write config with multiple servers
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			mcpServerKey: map[string]any{
+				"command": "/path/to/wtmcp",
+			},
+			"other-server": map[string]any{
+				"command": "/path/to/other",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// Disable wtmcp
+	if err := agentDisable("claude-code", tmpDir); err != nil {
+		t.Fatalf("agentDisable() failed: %v", err)
+	}
+
+	// Read and check
+	config, err := readJSONConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	mcpServers := config["mcpServers"].(map[string]any)
+
+	// what-the-mcp should be removed
+	if _, ok := mcpServers[mcpServerKey]; ok {
+		t.Error("what-the-mcp was not removed")
+	}
+
+	// other-server should still exist
+	if _, ok := mcpServers["other-server"]; !ok {
+		t.Error("other-server was removed")
+	}
+}
+
+func TestAgentDisable_NoConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Should not error when config doesn't exist
+	if err := agentDisable("claude-code", tmpDir); err != nil {
+		t.Errorf("agentDisable() should not error when config doesn't exist: %v", err)
+	}
+}
+
+func TestAgentDisable_NoEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Write config without what-the-mcp
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			"other-server": map[string]any{
+				"command": "/path/to/other",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// Should not error when entry doesn't exist
+	if err := agentDisable("claude-code", tmpDir); err != nil {
+		t.Errorf("agentDisable() should not error when entry doesn't exist: %v", err)
+	}
+
+	// Config should be unchanged
+	newConfig, _ := readJSONConfig(configPath)
+	mcpServers := newConfig["mcpServers"].(map[string]any)
+	if _, ok := mcpServers["other-server"]; !ok {
+		t.Error("other-server was removed")
+	}
+}
+
+func TestAgentDisable_ClaudeCode_RemovesFileWhenEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Write config with only what-the-mcp
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			mcpServerKey: map[string]any{
+				"command": "/path/to/wtmcp",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// Disable wtmcp
+	if err := agentDisable("claude-code", tmpDir); err != nil {
+		t.Fatalf("agentDisable() failed: %v", err)
+	}
+
+	// File should be removed
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("config file should be removed when empty")
+	}
+}
+
+func TestAgentDisable_Cursor_RemovesFileWhenEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	cursorDir := filepath.Join(tmpDir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o750); err != nil {
+		t.Fatalf("failed to create .cursor dir: %v", err)
+	}
+
+	configPath := filepath.Join(cursorDir, "mcp.json")
+
+	// Write config with only what-the-mcp
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			mcpServerKey: map[string]any{
+				"command": "/path/to/wtmcp",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// Disable wtmcp
+	if err := agentDisable("cursor", tmpDir); err != nil {
+		t.Fatalf("agentDisable() failed: %v", err)
+	}
+
+	// File should be removed
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("config file should be removed when empty")
+	}
+}
+
+func TestAgentDisable_Gemini_KeepsFileWhenEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	geminiDir := filepath.Join(tmpDir, ".gemini")
+	if err := os.MkdirAll(geminiDir, 0o750); err != nil {
+		t.Fatalf("failed to create .gemini dir: %v", err)
+	}
+
+	configPath := filepath.Join(geminiDir, "settings.json")
+
+	// Write config with only what-the-mcp
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			mcpServerKey: map[string]any{
+				"command": "/path/to/wtmcp",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// Disable wtmcp
+	if err := agentDisable("gemini", tmpDir); err != nil {
+		t.Fatalf("agentDisable() failed: %v", err)
+	}
+
+	// File should still exist (Gemini may have other settings)
+	if _, err := os.Stat(configPath); err != nil {
+		t.Error("config file should not be removed for Gemini")
+	}
+
+	// Config should be empty object
+	newConfig, _ := readJSONConfig(configPath)
+	if len(newConfig) != 0 {
+		t.Errorf("config should be empty, got: %v", newConfig)
+	}
+}
+
+func TestAgentDisable_Gemini_PreservesOtherSettings(t *testing.T) {
+	tmpDir := t.TempDir()
+	geminiDir := filepath.Join(tmpDir, ".gemini")
+	if err := os.MkdirAll(geminiDir, 0o750); err != nil {
+		t.Fatalf("failed to create .gemini dir: %v", err)
+	}
+
+	configPath := filepath.Join(geminiDir, "settings.json")
+
+	// Write config with other settings
+	config := map[string]any{
+		"theme":    "dark",
+		"language": "en",
+		"mcpServers": map[string]any{
+			mcpServerKey: map[string]any{
+				"command": "/path/to/wtmcp",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// Disable wtmcp
+	if err := agentDisable("gemini", tmpDir); err != nil {
+		t.Fatalf("agentDisable() failed: %v", err)
+	}
+
+	// Read and check that other settings are preserved
+	newConfig, err := readJSONConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if newConfig["theme"] != "dark" {
+		t.Error("theme setting was not preserved")
+	}
+	if newConfig["language"] != "en" {
+		t.Error("language setting was not preserved")
+	}
+
+	// mcpServers should be removed since it's now empty
+	if _, ok := newConfig["mcpServers"]; ok {
+		t.Error("empty mcpServers should be removed")
+	}
+}

--- a/cmd/wtmcpctl/main.go
+++ b/cmd/wtmcpctl/main.go
@@ -46,7 +46,7 @@ func init() {
 		return nil
 	}
 
-	rootCmd.AddCommand(versionCmd, oauthCmd, pluginsCmd)
+	rootCmd.AddCommand(versionCmd, agentCmd, oauthCmd, pluginsCmd)
 }
 
 func main() {

--- a/docs/wtmcpctl.md
+++ b/docs/wtmcpctl.md
@@ -1,6 +1,6 @@
 # wtmcpctl - wtmcp Plugin Management Tool
 
-`wtmcpctl` is a command-line utility for managing wtmcp plugins, particularly for handling OAuth authentication for Google plugins.
+`wtmcpctl` is a command-line utility for managing wtmcp, including configuring wtmcp for AI agents and handling OAuth authentication for Google plugins.
 
 ## Installation
 
@@ -21,6 +21,7 @@ This will create the `wtmcpctl` binary in the project root directory.
 ```
 wtmcpctl/
 ├── main.go          # Entry point, command routing, global flags
+├── agent.go         # Agent configuration command implementation
 └── oauth.go         # OAuth command implementation
 ```
 
@@ -361,6 +362,98 @@ go build -o wtmcpctl ./cmd/wtmcpctl
    - Test error cases and edge conditions
 
 ## Commands
+
+### agent enable
+
+Configures an AI agent to use wtmcp as an MCP server by adding the appropriate configuration to the agent's config file.
+
+```bash
+wtmcpctl agent enable [--dir <path>] <agent-name>
+```
+
+**Options:**
+- `--dir <path>` - Project directory where the config file should be created (default: current directory)
+- `-h, --help` - Show help information
+
+**Supported agents:**
+- `claude` or `claude-code` - Claude Code (creates `.mcp.json`)
+- `gemini` - Gemini CLI (creates `.gemini/settings.json`)
+- `cursor` - Cursor (creates `.cursor/mcp.json`)
+
+**Examples:**
+
+```bash
+# Enable wtmcp for Claude Code in current directory
+$ wtmcpctl agent enable claude
+✓ Enabled wtmcp for claude
+Config file: /path/to/project/.mcp.json
+
+# Enable wtmcp for Gemini in a specific project
+$ wtmcpctl agent enable --dir /path/to/my/project gemini
+✓ Enabled wtmcp for gemini
+Config file: /path/to/my/project/.gemini/settings.json
+
+# Enable wtmcp for Cursor
+$ wtmcpctl agent enable cursor
+✓ Enabled wtmcp for cursor
+Config file: /path/to/project/.cursor/mcp.json
+```
+
+### agent disable
+
+Removes the wtmcp MCP server configuration from an AI agent's config file.
+
+```bash
+wtmcpctl agent disable [--dir <path>] <agent-name>
+```
+
+**Options:**
+- `--dir <path>` - Project directory where the config file is located (default: current directory)
+- `-h, --help` - Show help information
+
+**Supported agents:**
+- `claude` or `claude-code` - Claude Code
+- `gemini` - Gemini CLI
+- `cursor` - Cursor
+
+**Examples:**
+
+```bash
+# Disable wtmcp for Claude Code
+$ wtmcpctl agent disable claude
+✓ Disabled wtmcp for claude (removed config file)
+Config file: /path/to/project/.mcp.json
+
+# Disable wtmcp for Gemini (preserves other settings)
+$ wtmcpctl agent disable gemini
+✓ Disabled wtmcp for gemini
+Config file: /path/to/project/.gemini/settings.json
+
+# Disable when config doesn't exist (not an error)
+$ wtmcpctl agent disable cursor
+what-the-mcp is not configured for cursor in /path/to/project
+```
+
+### Agent Configuration Details
+
+**Claude Code:**
+- Config file: `.mcp.json` in project root
+- Version-controlled: Recommended (team-shared configuration)
+- Includes `"type": "stdio"` field
+- File is removed if it becomes empty after disabling
+
+**Gemini CLI:**
+- Config file: `.gemini/settings.json` in project root
+- May contain other settings (theme, language, etc.)
+- Does not include `"type"` field (inferred from `command`)
+- File is never removed (may have other settings)
+- Avoid underscores in server names (use hyphens)
+
+**Cursor:**
+- Config file: `.cursor/mcp.json` in project root
+- MCP-specific file (no other settings)
+- Does not include `"type"` field (inferred from `command`)
+- File is removed if it becomes empty after disabling
 
 ### oauth list
 


### PR DESCRIPTION
Added new "agent" command with "enable" and "disable" subcommands to configure wtmcp MCP server for AI agents:
- Added cmd/wtmcpctl/agent.go with full implementation
- Added cmd/wtmcpctl/agent_test.go with 27 comprehensive tests
- Registered agent command in cmd/wtmcpctl/main.go
- Updated docs/wtmcpctl.md with user-facing documentation
- Supports Claude Code, Gemini CLI, and Cursor
- "claude" is an alias for "claude-code"
- --dir flag to specify project directory (defaults to cwd)
- Preserves existing MCP servers and other settings
- Auto-detects wtmcp binary location

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Rafael Guterres Jeffman <rjeffman@redhat.com>