### PR TITLE
feat: add Jira wiki markup to ADF conversion

### DIFF
--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -157,7 +157,9 @@ def _parse_inline_markup(text):
             link_text = m.group("link_text")
             link_url = m.group("link_url")
             if _is_safe_url(link_url):
-                nodes.append({"type": "text", "text": link_text, "marks": [{"type": "link", "attrs": {"href": link_url}}]})
+                nodes.append(
+                    {"type": "text", "text": link_text, "marks": [{"type": "link", "attrs": {"href": link_url}}]}
+                )
             else:
                 nodes.append({"type": "text", "text": m.group("link")})
         elif m.group("bare_link"):

--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -11,6 +11,50 @@ _ISSUE_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]+-\d+$")
 
 _USER_ALIASES = frozenset({"me", "myself", "currentuser"})
 
+# --- Wiki markup regex patterns (compiled at module level) ---
+
+_WIKI_HEADING_RE = re.compile(r"^h([1-6])\.\s+(.*)")
+_WIKI_LIST_UL_RE = re.compile(r"^(\*+)\s+(.*)")
+_WIKI_LIST_OL_RE = re.compile(r"^(#+)\s+(.*)")
+_WIKI_CODE_START_RE = re.compile(r"^\{code(?::(\w+))?\}\s*$")
+_WIKI_CODE_END_RE = re.compile(r"^\{code\}\s*$")
+_WIKI_QUOTE_START_RE = re.compile(r"^\{quote\}\s*$")
+_WIKI_QUOTE_END_RE = re.compile(r"^\{quote\}\s*$")
+_WIKI_BQ_RE = re.compile(r"^bq\.\s+(.*)")
+_WIKI_RULE_RE = re.compile(r"^----\s*$")
+_WIKI_TABLE_HEADER_RE = re.compile(r"^\|\|")
+_WIKI_TABLE_ROW_RE = re.compile(r"^\|[^|]")
+_WIKI_PANEL_START_RE = re.compile(r"^\{panel(?::([^}]*))?\}\s*$")
+_WIKI_PANEL_END_RE = re.compile(r"^\{panel\}\s*$")
+
+_WIKI_BLOCK_DETECT_RE = re.compile(
+    r"(?m)"
+    r"(?:^h[1-6]\.\s)"
+    r"|(?:^\*+\s)"
+    r"|(?:^#+\s)"
+    r"|(?:^\{code(?::|\}))"
+    r"|(?:^\{quote\})"
+    r"|(?:^\{panel(?::|\}))"
+    r"|(?:^bq\.\s)"
+    r"|(?:^----\s*$)"
+    r"|(?:^\|\|)"
+)
+
+_WIKI_INLINE_RE = re.compile(
+    r"(?P<monospace>\{\{(.+?)\}\})"
+    r"|(?P<link>\[(?P<link_text>[^]|~]*)\|(?P<link_url>[^]]+)\])"
+    r"|(?P<bare_link>\[(?P<bare_url>https?://[^]]+)\])"
+    r"|(?P<mention>\[~(?P<mention_id>[^]]+)\])"
+    r"|(?P<image>!(?P<image_url>\S+?)!)"
+    r"|(?P<bold>\*(?=\S)(?P<bold_text>.+?)(?<=\S)\*)"
+    r"|(?P<italic>_(?=\S)(?P<italic_text>.+?)(?<=\S)_)"
+    r"|(?P<strike>-(?=\S)(?P<strike_text>.+?)(?<=\S)-)"
+    r"|(?P<underline>\+(?=\S)(?P<underline_text>.+?)(?<=\S)\+)"
+    r"|(?P<sup>\^(?P<sup_text>.+?)\^)"
+    r"|(?P<sub>~(?P<sub_text>.+?)~)"
+    r"|(?P<linebreak>\\\\)"
+)
+
 
 def http_error(status, body):
     """Build a compact error dict from an HTTP error response.
@@ -73,6 +117,347 @@ def extract_brief_issue(issue):
     }
 
 
+def _looks_like_wiki_markup(text):
+    """Check if text contains Jira wiki markup patterns.
+
+    Uses block-level patterns only to avoid false positives from
+    inline characters like * or _ in plain text.
+    """
+    return bool(_WIKI_BLOCK_DETECT_RE.search(text))
+
+
+def _parse_inline_markup(text):
+    """Parse inline wiki markup into ADF inline nodes.
+
+    Returns a list of ADF inline nodes (text with marks, mentions,
+    hard breaks, etc.).
+    """
+    if not text:
+        return []
+
+    nodes = []
+    last_end = 0
+
+    for m in _WIKI_INLINE_RE.finditer(text):
+        # Emit plain text before this match
+        if m.start() > last_end:
+            nodes.append({"type": "text", "text": text[last_end : m.start()]})
+
+        if m.group("monospace"):
+            nodes.append({"type": "text", "text": m.group(2), "marks": [{"type": "code"}]})
+        elif m.group("link"):
+            link_text = m.group("link_text")
+            link_url = m.group("link_url")
+            nodes.append({"type": "text", "text": link_text, "marks": [{"type": "link", "attrs": {"href": link_url}}]})
+        elif m.group("bare_link"):
+            url = m.group("bare_url")
+            nodes.append({"type": "text", "text": url, "marks": [{"type": "link", "attrs": {"href": url}}]})
+        elif m.group("mention"):
+            nodes.append({"type": "mention", "attrs": {"id": m.group("mention_id")}})
+        elif m.group("image"):
+            url = m.group("image_url")
+            nodes.append({"type": "text", "text": url, "marks": [{"type": "link", "attrs": {"href": url}}]})
+        elif m.group("bold"):
+            nodes.append({"type": "text", "text": m.group("bold_text"), "marks": [{"type": "strong"}]})
+        elif m.group("italic"):
+            nodes.append({"type": "text", "text": m.group("italic_text"), "marks": [{"type": "em"}]})
+        elif m.group("strike"):
+            nodes.append({"type": "text", "text": m.group("strike_text"), "marks": [{"type": "strike"}]})
+        elif m.group("underline"):
+            nodes.append({"type": "text", "text": m.group("underline_text"), "marks": [{"type": "underline"}]})
+        elif m.group("sup"):
+            nodes.append(
+                {"type": "text", "text": m.group("sup_text"), "marks": [{"type": "subsup", "attrs": {"type": "sup"}}]}
+            )
+        elif m.group("sub"):
+            nodes.append(
+                {"type": "text", "text": m.group("sub_text"), "marks": [{"type": "subsup", "attrs": {"type": "sub"}}]}
+            )
+        elif m.group("linebreak"):
+            nodes.append({"type": "hardBreak"})
+
+        last_end = m.end()
+
+    # Emit trailing plain text
+    if last_end < len(text):
+        nodes.append({"type": "text", "text": text[last_end:]})
+
+    return nodes
+
+
+def _build_list_tree(items, list_type):
+    """Build a nested ADF list from (depth, text) tuples.
+
+    list_type is "bulletList" or "orderedList".
+    """
+
+    def _build(items, current_depth):
+        list_items = []
+        i = 0
+        while i < len(items):
+            depth, text = items[i]
+            if depth == current_depth:
+                content = [{"type": "paragraph", "content": _parse_inline_markup(text)}]
+                i += 1
+                # Collect deeper items as children
+                children = []
+                while i < len(items) and items[i][0] > current_depth:
+                    children.append(items[i])
+                    i += 1
+                if children:
+                    content.append(_build(children, current_depth + 1))
+                list_items.append({"type": "listItem", "content": content})
+            elif depth > current_depth:
+                # Orphaned deeper items — wrap in a list item
+                children = []
+                while i < len(items) and items[i][0] > current_depth:
+                    children.append(items[i])
+                    i += 1
+                if children:
+                    nested = _build(children, children[0][0])
+                    list_items.append({"type": "listItem", "content": [nested]})
+            else:
+                break
+        return {"type": list_type, "content": list_items}
+
+    return _build(items, items[0][0] if items else 1)
+
+
+def _parse_table_rows(lines):
+    """Parse consecutive table lines into an ADF table node."""
+    rows = []
+    for line in lines:
+        is_header = line.startswith("||")
+        if is_header:
+            # Split on || but skip empty first/last from leading/trailing ||
+            raw = line.strip()
+            if raw.startswith("||"):
+                raw = raw[2:]
+            if raw.endswith("||"):
+                raw = raw[:-2]
+            cells = [c.strip() for c in raw.split("||")]
+            cell_type = "tableHeader"
+        else:
+            raw = line.strip()
+            if raw.startswith("|"):
+                raw = raw[1:]
+            if raw.endswith("|"):
+                raw = raw[:-1]
+            cells = [c.strip() for c in raw.split("|")]
+            cell_type = "tableCell"
+
+        row_content = []
+        for cell_text in cells:
+            row_content.append(
+                {"type": cell_type, "content": [{"type": "paragraph", "content": _parse_inline_markup(cell_text)}]}
+            )
+        rows.append({"type": "tableRow", "content": row_content})
+
+    return {"type": "table", "content": rows}
+
+
+def _parse_wiki_blocks(text):
+    """Parse wiki markup text into a list of ADF block nodes.
+
+    Uses a line-by-line state machine for block-level constructs,
+    then applies inline parsing to text content.
+    """
+    lines = text.split("\n")
+    blocks = []
+    para_buffer = []
+    state = "NORMAL"  # NORMAL, CODE, QUOTE, PANEL
+    block_buffer = []
+    code_lang = None
+
+    def _flush_para():
+        if para_buffer:
+            combined = "\n".join(para_buffer).strip()
+            if combined:
+                blocks.append({"type": "paragraph", "content": _parse_inline_markup(combined)})
+            para_buffer.clear()
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+
+        if state == "CODE":
+            if _WIKI_CODE_END_RE.match(line):
+                attrs = {}
+                if code_lang:
+                    attrs["language"] = code_lang
+                node = {"type": "codeBlock", "content": [{"type": "text", "text": "\n".join(block_buffer)}]}
+                if attrs:
+                    node["attrs"] = attrs
+                blocks.append(node)
+                block_buffer.clear()
+                state = "NORMAL"
+            else:
+                block_buffer.append(line)
+            i += 1
+            continue
+
+        if state == "QUOTE":
+            if _WIKI_QUOTE_END_RE.match(line):
+                inner = "\n".join(block_buffer)
+                inner_blocks = _parse_wiki_blocks(inner) if inner.strip() else []
+                if not inner_blocks:
+                    inner_blocks = [{"type": "paragraph", "content": []}]
+                blocks.append({"type": "blockquote", "content": inner_blocks})
+                block_buffer.clear()
+                state = "NORMAL"
+            else:
+                block_buffer.append(line)
+            i += 1
+            continue
+
+        if state == "PANEL":
+            if _WIKI_PANEL_END_RE.match(line):
+                inner = "\n".join(block_buffer)
+                inner_blocks = _parse_wiki_blocks(inner) if inner.strip() else []
+                if not inner_blocks:
+                    inner_blocks = [{"type": "paragraph", "content": []}]
+                node = {"type": "panel", "attrs": {"panelType": "info"}, "content": inner_blocks}
+                blocks.append(node)
+                block_buffer.clear()
+                state = "NORMAL"
+            else:
+                block_buffer.append(line)
+            i += 1
+            continue
+
+        # --- NORMAL state ---
+
+        # Code block start
+        m = _WIKI_CODE_START_RE.match(line)
+        if m:
+            _flush_para()
+            code_lang = m.group(1)
+            state = "CODE"
+            i += 1
+            continue
+
+        # Quote block start
+        if _WIKI_QUOTE_START_RE.match(line):
+            _flush_para()
+            state = "QUOTE"
+            i += 1
+            continue
+
+        # Panel start
+        m = _WIKI_PANEL_START_RE.match(line)
+        if m:
+            _flush_para()
+            state = "PANEL"
+            i += 1
+            continue
+
+        # Heading
+        m = _WIKI_HEADING_RE.match(line)
+        if m:
+            _flush_para()
+            level = int(m.group(1))
+            heading_text = m.group(2).strip()
+            blocks.append(
+                {"type": "heading", "attrs": {"level": level}, "content": _parse_inline_markup(heading_text)}
+            )
+            i += 1
+            continue
+
+        # Horizontal rule
+        if _WIKI_RULE_RE.match(line):
+            _flush_para()
+            blocks.append({"type": "rule"})
+            i += 1
+            continue
+
+        # Blockquote shorthand
+        m = _WIKI_BQ_RE.match(line)
+        if m:
+            _flush_para()
+            blocks.append(
+                {
+                    "type": "blockquote",
+                    "content": [{"type": "paragraph", "content": _parse_inline_markup(m.group(1))}],
+                }
+            )
+            i += 1
+            continue
+
+        # Unordered list
+        m = _WIKI_LIST_UL_RE.match(line)
+        if m:
+            _flush_para()
+            items = []
+            while i < len(lines):
+                lm = _WIKI_LIST_UL_RE.match(lines[i])
+                if not lm:
+                    break
+                items.append((len(lm.group(1)), lm.group(2)))
+                i += 1
+            blocks.append(_build_list_tree(items, "bulletList"))
+            continue
+
+        # Ordered list
+        m = _WIKI_LIST_OL_RE.match(line)
+        if m:
+            _flush_para()
+            items = []
+            while i < len(lines):
+                lm = _WIKI_LIST_OL_RE.match(lines[i])
+                if not lm:
+                    break
+                items.append((len(lm.group(1)), lm.group(2)))
+                i += 1
+            blocks.append(_build_list_tree(items, "orderedList"))
+            continue
+
+        # Table
+        if _WIKI_TABLE_HEADER_RE.match(line) or _WIKI_TABLE_ROW_RE.match(line):
+            _flush_para()
+            table_lines = []
+            while i < len(lines) and (_WIKI_TABLE_HEADER_RE.match(lines[i]) or _WIKI_TABLE_ROW_RE.match(lines[i])):
+                table_lines.append(lines[i])
+                i += 1
+            blocks.append(_parse_table_rows(table_lines))
+            continue
+
+        # Regular text — accumulate into paragraph
+        if line.strip():
+            para_buffer.append(line)
+        else:
+            _flush_para()
+        i += 1
+
+    # Handle unclosed blocks
+    if state == "CODE":
+        attrs = {}
+        if code_lang:
+            attrs["language"] = code_lang
+        node = {"type": "codeBlock", "content": [{"type": "text", "text": "\n".join(block_buffer)}]}
+        if attrs:
+            node["attrs"] = attrs
+        blocks.append(node)
+    elif state == "QUOTE":
+        inner = "\n".join(block_buffer)
+        inner_blocks = _parse_wiki_blocks(inner) if inner.strip() else [{"type": "paragraph", "content": []}]
+        blocks.append({"type": "blockquote", "content": inner_blocks})
+    elif state == "PANEL":
+        inner = "\n".join(block_buffer)
+        inner_blocks = _parse_wiki_blocks(inner) if inner.strip() else [{"type": "paragraph", "content": []}]
+        blocks.append({"type": "panel", "attrs": {"panelType": "info"}, "content": inner_blocks})
+
+    _flush_para()
+    return blocks
+
+
+def wiki_to_adf(text):
+    """Convert Jira wiki markup text to an ADF document."""
+    blocks = _parse_wiki_blocks(text)
+    if not blocks:
+        blocks = [{"type": "paragraph", "content": []}]
+    return {"version": 1, "type": "doc", "content": blocks}
+
+
 def text_to_adf(text: str | dict | None) -> dict:
     """Convert plain text to Atlassian Document Format (ADF).
 
@@ -108,6 +493,10 @@ def text_to_adf(text: str | dict | None) -> dict:
                 return parsed
         except (json.JSONDecodeError, ValueError):
             pass
+
+    # Wiki markup detection — convert before plain text fallback
+    if isinstance(text, str) and _looks_like_wiki_markup(text):
+        return wiki_to_adf(text)
 
     # Plain text — split into paragraphs
     content = []

--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -282,12 +282,9 @@ def _parse_wiki_blocks(text):
 
         if state == "CODE":
             if _WIKI_CODE_END_RE.match(line):
-                attrs = {}
+                node: dict = {"type": "codeBlock", "content": [{"type": "text", "text": "\n".join(block_buffer)}]}
                 if code_lang:
-                    attrs["language"] = code_lang
-                node = {"type": "codeBlock", "content": [{"type": "text", "text": "\n".join(block_buffer)}]}
-                if attrs:
-                    node["attrs"] = attrs
+                    node["attrs"] = {"language": code_lang}
                 blocks.append(node)
                 block_buffer.clear()
                 state = "NORMAL"
@@ -357,9 +354,7 @@ def _parse_wiki_blocks(text):
             _flush_para()
             level = int(m.group(1))
             heading_text = m.group(2).strip()
-            blocks.append(
-                {"type": "heading", "attrs": {"level": level}, "content": _parse_inline_markup(heading_text)}
-            )
+            blocks.append({"type": "heading", "attrs": {"level": level}, "content": _parse_inline_markup(heading_text)})
             i += 1
             continue
 
@@ -430,12 +425,9 @@ def _parse_wiki_blocks(text):
 
     # Handle unclosed blocks
     if state == "CODE":
-        attrs = {}
+        node: dict = {"type": "codeBlock", "content": [{"type": "text", "text": "\n".join(block_buffer)}]}
         if code_lang:
-            attrs["language"] = code_lang
-        node = {"type": "codeBlock", "content": [{"type": "text", "text": "\n".join(block_buffer)}]}
-        if attrs:
-            node["attrs"] = attrs
+            node["attrs"] = {"language": code_lang}
         blocks.append(node)
     elif state == "QUOTE":
         inner = "\n".join(block_buffer)

--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -45,7 +45,7 @@ _WIKI_INLINE_RE = re.compile(
     r"|(?P<link>\[(?P<link_text>[^]|~]*)\|(?P<link_url>[^]]+)\])"
     r"|(?P<bare_link>\[(?P<bare_url>https?://[^]]+)\])"
     r"|(?P<mention>\[~(?P<mention_id>[^]]+)\])"
-    r"|(?P<image>!(?P<image_url>\S+?)!)"
+    r"|(?P<image>!(?P<image_url>\S+?\.\S+?)!)"
     r"|(?P<bold>\*(?=\S)(?P<bold_text>.+?)(?<=\S)\*)"
     r"|(?P<italic>_(?=\S)(?P<italic_text>.+?)(?<=\S)_)"
     r"|(?P<strike>-(?=\S)(?P<strike_text>.+?)(?<=\S)-)"
@@ -117,6 +117,14 @@ def extract_brief_issue(issue):
     }
 
 
+_UNSAFE_URL_RE = re.compile(r"^(?:javascript|data|vbscript):", re.IGNORECASE)
+
+
+def _is_safe_url(url):
+    """Check that a URL does not use a dangerous scheme (javascript, data, vbscript)."""
+    return not _UNSAFE_URL_RE.match(url)
+
+
 def _looks_like_wiki_markup(text):
     """Check if text contains Jira wiki markup patterns.
 
@@ -148,7 +156,10 @@ def _parse_inline_markup(text):
         elif m.group("link"):
             link_text = m.group("link_text")
             link_url = m.group("link_url")
-            nodes.append({"type": "text", "text": link_text, "marks": [{"type": "link", "attrs": {"href": link_url}}]})
+            if _is_safe_url(link_url):
+                nodes.append({"type": "text", "text": link_text, "marks": [{"type": "link", "attrs": {"href": link_url}}]})
+            else:
+                nodes.append({"type": "text", "text": m.group("link")})
         elif m.group("bare_link"):
             url = m.group("bare_url")
             nodes.append({"type": "text", "text": url, "marks": [{"type": "link", "attrs": {"href": url}}]})
@@ -156,7 +167,10 @@ def _parse_inline_markup(text):
             nodes.append({"type": "mention", "attrs": {"id": m.group("mention_id")}})
         elif m.group("image"):
             url = m.group("image_url")
-            nodes.append({"type": "text", "text": url, "marks": [{"type": "link", "attrs": {"href": url}}]})
+            if _is_safe_url(url):
+                nodes.append({"type": "text", "text": url, "marks": [{"type": "link", "attrs": {"href": url}}]})
+            else:
+                nodes.append({"type": "text", "text": m.group("image")})
         elif m.group("bold"):
             nodes.append({"type": "text", "text": m.group("bold_text"), "marks": [{"type": "strong"}]})
         elif m.group("italic"):

--- a/plugins/jira/tests/test_helpers.py
+++ b/plugins/jira/tests/test_helpers.py
@@ -766,6 +766,53 @@ class TestParseInlineMarkup:
     def test_empty_string(self):
         assert _parse_inline_markup("") == []
 
+    def test_image_requires_dot(self):
+        """!important! should not be treated as an image."""
+        nodes = _parse_inline_markup("This is !important! news")
+        assert len(nodes) == 1
+        assert nodes[0]["text"] == "This is !important! news"
+
+    def test_image_with_path(self):
+        nodes = _parse_inline_markup("!images/photo.jpg!")
+        assert nodes[0]["text"] == "images/photo.jpg"
+        assert nodes[0]["marks"][0]["type"] == "link"
+
+    def test_link_unsafe_scheme_javascript(self):
+        """javascript: URLs should be emitted as plain text."""
+        nodes = _parse_inline_markup("[click|javascript:alert(1)]")
+        assert len(nodes) == 1
+        assert nodes[0] == {"type": "text", "text": "[click|javascript:alert(1)]"}
+
+    def test_link_unsafe_scheme_data(self):
+        """data: URLs should be emitted as plain text."""
+        nodes = _parse_inline_markup("[click|data:text/html,<script>]")
+        assert len(nodes) == 1
+        assert "marks" not in nodes[0]
+
+    def test_link_safe_scheme_https(self):
+        nodes = _parse_inline_markup("[Example|https://example.com]")
+        assert nodes[0]["marks"] == [{"type": "link", "attrs": {"href": "https://example.com"}}]
+
+    def test_link_safe_scheme_mailto(self):
+        nodes = _parse_inline_markup("[Email|mailto:user@example.com]")
+        assert nodes[0]["marks"] == [{"type": "link", "attrs": {"href": "mailto:user@example.com"}}]
+
+    def test_link_safe_scheme_relative(self):
+        nodes = _parse_inline_markup("[Page|/wiki/page]")
+        assert nodes[0]["marks"] == [{"type": "link", "attrs": {"href": "/wiki/page"}}]
+
+    def test_image_unsafe_scheme(self):
+        """javascript: image URL should be emitted as plain text."""
+        nodes = _parse_inline_markup("!javascript:alert.x!")
+        assert len(nodes) == 1
+        assert "marks" not in nodes[0]
+
+    def test_link_unsafe_scheme_vbscript(self):
+        """vbscript: URLs should be emitted as plain text."""
+        nodes = _parse_inline_markup("[click|vbscript:MsgBox]")
+        assert len(nodes) == 1
+        assert "marks" not in nodes[0]
+
 
 # --- Wiki to ADF block parsing ---
 

--- a/plugins/jira/tests/test_helpers.py
+++ b/plugins/jira/tests/test_helpers.py
@@ -1,7 +1,11 @@
 """Unit tests for helpers.py — pure functions, no mocking needed."""
 
+import json
+
 import pytest
 from helpers import (
+    _looks_like_wiki_markup,
+    _parse_inline_markup,
     adf_to_text,
     calculate_sprint_metrics,
     escape_jql,
@@ -16,6 +20,7 @@ from helpers import (
     resolve_field_value,
     text_to_adf,
     validate_issue_key,
+    wiki_to_adf,
 )
 
 # --- validate_issue_key ---
@@ -224,8 +229,6 @@ class TestTextToAdf:
         assert result is adf
 
     def test_adf_json_string_passthrough(self):
-        import json
-
         adf = {
             "version": 1,
             "type": "doc",
@@ -627,3 +630,358 @@ class TestAdfToText:
         """Dict without type=doc passes through unchanged."""
         not_adf = {"key": "value", "foo": "bar"}
         assert adf_to_text(not_adf) == not_adf
+
+
+# --- Wiki markup detection ---
+
+
+class TestLooksLikeWikiMarkup:
+    def test_heading(self):
+        assert _looks_like_wiki_markup("h2. Title")
+
+    def test_heading_h1(self):
+        assert _looks_like_wiki_markup("h1. Main Title")
+
+    def test_heading_h6(self):
+        assert _looks_like_wiki_markup("h6. Deep heading")
+
+    def test_unordered_list(self):
+        assert _looks_like_wiki_markup("* item one")
+
+    def test_ordered_list(self):
+        assert _looks_like_wiki_markup("# first item")
+
+    def test_code_block(self):
+        assert _looks_like_wiki_markup("{code}\nprint('hi')\n{code}")
+
+    def test_code_block_with_lang(self):
+        assert _looks_like_wiki_markup("{code:python}\nx = 1\n{code}")
+
+    def test_quote_block(self):
+        assert _looks_like_wiki_markup("{quote}\nsome quote\n{quote}")
+
+    def test_bq_shorthand(self):
+        assert _looks_like_wiki_markup("bq. Some quoted text")
+
+    def test_panel(self):
+        assert _looks_like_wiki_markup("{panel}\ncontent\n{panel}")
+
+    def test_horizontal_rule(self):
+        assert _looks_like_wiki_markup("----")
+
+    def test_table_header(self):
+        assert _looks_like_wiki_markup("||H1||H2||")
+
+    def test_plain_text(self):
+        assert not _looks_like_wiki_markup("Just some regular text")
+
+    def test_plain_with_asterisk_mid_sentence(self):
+        assert not _looks_like_wiki_markup("This is a * note about things")
+
+    def test_json_not_wiki(self):
+        assert not _looks_like_wiki_markup('{"key": "value"}')
+
+    def test_multiline_with_heading(self):
+        assert _looks_like_wiki_markup("Some intro\nh2. Title\nMore text")
+
+
+# --- Inline markup parsing ---
+
+
+class TestParseInlineMarkup:
+    def test_plain_text(self):
+        nodes = _parse_inline_markup("just plain text")
+        assert len(nodes) == 1
+        assert nodes[0] == {"type": "text", "text": "just plain text"}
+
+    def test_bold(self):
+        nodes = _parse_inline_markup("*bold*")
+        assert len(nodes) == 1
+        assert nodes[0]["text"] == "bold"
+        assert nodes[0]["marks"] == [{"type": "strong"}]
+
+    def test_italic(self):
+        nodes = _parse_inline_markup("_italic_")
+        assert nodes[0]["text"] == "italic"
+        assert nodes[0]["marks"] == [{"type": "em"}]
+
+    def test_strikethrough(self):
+        nodes = _parse_inline_markup("-struck-")
+        assert nodes[0]["text"] == "struck"
+        assert nodes[0]["marks"] == [{"type": "strike"}]
+
+    def test_underline(self):
+        nodes = _parse_inline_markup("+under+")
+        assert nodes[0]["text"] == "under"
+        assert nodes[0]["marks"] == [{"type": "underline"}]
+
+    def test_monospace(self):
+        nodes = _parse_inline_markup("{{code}}")
+        assert nodes[0]["text"] == "code"
+        assert nodes[0]["marks"] == [{"type": "code"}]
+
+    def test_superscript(self):
+        nodes = _parse_inline_markup("^sup^")
+        assert nodes[0]["text"] == "sup"
+        assert nodes[0]["marks"] == [{"type": "subsup", "attrs": {"type": "sup"}}]
+
+    def test_subscript(self):
+        nodes = _parse_inline_markup("~sub~")
+        assert nodes[0]["text"] == "sub"
+        assert nodes[0]["marks"] == [{"type": "subsup", "attrs": {"type": "sub"}}]
+
+    def test_link_with_text(self):
+        nodes = _parse_inline_markup("[Example|https://example.com]")
+        assert nodes[0]["text"] == "Example"
+        assert nodes[0]["marks"] == [{"type": "link", "attrs": {"href": "https://example.com"}}]
+
+    def test_bare_link(self):
+        nodes = _parse_inline_markup("[https://example.com]")
+        assert nodes[0]["text"] == "https://example.com"
+        assert nodes[0]["marks"] == [{"type": "link", "attrs": {"href": "https://example.com"}}]
+
+    def test_mention(self):
+        nodes = _parse_inline_markup("[~abc123]")
+        assert nodes[0] == {"type": "mention", "attrs": {"id": "abc123"}}
+
+    def test_image_as_link(self):
+        nodes = _parse_inline_markup("!screenshot.png!")
+        assert nodes[0]["text"] == "screenshot.png"
+        assert nodes[0]["marks"][0]["type"] == "link"
+
+    def test_linebreak(self):
+        nodes = _parse_inline_markup("before\\\\after")
+        assert nodes[0] == {"type": "text", "text": "before"}
+        assert nodes[1] == {"type": "hardBreak"}
+        assert nodes[2] == {"type": "text", "text": "after"}
+
+    def test_mixed_inline(self):
+        nodes = _parse_inline_markup("Hello *bold* and _italic_")
+        texts = [(n.get("text", ""), n.get("marks", [])) for n in nodes]
+        assert texts[0] == ("Hello ", [])
+        assert texts[1] == ("bold", [{"type": "strong"}])
+        assert texts[2] == (" and ", [])
+        assert texts[3] == ("italic", [{"type": "em"}])
+
+    def test_empty_string(self):
+        assert _parse_inline_markup("") == []
+
+
+# --- Wiki to ADF block parsing ---
+
+
+class TestWikiToAdf:
+    # Headings
+    def test_heading_h1(self):
+        result = wiki_to_adf("h1. Title")
+        block = result["content"][0]
+        assert block["type"] == "heading"
+        assert block["attrs"]["level"] == 1
+        assert block["content"][0]["text"] == "Title"
+
+    def test_heading_h6(self):
+        result = wiki_to_adf("h6. Deep")
+        assert result["content"][0]["attrs"]["level"] == 6
+
+    def test_heading_with_inline(self):
+        result = wiki_to_adf("h2. *Bold* title")
+        content = result["content"][0]["content"]
+        assert content[0]["marks"] == [{"type": "strong"}]
+        assert content[0]["text"] == "Bold"
+        assert content[1]["text"] == " title"
+
+    # Lists
+    def test_unordered_list(self):
+        result = wiki_to_adf("* item1\n* item2")
+        block = result["content"][0]
+        assert block["type"] == "bulletList"
+        assert len(block["content"]) == 2
+        assert block["content"][0]["type"] == "listItem"
+
+    def test_ordered_list(self):
+        result = wiki_to_adf("# first\n# second")
+        block = result["content"][0]
+        assert block["type"] == "orderedList"
+        assert len(block["content"]) == 2
+
+    def test_nested_unordered_list(self):
+        result = wiki_to_adf("* top\n** nested\n* bottom")
+        block = result["content"][0]
+        assert block["type"] == "bulletList"
+        # First item should have nested list
+        first_item = block["content"][0]
+        assert len(first_item["content"]) == 2  # paragraph + nested list
+        assert first_item["content"][1]["type"] == "bulletList"
+
+    def test_nested_ordered_list(self):
+        result = wiki_to_adf("# top\n## nested")
+        block = result["content"][0]
+        first_item = block["content"][0]
+        assert first_item["content"][1]["type"] == "orderedList"
+
+    # Code blocks
+    def test_code_block_no_lang(self):
+        result = wiki_to_adf("{code}\nprint('hi')\n{code}")
+        block = result["content"][0]
+        assert block["type"] == "codeBlock"
+        assert block["content"][0]["text"] == "print('hi')"
+        assert "attrs" not in block
+
+    def test_code_block_with_lang(self):
+        result = wiki_to_adf("{code:python}\nx = 1\n{code}")
+        block = result["content"][0]
+        assert block["type"] == "codeBlock"
+        assert block["attrs"]["language"] == "python"
+        assert block["content"][0]["text"] == "x = 1"
+
+    def test_code_block_multiline(self):
+        result = wiki_to_adf("{code}\nline1\nline2\nline3\n{code}")
+        assert result["content"][0]["content"][0]["text"] == "line1\nline2\nline3"
+
+    def test_code_block_unclosed(self):
+        result = wiki_to_adf("{code}\nsome code")
+        block = result["content"][0]
+        assert block["type"] == "codeBlock"
+        assert block["content"][0]["text"] == "some code"
+
+    # Blockquotes
+    def test_bq_shorthand(self):
+        result = wiki_to_adf("bq. Some quote")
+        block = result["content"][0]
+        assert block["type"] == "blockquote"
+        assert block["content"][0]["type"] == "paragraph"
+
+    def test_quote_block(self):
+        result = wiki_to_adf("{quote}\nquoted text\n{quote}")
+        block = result["content"][0]
+        assert block["type"] == "blockquote"
+        assert block["content"][0]["content"][0]["text"] == "quoted text"
+
+    def test_quote_block_unclosed(self):
+        result = wiki_to_adf("{quote}\nunclosed quote")
+        assert result["content"][0]["type"] == "blockquote"
+
+    # Horizontal rule
+    def test_horizontal_rule(self):
+        result = wiki_to_adf("----")
+        assert result["content"][0]["type"] == "rule"
+
+    # Tables
+    def test_simple_table(self):
+        result = wiki_to_adf("||H1||H2||\n|c1|c2|")
+        table = result["content"][0]
+        assert table["type"] == "table"
+        assert len(table["content"]) == 2
+        # Header row
+        header_row = table["content"][0]
+        assert header_row["content"][0]["type"] == "tableHeader"
+        # Data row
+        data_row = table["content"][1]
+        assert data_row["content"][0]["type"] == "tableCell"
+
+    def test_table_header_content(self):
+        result = wiki_to_adf("||Name||Age||")
+        row = result["content"][0]["content"][0]
+        cells = row["content"]
+        assert cells[0]["content"][0]["content"][0]["text"] == "Name"
+        assert cells[1]["content"][0]["content"][0]["text"] == "Age"
+
+    def test_table_with_inline_markup(self):
+        result = wiki_to_adf("||*Bold Header*||Plain||")
+        cell = result["content"][0]["content"][0]["content"][0]
+        para_content = cell["content"][0]["content"]
+        assert para_content[0]["marks"] == [{"type": "strong"}]
+
+    # Panel
+    def test_panel(self):
+        result = wiki_to_adf("{panel}\ncontent here\n{panel}")
+        block = result["content"][0]
+        assert block["type"] == "panel"
+        assert block["attrs"]["panelType"] == "info"
+        assert block["content"][0]["content"][0]["text"] == "content here"
+
+    def test_panel_unclosed(self):
+        result = wiki_to_adf("{panel}\nunclosed panel")
+        assert result["content"][0]["type"] == "panel"
+
+    # Mixed content
+    def test_heading_then_paragraph(self):
+        result = wiki_to_adf("h2. Title\n\nSome text")
+        assert result["content"][0]["type"] == "heading"
+        assert result["content"][1]["type"] == "paragraph"
+        assert result["content"][1]["content"][0]["text"] == "Some text"
+
+    def test_complex_document(self):
+        doc = """h1. Project Overview
+
+This is the *introduction*.
+
+h2. Tasks
+
+* Task one
+* Task two
+** Sub-task
+
+h2. Code
+
+{code:python}
+def hello():
+    print("world")
+{code}
+
+----
+
+bq. Important note here"""
+        result = wiki_to_adf(doc)
+        types = [b["type"] for b in result["content"]]
+        assert "heading" in types
+        assert "paragraph" in types
+        assert "bulletList" in types
+        assert "codeBlock" in types
+        assert "rule" in types
+        assert "blockquote" in types
+
+    def test_empty_input(self):
+        result = wiki_to_adf("")
+        assert result["content"] == [{"type": "paragraph", "content": []}]
+
+    def test_version_and_type(self):
+        result = wiki_to_adf("h1. Test")
+        assert result["version"] == 1
+        assert result["type"] == "doc"
+
+
+# --- Integration: text_to_adf with wiki markup ---
+
+
+class TestTextToAdfWikiIntegration:
+    def test_wiki_heading_converted(self):
+        result = text_to_adf("h2. Title\n\nSome paragraph")
+        assert result["type"] == "doc"
+        assert result["content"][0]["type"] == "heading"
+
+    def test_wiki_list_converted(self):
+        result = text_to_adf("* item 1\n* item 2")
+        assert result["content"][0]["type"] == "bulletList"
+
+    def test_plain_text_still_works(self):
+        result = text_to_adf("Just plain text here")
+        assert result["content"][0]["type"] == "paragraph"
+        assert result["content"][0]["content"][0]["text"] == "Just plain text here"
+
+    def test_adf_passthrough_still_works(self):
+        adf = {"version": 1, "type": "doc", "content": []}
+        assert text_to_adf(adf) is adf
+
+    def test_json_adf_passthrough_still_works(self):
+        adf = {"version": 1, "type": "doc", "content": []}
+        assert text_to_adf(json.dumps(adf)) == adf
+
+    def test_wiki_code_block_converted(self):
+        result = text_to_adf("{code:java}\nSystem.out.println();\n{code}")
+        assert result["content"][0]["type"] == "codeBlock"
+        assert result["content"][0]["attrs"]["language"] == "java"
+
+    def test_wiki_table_converted(self):
+        result = text_to_adf("||Col1||Col2||\n|a|b|")
+        assert result["content"][0]["type"] == "table"


### PR DESCRIPTION
## Summary

Adds automatic Jira wiki markup detection and conversion to `text_to_adf()`, enabling rich-text formatting when creating issues or adding comments on Jira Cloud.

**Block-level constructs:**
- Headings (`h1.` through `h6.`)
- Bullet lists (`*`, `**` nested) and ordered lists (`#`, `##` nested)
- Code blocks (`{code}`, `{code:python}`)
- Blockquotes (`bq.` shorthand and `{quote}...{quote}`)
- Tables (`||header||` and `|cell|`)
- Panels (`{panel}...{panel}`)
- Horizontal rules (`----`)

**Inline formatting:**
- Bold (`*text*`), italic (`_text_`), strikethrough (`-text-`), underline (`+text+`)
- Monospace (`{{text}}`), superscript (`^text^`), subscript (`~text~`)
- Links (`[text|url]`, `[url]`), mentions (`[~accountId]`), images (`!url!`)
- Line breaks (`\\`)

**Design decisions:**
- Detection uses block-level patterns only (conservative) to avoid false positives from `*` or `_` in plain text
- Two-pass parser: block-level state machine, then inline regex scanner
- Unclosed blocks (`{code}`, `{quote}`, `{panel}`) handled gracefully
- Images converted to linked text (ADF media nodes require server-side IDs)
- No tool signature changes — fully transparent to callers
- Plain text and ADF passthrough behavior unchanged

**Depends on:** #13 (ADF passthrough)

## Test plan

- [x] 16 detection tests (`TestLooksLikeWikiMarkup`)
- [x] 15 inline parsing tests (`TestParseInlineMarkup`)
- [x] 24 block parsing tests (`TestWikiToAdf`) — headings, lists, nesting, code, quotes, tables, panels, rules, mixed content
- [x] 7 integration tests (`TestTextToAdfWikiIntegration`) — end-to-end through `text_to_adf()`
- [x] All 351 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)