### PR TITLE
chore: gitignore compiled binaries, runtime state, and uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /wtmcp
 /wtmcpctl
 plugins/google-*/handler
+plugins/gitlab/handler
 
 # Test/coverage
 coverage.out
@@ -28,7 +29,13 @@ __pycache__/
 # Claude Code
 CLAUDE.md
 
+# Runtime state
+control/
+
 # Staging area for temp files
 staging/
+
+# Python lock file
+uv.lock
 
 .serena/


### PR DESCRIPTION
## Summary
- Add `plugins/gitlab/handler` (compiled Go binary) to `.gitignore`, matching the existing `plugins/google-*/handler` pattern
- Add `control/` (runtime state directory with commands/results) to `.gitignore`
- Add `uv.lock` (auto-generated Python UV lock file) to `.gitignore`

These files are local build artifacts and runtime state that should not be version-controlled.

## Test plan
- [x] Verify `git status` no longer shows `control/`, `plugins/gitlab/handler`, and `uv.lock` as untracked

Made with [Cursor](https://cursor.com)