### PR TITLE
fix: require word boundaries for wiki inline markup

### DIFF
--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -51,12 +51,12 @@ _WIKI_INLINE_RE = re.compile(
     r"|(?P<bare_link>\[(?P<bare_url>https?://[^]]+)\])"
     r"|(?P<mention>\[~(?P<mention_id>[^]]+)\])"
     r"|(?P<image>!(?P<image_url>\S+?\.\S+?)!)"
-    r"|(?P<bold>\*(?=\S)(?P<bold_text>.+?)(?<=\S)\*)"
-    r"|(?P<italic>_(?=\S)(?P<italic_text>.+?)(?<=\S)_)"
-    r"|(?P<strike>-(?=\S)(?P<strike_text>.+?)(?<=\S)-)"
-    r"|(?P<underline>\+(?=\S)(?P<underline_text>.+?)(?<=\S)\+)"
-    r"|(?P<sup>\^(?=\S)(?P<sup_text>.+?)(?<=\S)\^)"
-    r"|(?P<sub>~(?=\S)(?P<sub_text>.+?)(?<=\S)~)"
+    r"|(?P<bold>(?<!\w)\*(?=\S)(?P<bold_text>.+?)(?<=\S)\*(?!\w))"
+    r"|(?P<italic>(?<!\w)_(?=\S)(?P<italic_text>.+?)(?<=\S)_(?!\w))"
+    r"|(?P<strike>(?<!\w)-(?=\S)(?P<strike_text>.+?)(?<=\S)-(?!\w))"
+    r"|(?P<underline>(?<!\w)\+(?=\S)(?P<underline_text>.+?)(?<=\S)\+(?!\w))"
+    r"|(?P<sup>(?<!\w)\^(?=\S)(?P<sup_text>.+?)(?<=\S)\^(?!\w))"
+    r"|(?P<sub>(?<!\w)~(?=\S)(?P<sub_text>.+?)(?<=\S)~(?!\w))"
     r"|(?P<linebreak>\\\\)"
 )
 

--- a/plugins/jira/tests/test_helpers.py
+++ b/plugins/jira/tests/test_helpers.py
@@ -790,6 +790,48 @@ class TestParseInlineMarkup:
     def test_empty_string(self):
         assert _parse_inline_markup("") == []
 
+    def test_hyphen_mid_word_not_strike(self):
+        """Hyphens inside words should not be treated as strikethrough."""
+        nodes = _parse_inline_markup("foo-bar-baz")
+        assert len(nodes) == 1
+        assert nodes[0] == {"type": "text", "text": "foo-bar-baz"}
+
+    def test_underscore_mid_word_not_italic(self):
+        """Underscores inside identifiers should not be treated as italic."""
+        nodes = _parse_inline_markup("test_configuration_docs")
+        assert len(nodes) == 1
+        assert nodes[0] == {"type": "text", "text": "test_configuration_docs"}
+
+    def test_iso_date_not_strike(self):
+        """ISO dates should not be treated as strikethrough."""
+        nodes = _parse_inline_markup("2026-03-31")
+        assert len(nodes) == 1
+        assert nodes[0] == {"type": "text", "text": "2026-03-31"}
+
+    def test_strike_with_word_boundaries(self):
+        """Strikethrough with proper word boundaries should still work."""
+        nodes = _parse_inline_markup("some -struck- here")
+        assert nodes[1]["text"] == "struck"
+        assert nodes[1]["marks"] == [{"type": "strike"}]
+
+    def test_italic_with_word_boundaries(self):
+        """Italic with proper word boundaries should still work."""
+        nodes = _parse_inline_markup("hello _italic_ world")
+        assert nodes[1]["text"] == "italic"
+        assert nodes[1]["marks"] == [{"type": "em"}]
+
+    def test_bold_mid_word_not_bold(self):
+        """Asterisks inside words should not be treated as bold."""
+        nodes = _parse_inline_markup("foo*bar*baz")
+        assert len(nodes) == 1
+        assert nodes[0] == {"type": "text", "text": "foo*bar*baz"}
+
+    def test_strike_after_punctuation(self):
+        """Strikethrough after punctuation (not word char) should work."""
+        nodes = _parse_inline_markup("(-struck-)")
+        assert nodes[1]["text"] == "struck"
+        assert nodes[1]["marks"] == [{"type": "strike"}]
+
     def test_image_requires_dot(self):
         """!important! should not be treated as an image."""
         nodes = _parse_inline_markup("This is !important! news")
@@ -1263,3 +1305,27 @@ class TestTextToAdfWikiIntegration:
     def test_wiki_table_converted(self):
         result = text_to_adf("||Col1||Col2||\n|a|b|")
         assert result["content"][0]["type"] == "table"
+
+    def test_wiki_list_with_underscore_identifier(self):
+        """Underscores in identifiers should not become italic inside wiki lists."""
+        result = text_to_adf("* Update test_configuration_docs\n* Add tests")
+        item = result["content"][0]["content"][0]["content"][0]
+        assert len(item["content"]) == 1
+        assert item["content"][0]["text"] == "Update test_configuration_docs"
+        assert "marks" not in item["content"][0]
+
+    def test_wiki_list_with_iso_date(self):
+        """ISO dates should not become strikethrough inside wiki lists."""
+        result = text_to_adf("* Deadline: 2026-03-31\n* Status: Done")
+        item = result["content"][0]["content"][0]["content"][0]
+        assert len(item["content"]) == 1
+        assert item["content"][0]["text"] == "Deadline: 2026-03-31"
+        assert "marks" not in item["content"][0]
+
+    def test_wiki_list_with_hyphenated_words(self):
+        """Hyphenated words should not become strikethrough inside wiki lists."""
+        result = text_to_adf("* Use foo-bar-baz option\n* Done")
+        item = result["content"][0]["content"][0]["content"][0]
+        assert len(item["content"]) == 1
+        assert item["content"][0]["text"] == "Use foo-bar-baz option"
+        assert "marks" not in item["content"][0]


### PR DESCRIPTION
## Summary
- Wiki-to-ADF inline formatting patterns (`-strike-`, `_italic_`, `*bold*`, etc.) matched mid-word delimiters, causing false positives on plain text like ISO dates (`2026-03-31` → ~~03~~), identifiers (`test_configuration_docs` → *configuration*), and hyphenated words (`foo-bar-baz` → ~~bar~~)
- Added `(?<!\w)` / `(?!\w)` word-boundary guards to all six inline formatting regex patterns so they only fire when delimiters sit at actual word boundaries (whitespace, punctuation, or start/end of text)
- Legitimate wiki markup (e.g., `some -struck- here`, `(_italic_)`) continues to work correctly

## Test plan
- [x] All 435 existing Jira plugin tests pass (0 regressions)
- [x] 10 new tests added covering the reported false-positive patterns and confirming proper word-boundary matching still works
- [x] Pre-commit hooks pass (ruff, ty, pytest, trailing whitespace, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)