### PR TITLE
Fix testing-farm information gathering and status report

### DIFF
--- a/plugins/testing-farm/handler.py
+++ b/plugins/testing-farm/handler.py
@@ -253,8 +253,8 @@ def testing_farm_get_request(params):
     envs = body.get("environments_requested", [])
     env0 = envs[0] if envs else {}
 
-    artifacts_url = body.get("artifacts_url", "")
     run = body.get("run", {}) or {}
+    artifacts_url = run.get("artifacts", "")
 
     result = {
         "id": body.get("id", ""),
@@ -362,7 +362,8 @@ def testing_farm_get_ssh(params):
     if status != 200:
         raise Exception(f"API error (HTTP {status}): {body}")
 
-    artifacts_url = body.get("artifacts_url", "")
+    run = body.get("run", {}) or {}
+    artifacts_url = run.get("artifacts", "")
     if not artifacts_url:
         raise Exception("No artifacts URL found — request may still be queued")
 
@@ -579,8 +580,8 @@ def testing_farm_get_logs(params):
     if status != 200:
         raise Exception(f"API error (HTTP {status}): {body}")
 
-    artifacts_url = body.get("artifacts_url", "")
     run = body.get("run", {}) or {}
+    artifacts_url = run.get("artifacts", "")
 
     result = {
         "request_id": request_id,

--- a/plugins/testing-farm/handler.py
+++ b/plugins/testing-farm/handler.py
@@ -368,12 +368,17 @@ def testing_farm_get_ssh(params):
         raise Exception("No artifacts URL found — request may still be queued")
 
     state = body.get("state", "")
-    if state not in ("running", "complete"):
-        return {
-            "error": f"Request is in state '{state}' — SSH info is only available for running or complete reservations",
-            "state": state,
-            "request_id": request_id,
-        }
+    ret = {
+        "error": "",
+        "state": state,
+        "request_id": request_id,
+    }
+    if state == "complete":
+        ret["error"] = "Reservation is complete — the host has been returned to the infrastructure"
+        return ret
+    elif state != "running":
+        ret["error"] = f"Request is in state '{state}' — SSH info is only available for running reservations"
+        return ret
 
     envs = body.get("environments_requested", [])
     env0 = envs[0] if envs else {}

--- a/plugins/testing-farm/handler.py
+++ b/plugins/testing-farm/handler.py
@@ -410,7 +410,10 @@ def testing_farm_get_ssh(params):
 
 
 def _parse_ssh_from_results_xml(xml_text, artifacts_url):
-    """Parse results.xml to find the IP address from console logs."""
+    """
+    Parse results.xml to find workdir and extract IP from guests.yaml.
+    Fall back to console logs.
+    """
     try:
         root = ET.fromstring(xml_text)
     except ET.ParseError:
@@ -433,8 +436,21 @@ def _parse_ssh_from_results_xml(xml_text, artifacts_url):
                 return _fetch_and_parse_console_log(href)
         return None
 
-    # List workdir to find console-*.log files.
     dir_url = workdir_href if workdir_href.startswith("http") else f"{artifacts_url}/{workdir_href}"
+
+    # Try guests.yaml first
+    guests_url = f"{dir_url.rstrip('/')}/testing-farm/reserve/provision/guests.yaml"
+    gstatus, gbody, _ = http("GET", "/", url=guests_url)
+    if gstatus == 200:
+        guests_text = (
+            gbody if isinstance(gbody, str) else gbody.decode("utf-8") if isinstance(gbody, bytes) else str(gbody)
+        )
+        # Find primary-address: <ip>
+        match = re.search(r"primary-address:\s*(\d+\.\d+\.\d+\.\d+)", guests_text)
+        if match:
+            return match.group(1)
+
+    # List workdir to find console-*.log files.
     dstatus, dbody, _ = http("GET", "/", url=dir_url)
     if dstatus != 200:
         return None

--- a/plugins/testing-farm/tests/test_handler.py
+++ b/plugins/testing-farm/tests/test_handler.py
@@ -255,6 +255,31 @@ class TestExtractResult:
         assert handler._extract_result({}) == "unknown"
 
 
+# --- _parse_ssh_from_results_xml ---
+
+
+class TestParseSshFromResultsXml:
+    def test_from_guests_yaml(self):
+        xml = '<testsuite><logs><log href="work-dir/" name="workdir"/></logs></testsuite>'
+        yaml_content = """default-0:
+            -OPTIONLESS-FIELDS:
+              - primary_address
+              - topology_address
+              - facts
+            primary-address: 10.31.8.213
+            topology-address: 10.31.8.213
+        """
+
+        def mock_http(method, path, url=None, **kwargs):
+            if url and url.endswith("guests.yaml"):
+                return 200, yaml_content, {}
+            return 404, "", {}
+
+        with patch.object(handler, "http", side_effect=mock_http):
+            ip = handler._parse_ssh_from_results_xml(xml, "https://artifacts")
+            assert ip == "10.31.8.213"
+
+
 # --- _extract_ip_from_console ---
 
 

--- a/plugins/testing-farm/tests/test_handler.py
+++ b/plugins/testing-farm/tests/test_handler.py
@@ -606,6 +606,15 @@ class TestGetSsh:
             assert "error" in result
             assert result["state"] == "queued"
 
+    def test_complete(self):
+        req = {**SAMPLE_REQUEST, "state": "complete"}
+        req["run"] = {"artifacts": "https://artifacts.example.com/req-1"}
+        with _mock_cache_get(None), _mock_http(200, req):
+            result = handler.testing_farm_get_ssh({"request_id": "req-1"})
+            assert "error" in result
+            assert result["state"] == "complete"
+            assert "returned" in result["error"]
+
     def test_no_artifacts_url(self):
         req = {**SAMPLE_REQUEST, "run": {}}
         with _mock_cache_get(None), _mock_http(200, req):

--- a/plugins/testing-farm/tests/test_handler.py
+++ b/plugins/testing-farm/tests/test_handler.py
@@ -42,7 +42,6 @@ SAMPLE_REQUEST = {
     "result": {"overall": "passed"},
     "created": "2025-01-15T10:00:00Z",
     "updated": "2025-01-15T10:30:00Z",
-    "artifacts_url": "https://artifacts.example.com/req-abc-123",
     "test": {"fmf": {"url": "https://example.com/tests", "ref": "main", "name": "/plan/test1"}},
     "environments_requested": [
         {
@@ -50,7 +49,7 @@ SAMPLE_REQUEST = {
             "arch": "x86_64",
         }
     ],
-    "run": {"log": "https://example.com/log", "stages": []},
+    "run": {"log": "https://example.com/log", "stages": [], "artifacts": "https://artifacts.example.com/req-abc-123"},
 }
 
 RESERVE_REQUEST = {
@@ -575,14 +574,15 @@ class TestGetSsh:
             assert result == cached
 
     def test_not_running(self):
-        req = {**SAMPLE_REQUEST, "state": "queued", "artifacts_url": "https://artifacts.example.com/req-1"}
+        req = {**SAMPLE_REQUEST, "state": "queued"}
+        req["run"] = {"artifacts": "https://artifacts.example.com/req-1"}
         with _mock_cache_get(None), _mock_http(200, req):
             result = handler.testing_farm_get_ssh({"request_id": "req-1"})
             assert "error" in result
             assert result["state"] == "queued"
 
     def test_no_artifacts_url(self):
-        req = {**SAMPLE_REQUEST, "artifacts_url": ""}
+        req = {**SAMPLE_REQUEST, "run": {}}
         with _mock_cache_get(None), _mock_http(200, req):
             try:
                 handler.testing_farm_get_ssh({"request_id": "req-1"})


### PR DESCRIPTION
This PR makes fixes a few issues with relation to how testing-farm plugin gathered the artifacts and also the IP address for SSH during reservations.

* We now properly grab the artifacts URL from the `run` object in the API response instead from the root object.
* Instead of relying on parsing console log (which can sometimes be empty), we now pull the SSH IP directly from `provision/guests.yaml`. If that fails, it still falls back to checking the console log.
* If a reservation is already in the `complete` state, the plugin now explicitly tells you that the host has been returned and is no longer accessible, instead of giving a false positive that you can still SSH into it.