### PR TITLE
feat: add parent param to jira_create_issue

### DIFF
--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -170,6 +170,9 @@ tools:
         items:
           type: string
         description: "List of labels"
+      parent:
+        type: string
+        description: "Parent issue key (e.g. PROJ-100) to create this issue as a child"
       components:
         type: array
         items:

--- a/plugins/jira/tests/test_tools_write.py
+++ b/plugins/jira/tests/test_tools_write.py
@@ -79,6 +79,44 @@ class TestCreateIssue:
             assert "error" in result
             assert result["status"] == 400
 
+    def test_parent_dry_run(self):
+        result = tools_write.create_issue(
+            {
+                "project": "PROJ",
+                "issue_type": "Sub-task",
+                "summary": "Child issue",
+                "parent": "PROJ-100",
+                "dry_run": True,
+            }
+        )
+        assert result["fields"]["parent"] == {"key": "PROJ-100"}
+
+    def test_parent_create_success(self):
+        resp = {"key": "PROJ-124", "id": "10002", "self": "https://jira/issue/10002"}
+        with _mock_http(201, resp):
+            result = tools_write.create_issue(
+                {
+                    "project": "PROJ",
+                    "issue_type": "Sub-task",
+                    "summary": "Child",
+                    "parent": "PROJ-100",
+                    "dry_run": False,
+                }
+            )
+            assert result["key"] == "PROJ-124"
+
+    def test_parent_invalid_key_raises(self):
+        with pytest.raises(ValueError):
+            tools_write.create_issue(
+                {
+                    "project": "PROJ",
+                    "issue_type": "Sub-task",
+                    "summary": "Child",
+                    "parent": "invalid",
+                    "dry_run": True,
+                }
+            )
+
     def test_cloud_description_uses_adf(self):
         with patch.object(handler, "is_cloud", True):
             result = tools_write.create_issue(

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -16,6 +16,7 @@ def create_issue(params):
     assignee = params.get("assignee")
     priority = params.get("priority")
     labels = params.get("labels")
+    parent = params.get("parent")
     components = params.get("components")
     dry_run = params.get("dry_run", True)
 
@@ -39,6 +40,9 @@ def create_issue(params):
 
     if labels:
         fields["labels"] = labels if isinstance(labels, list) else [labels]
+
+    if parent:
+        fields["parent"] = {"key": validate_issue_key(parent)}
 
     if components:
         comp_list = components if isinstance(components, list) else [components]


### PR DESCRIPTION
## Summary

- Adds an optional `parent` parameter to `jira_create_issue`, allowing child issues to be created with their parent set in a single call
- The parent key is validated via `validate_issue_key` before being included in the API payload
- Eliminates the need to call `jira_set_parent` separately after issue creation

## Test plan

- [x] `test_parent_dry_run` — parent field appears in dry-run preview
- [x] `test_parent_create_success` — creation works with parent set
- [x] `test_parent_invalid_key_raises` — invalid parent keys are rejected
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)