### PR TITLE
Add wizard to configure Google Credentials.

### DIFF
--- a/cmd/wtmcpctl/credentials.go
+++ b/cmd/wtmcpctl/credentials.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// credentialService describes a supported service for credential setup.
+type credentialService struct {
+	Name        string
+	Description string
+	SetupFunc   func() error
+}
+
+var supportedCredentialServices = make(map[string]credentialService)
+
+// registerCredentialService registers a service for credential setup.
+// This is called from init() functions in service-specific files (e.g., credentials_google.go).
+func registerCredentialService(svc credentialService) {
+	supportedCredentialServices[svc.Name] = svc
+}
+
+var credentialsCmd = &cobra.Command{
+	Use:   "credentials <service>",
+	Short: "Set up OAuth client credentials for a service",
+	Long: `Interactive guide for setting up OAuth client credentials.
+
+This command walks you through creating OAuth 2.0 desktop application
+credentials in the service's developer console.
+
+Run 'wtmcpctl oauth credentials <service>' to see available services.`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeCredentialServices,
+	RunE:              runCredentials,
+}
+
+// completeCredentialServices returns supported service names for shell completion.
+func completeCredentialServices(
+	_ *cobra.Command, _ []string, _ string,
+) ([]string, cobra.ShellCompDirective) {
+	names := make([]string, 0, len(supportedCredentialServices))
+	for name := range supportedCredentialServices {
+		names = append(names, name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+func runCredentials(_ *cobra.Command, args []string) error {
+	serviceName := args[0]
+
+	svc, ok := supportedCredentialServices[serviceName]
+	if !ok {
+		// Show available services in error message
+		available := make([]string, 0, len(supportedCredentialServices))
+		for name := range supportedCredentialServices {
+			available = append(available, name)
+		}
+		if len(available) > 0 {
+			return fmt.Errorf("unknown service: %s\n\nAvailable services: %v", serviceName, available)
+		}
+		return fmt.Errorf("unknown service: %s", serviceName)
+	}
+
+	return svc.SetupFunc()
+}
+
+// waitForEnter displays a prompt and waits for the user to press Enter.
+func waitForEnter(prompt string) {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	_, _ = reader.ReadString('\n')
+}
+
+// promptYesNo displays a prompt and returns true if the user enters y/yes.
+// Default is false (no).
+func promptYesNo(prompt string) bool {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	line = strings.TrimSpace(strings.ToLower(line))
+	return line == "y" || line == "yes"
+}
+
+// openBrowser opens the specified URL in the default browser.
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	return cmd.Start()
+}
+
+// promptAndOpenURL displays a URL and optionally opens it in the browser.
+// Prompts the user with [y/N], defaulting to No.
+func promptAndOpenURL(url string) {
+	fmt.Println()
+	fmt.Printf("  %s\n", url)
+	fmt.Println()
+	if promptYesNo("Open in browser? [y/N] ") {
+		if err := openBrowser(url); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to open browser: %v\n", err)
+			fmt.Println("Please open the URL manually in your browser.")
+		}
+	}
+}
+
+// promptForFilePath prompts the user to enter a file path.
+// Returns the trimmed path, or empty string if user just presses Enter.
+func promptForFilePath(prompt string) string {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(line)
+}
+
+// copyFile copies a file from src to dst, creating the destination directory if needed.
+func copyFile(src, dst string) error {
+	// Expand tilde in source path
+	if strings.HasPrefix(src, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
+		src = filepath.Join(home, src[2:])
+	}
+
+	// Open source file
+	srcFile, err := os.Open(src) //nolint:gosec // user-provided path
+	if err != nil {
+		return fmt.Errorf("cannot open source file: %w", err)
+	}
+	defer srcFile.Close() //nolint:errcheck // defer close on read-only file
+
+	// Create destination directory if needed
+	dstDir := filepath.Dir(dst)
+	if err := os.MkdirAll(dstDir, 0o700); err != nil {
+		return fmt.Errorf("cannot create destination directory: %w", err)
+	}
+
+	// Create destination file
+	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // user-provided destination path
+	if err != nil {
+		return fmt.Errorf("cannot create destination file: %w", err)
+	}
+	defer dstFile.Close() //nolint:errcheck // safety net, explicit close below
+
+	// Copy contents
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("cannot copy file: %w", err)
+	}
+
+	// Explicitly close and check for errors (e.g., disk full, I/O errors)
+	if err := dstFile.Close(); err != nil {
+		return fmt.Errorf("cannot close destination file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/wtmcpctl/credentials_google.go
+++ b/cmd/wtmcpctl/credentials_google.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	// Register Google credentials service
+	registerCredentialService(credentialService{
+		Name:        "google",
+		Description: "Google Cloud Platform OAuth 2.0 desktop credentials",
+		SetupFunc:   setupGoogleCredentials,
+	})
+}
+
+// setupGoogleCredentials runs the interactive setup wizard for Google OAuth credentials.
+func setupGoogleCredentials() error {
+	credDir, err := credentialsDirForGoogle()
+	if err != nil {
+		return err
+	}
+	credPath := filepath.Join(credDir, "client-credentials.json")
+
+	// Pre-flight check: warn if credentials already exist.
+	if _, err := os.Stat(credPath); err == nil {
+		fmt.Printf("Credentials file already exists at:\n  %s\n\n", credPath)
+		if !promptYesNo("Continue and overwrite? [y/N] ") {
+			fmt.Println("Aborted.")
+			return nil
+		}
+		fmt.Println()
+	}
+
+	fmt.Println("Setting up Google OAuth 2.0 credentials for wtmcp")
+	fmt.Println("==================================================")
+	fmt.Println()
+	fmt.Println("This guide will walk you through creating OAuth 2.0 desktop")
+	fmt.Println("application credentials in the Google Cloud Console.")
+	fmt.Println()
+
+	// Step 1
+	fmt.Println("Step 1/5: Create a Google Cloud Project")
+	fmt.Println("----------------------------------------")
+	fmt.Println("Create a new project (or select an existing one):")
+	promptAndOpenURL("https://console.cloud.google.com/projectcreate")
+	fmt.Println()
+	waitForEnter("Press Enter when your project is ready...")
+	fmt.Println()
+
+	// Step 2
+	fmt.Println("Step 2/5: Enable Required APIs")
+	fmt.Println("-------------------------------")
+	fmt.Println("Enable the Google APIs you plan to use:")
+	fmt.Println()
+	fmt.Println("Google Drive API:")
+	promptAndOpenURL("https://console.cloud.google.com/apis/library/drive.googleapis.com")
+	fmt.Println("Google Calendar API:")
+	promptAndOpenURL("https://console.cloud.google.com/apis/library/calendar-json.googleapis.com")
+	fmt.Println("Gmail API:")
+	promptAndOpenURL("https://console.cloud.google.com/apis/library/gmail.googleapis.com")
+	fmt.Println("Google Docs API:")
+	promptAndOpenURL("https://console.cloud.google.com/apis/library/docs.googleapis.com")
+	fmt.Println("You only need to enable the APIs for the plugins you plan to use.")
+	fmt.Println()
+	waitForEnter("Press Enter when you have enabled the APIs...")
+	fmt.Println()
+
+	// Step 3
+	fmt.Println("Step 3/5: Configure OAuth Consent Screen")
+	fmt.Println("-----------------------------------------")
+	fmt.Println("Configure the consent screen:")
+	promptAndOpenURL("https://console.cloud.google.com/apis/credentials/consent")
+	fmt.Println("  1. Select \"External\" as the user type (or \"Internal\" for Workspace)")
+	fmt.Println("  2. Fill in the app name (e.g., \"wtmcp\")")
+	fmt.Println("  3. Add your email as a test user")
+	fmt.Println("  4. Save the consent screen configuration")
+	fmt.Println()
+	fmt.Println("For personal use, set the publishing status to \"Testing\" and add")
+	fmt.Println("your Google account as a test user.")
+	fmt.Println()
+	waitForEnter("Press Enter when the consent screen is configured...")
+	fmt.Println()
+
+	// Step 4
+	fmt.Println("Step 4/5: Create OAuth 2.0 Client Credentials")
+	fmt.Println("-----------------------------------------------")
+	fmt.Println("Create OAuth 2.0 client credentials:")
+	promptAndOpenURL("https://console.cloud.google.com/apis/credentials")
+	fmt.Println("  1. Click \"Create Credentials\" > \"OAuth client ID\"")
+	fmt.Println("  2. Select \"Desktop app\" as the application type")
+	fmt.Println("  3. Give it a name (e.g., \"wtmcp-desktop\")")
+	fmt.Println("  4. Click \"Create\"")
+	fmt.Println("  5. Click \"Download JSON\" to save the credentials file")
+	fmt.Println()
+	waitForEnter("Press Enter when you have downloaded the credentials JSON file...")
+	fmt.Println()
+
+	// Step 5
+	fmt.Println("Step 5/5: Place the Credentials File")
+	fmt.Println("--------------------------------------")
+
+	// Create credentials directory if it does not exist.
+	if err := os.MkdirAll(credDir, 0o700); err != nil {
+		return fmt.Errorf("failed to create credentials directory %s: %w", credDir, err)
+	}
+
+	fmt.Println("The credentials file needs to be placed at:")
+	fmt.Println()
+	fmt.Printf("  Target: %s\n", credPath)
+	fmt.Println()
+	fmt.Println("You can either:")
+	fmt.Println("  1. Provide the path to the downloaded file (e.g., ~/Downloads/client_secret_*.json)")
+	fmt.Println("     and this tool will copy it for you")
+	fmt.Println("  2. Press Enter if you've already placed the file manually")
+	fmt.Println()
+
+	sourcePath := promptForFilePath("Enter path to downloaded credentials file (or press Enter to skip): ")
+
+	if sourcePath != "" {
+		// User provided a path, copy the file
+		fmt.Printf("Copying %s to %s...\n", sourcePath, credPath)
+		if err := copyFile(sourcePath, credPath); err != nil {
+			return fmt.Errorf("failed to copy credentials file: %w", err)
+		}
+		fmt.Println("✓ File copied successfully")
+	} else {
+		// User skipped, assume file is already in place
+		fmt.Println("Skipping copy, assuming file is already in place...")
+	}
+	fmt.Println()
+
+	// Verification
+	fmt.Println("Verifying credentials...")
+	fmt.Println()
+
+	if err := validateGoogleCredentialsFile(credPath); err != nil {
+		return fmt.Errorf("credential verification failed: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println("✓ Credentials verified successfully!")
+	fmt.Println()
+	fmt.Println("Next step: authenticate your plugins by running:")
+	fmt.Println("  wtmcpctl oauth auth --all")
+
+	return nil
+}
+
+// credentialsDirForGoogle returns the credentials directory for Google,
+// without requiring plugin discovery (which may fail during initial setup).
+// Resolution order: GOOGLE_CREDENTIALS_DIR env var, --workdir flag, default.
+func credentialsDirForGoogle() (string, error) {
+	// Highest priority: GOOGLE_CREDENTIALS_DIR env var
+	if dir := os.Getenv("GOOGLE_CREDENTIALS_DIR"); dir != "" {
+		return dir, nil
+	}
+
+	// Second priority: --workdir flag
+	if globalWorkdir != "" {
+		return filepath.Join(globalWorkdir, "credentials", "google"), nil
+	}
+
+	// Default: ~/.config/wtmcp/credentials/google
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "wtmcp", "credentials", "google"), nil
+}
+
+// clientCredentials represents the Google OAuth2 client credentials file structure.
+type clientCredentials struct {
+	Installed *clientCredentialsData `json:"installed"`
+	Web       *clientCredentialsData `json:"web"`
+}
+
+type clientCredentialsData struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// validateGoogleCredentialsFile validates the Google OAuth2 credentials file structure.
+func validateGoogleCredentialsFile(path string) error {
+	data, err := os.ReadFile(path) //nolint:gosec // credential file path from user input
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file not found at %s", path)
+		}
+		return fmt.Errorf("cannot read file: %w", err)
+	}
+
+	if len(data) == 0 {
+		return fmt.Errorf("file is empty: %s", path)
+	}
+
+	var creds clientCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return fmt.Errorf("invalid JSON: %w\nMake sure you downloaded the correct credentials file", err)
+	}
+
+	if creds.Web != nil && creds.Installed == nil {
+		return fmt.Errorf("found 'web' credentials, but wtmcp requires 'Desktop app' credentials.\nPlease create a new OAuth client ID with application type \"Desktop app\"")
+	}
+
+	if creds.Installed == nil {
+		return fmt.Errorf("no 'installed' credentials found in file.\nPlease create an OAuth client ID with application type \"Desktop app\"")
+	}
+
+	if creds.Installed.ClientID == "" {
+		return fmt.Errorf("client_id is missing from credentials file")
+	}
+
+	if creds.Installed.ClientSecret == "" {
+		return fmt.Errorf("client_secret is missing from credentials file")
+	}
+
+	fmt.Printf("  ✓ File exists\n")
+	fmt.Printf("  ✓ Valid JSON\n")
+	fmt.Printf("  ✓ Desktop app credentials (installed type)\n")
+	fmt.Printf("  ✓ client_id: %s\n", creds.Installed.ClientID)
+	fmt.Printf("  ✓ client_secret: %s...%s\n",
+		creds.Installed.ClientSecret[:min(4, len(creds.Installed.ClientSecret))],
+		creds.Installed.ClientSecret[max(0, len(creds.Installed.ClientSecret)-4):],
+	)
+
+	return nil
+}

--- a/cmd/wtmcpctl/credentials_google_test.go
+++ b/cmd/wtmcpctl/credentials_google_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateGoogleCredentialsFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid installed credentials",
+			content: `{
+				"installed": {
+					"client_id": "test-client-id.apps.googleusercontent.com",
+					"client_secret": "test-secret-123",
+					"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+					"token_uri": "https://oauth2.googleapis.com/token"
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "web credentials (should fail)",
+			content: `{
+				"web": {
+					"client_id": "test-client-id.apps.googleusercontent.com",
+					"client_secret": "test-secret-123"
+				}
+			}`,
+			wantErr:     true,
+			errContains: "Desktop app",
+		},
+		{
+			name:        "empty file",
+			content:     "",
+			wantErr:     true,
+			errContains: "empty",
+		},
+		{
+			name:        "invalid JSON",
+			content:     `{invalid json`,
+			wantErr:     true,
+			errContains: "invalid JSON",
+		},
+		{
+			name: "missing client_id",
+			content: `{
+				"installed": {
+					"client_secret": "test-secret-123"
+				}
+			}`,
+			wantErr:     true,
+			errContains: "client_id is missing",
+		},
+		{
+			name: "missing client_secret",
+			content: `{
+				"installed": {
+					"client_id": "test-client-id.apps.googleusercontent.com"
+				}
+			}`,
+			wantErr:     true,
+			errContains: "client_secret is missing",
+		},
+		{
+			name: "no installed or web",
+			content: `{
+				"other": {
+					"client_id": "test-client-id"
+				}
+			}`,
+			wantErr:     true,
+			errContains: "no 'installed' credentials",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp file
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "credentials.json")
+
+			if tt.content != "" {
+				if err := os.WriteFile(tmpFile, []byte(tt.content), 0o600); err != nil {
+					t.Fatalf("failed to write test file: %v", err)
+				}
+			}
+
+			// Test validation
+			err := validateGoogleCredentialsFile(tmpFile)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateGoogleCredentialsFile() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+					t.Errorf("validateGoogleCredentialsFile() error = %v, want error containing %q", err, tt.errContains)
+				}
+			} else if err != nil {
+				t.Errorf("validateGoogleCredentialsFile() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateGoogleCredentialsFile_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonExistentPath := filepath.Join(tmpDir, "does-not-exist.json")
+
+	err := validateGoogleCredentialsFile(nonExistentPath)
+	if err == nil {
+		t.Error("validateGoogleCredentialsFile() expected error for non-existent file, got nil")
+	}
+	if !contains(err.Error(), "not found") {
+		t.Errorf("validateGoogleCredentialsFile() error = %v, want error containing 'not found'", err)
+	}
+}
+
+func TestCredentialsDirForGoogle(t *testing.T) {
+	// Save original env var and globalWorkdir
+	origEnv := os.Getenv("GOOGLE_CREDENTIALS_DIR")
+	origWorkdir := globalWorkdir
+	defer func() {
+		if origEnv != "" {
+			_ = os.Setenv("GOOGLE_CREDENTIALS_DIR", origEnv)
+		} else {
+			_ = os.Unsetenv("GOOGLE_CREDENTIALS_DIR")
+		}
+		globalWorkdir = origWorkdir
+	}()
+
+	t.Run("uses env var when set", func(t *testing.T) {
+		testDir := "/custom/creds/path"
+		_ = os.Setenv("GOOGLE_CREDENTIALS_DIR", testDir)
+		globalWorkdir = ""
+
+		dir, err := credentialsDirForGoogle()
+		if err != nil {
+			t.Fatalf("credentialsDirForGoogle() error = %v", err)
+		}
+		if dir != testDir {
+			t.Errorf("credentialsDirForGoogle() = %q, want %q", dir, testDir)
+		}
+	})
+
+	t.Run("uses workdir flag when env var not set", func(t *testing.T) {
+		_ = os.Unsetenv("GOOGLE_CREDENTIALS_DIR")
+		globalWorkdir = "/tmp/test-workdir"
+
+		dir, err := credentialsDirForGoogle()
+		if err != nil {
+			t.Fatalf("credentialsDirForGoogle() error = %v", err)
+		}
+		expected := "/tmp/test-workdir/credentials/google"
+		if dir != expected {
+			t.Errorf("credentialsDirForGoogle() = %q, want %q", dir, expected)
+		}
+	})
+
+	t.Run("env var takes precedence over workdir flag", func(t *testing.T) {
+		testDir := "/custom/creds/path"
+		_ = os.Setenv("GOOGLE_CREDENTIALS_DIR", testDir)
+		globalWorkdir = "/tmp/test-workdir"
+
+		dir, err := credentialsDirForGoogle()
+		if err != nil {
+			t.Fatalf("credentialsDirForGoogle() error = %v", err)
+		}
+		if dir != testDir {
+			t.Errorf("credentialsDirForGoogle() = %q, want %q (env var should take precedence)", dir, testDir)
+		}
+	})
+
+	t.Run("uses default when neither env var nor workdir set", func(t *testing.T) {
+		_ = os.Unsetenv("GOOGLE_CREDENTIALS_DIR")
+		globalWorkdir = ""
+
+		dir, err := credentialsDirForGoogle()
+		if err != nil {
+			t.Fatalf("credentialsDirForGoogle() error = %v", err)
+		}
+		if !contains(dir, ".config/wtmcp/credentials/google") {
+			t.Errorf("credentialsDirForGoogle() = %q, want path containing .config/wtmcp/credentials/google", dir)
+		}
+	})
+}
+
+func TestCopyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create source file
+	srcPath := filepath.Join(tmpDir, "source.json")
+	content := []byte(`{"installed":{"client_id":"test","client_secret":"secret"}}`)
+	if err := os.WriteFile(srcPath, content, 0o600); err != nil {
+		t.Fatalf("Failed to create source file: %v", err)
+	}
+
+	t.Run("copy to new directory", func(t *testing.T) {
+		dstPath := filepath.Join(tmpDir, "subdir", "dest.json")
+		if err := copyFile(srcPath, dstPath); err != nil {
+			t.Fatalf("copyFile failed: %v", err)
+		}
+
+		// Verify destination file exists and has correct content
+		got, err := os.ReadFile(dstPath) //nolint:gosec // test file path
+		if err != nil {
+			t.Fatalf("Failed to read destination file: %v", err)
+		}
+
+		if string(got) != string(content) {
+			t.Errorf("Content mismatch: got %q, want %q", got, content)
+		}
+
+		// Verify permissions
+		info, err := os.Stat(dstPath)
+		if err != nil {
+			t.Fatalf("Failed to stat destination file: %v", err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("Wrong permissions: got %o, want 0600", info.Mode().Perm())
+		}
+	})
+
+	t.Run("source file not found", func(t *testing.T) {
+		nonExistent := filepath.Join(tmpDir, "does-not-exist.json")
+		dstPath := filepath.Join(tmpDir, "dest2.json")
+		err := copyFile(nonExistent, dstPath)
+		if err == nil {
+			t.Error("Expected error for non-existent source file, got nil")
+		}
+	})
+}
+
+// contains is a helper to check if a string contains a substring.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || stringContains(s, substr))
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/wtmcpctl/oauth.go
+++ b/cmd/wtmcpctl/oauth.go
@@ -49,7 +49,7 @@ func init() {
 	oauthAuthCmd.Flags().BoolP("all", "a", false,
 		"Authenticate all non-authenticated plugins")
 
-	oauthCmd.AddCommand(oauthListCmd, oauthAuthCmd)
+	oauthCmd.AddCommand(oauthListCmd, oauthAuthCmd, credentialsCmd)
 }
 
 // completeOAuthPlugins returns discovered OAuth plugin names for completion,


### PR DESCRIPTION
This PR adds a wizard to guide users in configuring the credentials required for the Google plugins.

It adds a new `oauth` sub-command `credentials` and leave room for future support of other OAuth services (e.g. Github).