### PR TITLE
pre-commit: fix hard-coded paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Create venv for local hooks
-        run: |
-          python -m venv .venv
-          .venv/bin/pip install pytest ty
-
       - uses: pre-commit/action@v3.0.1
 
   go:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,15 +32,17 @@ repos:
 
       - id: ty
         name: ty
-        entry: bash -c 'fail=0; for d in plugins/*/; do [ -f "$d/handler.py" ] && { .venv/bin/ty check --extra-search-path "$d" "$d" || fail=1; }; done; exit $fail'
-        language: system
+        entry: bash -c 'fail=0; for d in plugins/*/; do [ -f "$d/handler.py" ] && { ty check --extra-search-path "$d" "$d" || fail=1; }; done; exit $fail'
+        language: python
+        additional_dependencies: [ty, pytest]
         types: [python]
         pass_filenames: false
 
       - id: pytest
         name: pytest
-        entry: .venv/bin/pytest -x -q
-        language: system
+        entry: pytest -x -q
+        language: python
+        additional_dependencies: [pytest]
         types: [python]
         pass_filenames: false
 


### PR DESCRIPTION
pre-commit hooks used hard-coded paths based on '.venv', which might not be the ones used on different hosts. This patch allows for different virtual environment paths.