### PR TITLE
feat: add ADF passthrough to text_to_adf

### DIFF
--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -3,6 +3,7 @@
 Pure utility functions with no protocol or I/O dependencies.
 """
 
+import json
 import math
 import re
 
@@ -76,13 +77,36 @@ def text_to_adf(text):
     """Convert plain text to Atlassian Document Format (ADF).
 
     Jira Cloud API v3 requires comment/description bodies in ADF.
-    Splits on newlines into paragraphs.
+    Accepts plain text (split into paragraphs), pre-built ADF dicts
+    (passed through after validation), or JSON-encoded ADF strings
+    (parsed and validated).
+
+    Raises ValueError if a dict is passed that isn't valid ADF.
     """
+    # Already a valid ADF dict — pass through
+    if isinstance(text, dict):
+        if not text:
+            pass  # fall through to empty handling below
+        elif text.get("type") == "doc" and text.get("version") == 1:
+            return text
+        else:
+            raise ValueError("Invalid ADF dict: must have 'type': 'doc' and 'version': 1")
+
     if not text:
         return {"version": 1, "type": "doc", "content": [{"type": "paragraph", "content": []}]}
 
+    # Check if the string is a JSON-encoded ADF document
+    if isinstance(text, str):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict) and parsed.get("type") == "doc" and parsed.get("version") == 1:
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # Plain text — split into paragraphs
     content = []
-    for para in text.split("\n"):
+    for para in str(text).split("\n"):
         if para.strip():
             content.append({"type": "paragraph", "content": [{"type": "text", "text": para}]})
         else:

--- a/plugins/jira/tests/test_helpers.py
+++ b/plugins/jira/tests/test_helpers.py
@@ -214,6 +214,39 @@ class TestTextToAdf:
         result = text_to_adf(None)
         assert result["content"] == [{"type": "paragraph", "content": []}]
 
+    def test_adf_dict_passthrough(self):
+        adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Pre-built"}]}],
+        }
+        result = text_to_adf(adf)
+        assert result is adf
+
+    def test_adf_json_string_passthrough(self):
+        import json
+
+        adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "From JSON"}]}],
+        }
+        result = text_to_adf(json.dumps(adf))
+        assert result == adf
+
+    def test_invalid_adf_dict_raises(self):
+        with pytest.raises(ValueError, match="Invalid ADF dict"):
+            text_to_adf({"type": "not_doc", "version": 1})
+
+    def test_empty_dict_treated_as_empty(self):
+        result = text_to_adf({})
+        assert result["content"] == [{"type": "paragraph", "content": []}]
+
+    def test_non_adf_json_string_treated_as_text(self):
+        result = text_to_adf('{"key": "value"}')
+        assert result["type"] == "doc"
+        assert result["content"][0]["content"][0]["text"] == '{"key": "value"}'
+
 
 # --- normalize_components ---
 


### PR DESCRIPTION
## Summary

- `text_to_adf` now accepts pre-built ADF dicts (passed through after validation) and JSON-encoded ADF strings (parsed and validated), in addition to plain text
- Invalid ADF dicts raise `ValueError` instead of being silently wrapped
- Plain text behavior is unchanged — fully backward compatible
- No tool signature changes; callers that pass ADF as a JSON string (e.g. in `description` or `comment` fields) now get correct passthrough instead of double-wrapping

Inspired by [what-the-mcp MR !5](https://gitlab.cee.redhat.com/scorreia/what-the-mcp/-/merge_requests/5)

## Test plan

- [x] `test_adf_dict_passthrough` — valid ADF dict returned as-is
- [x] `test_adf_json_string_passthrough` — JSON-encoded ADF parsed and returned
- [x] `test_invalid_adf_dict_raises` — non-ADF dict raises ValueError
- [x] `test_empty_dict_treated_as_empty` — empty dict produces empty ADF
- [x] `test_non_adf_json_string_treated_as_text` — non-ADF JSON treated as plain text
- [x] All 289 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)