### PR TITLE
fix: preserve text formatting in google-docs plugin

### DIFF
--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -594,26 +594,26 @@ func indentDepth(indent string) int {
 
 // parseMarkdown parses markdown text and returns segments with formatting info.
 func parseMarkdown(markdown string) []markdownSegment {
+	// Normalize line endings
+	markdown = strings.ReplaceAll(markdown, "\r\n", "\n")
+	markdown = strings.ReplaceAll(markdown, "\r", "\n")
+
 	var segments []markdownSegment
 	lines := strings.Split(markdown, "\n")
 
-	for idx, line := range lines {
+	lastWasHeading := false
+
+	for _, line := range lines {
 		trimmedLine := strings.TrimSpace(line)
 
 		if trimmedLine == "" {
-			// Blank lines before headings are skipped — headings carry their own
-			// paragraph break. Blank lines elsewhere become a paragraph separator
-			// so that visual gaps between blocks are preserved in the document.
-			nextIsHeading := false
-			for _, next := range lines[idx+1:] {
-				if t := strings.TrimSpace(next); t != "" {
-					nextIsHeading = strings.HasPrefix(t, "#")
-					break
-				}
+			if lastWasHeading {
+				// Skip blank lines immediately after headings —
+				// headings create their own paragraph break via \n
+				continue
 			}
-			if !nextIsHeading {
-				segments = append(segments, markdownSegment{text: "\n"})
-			}
+			// Preserve blank lines between normal text as empty paragraphs
+			segments = append(segments, markdownSegment{text: "\n"})
 			continue
 		}
 
@@ -636,19 +636,24 @@ func parseMarkdown(markdown string) []markdownSegment {
 		}
 
 		if headingLevel > 0 && headingLevel <= 6 {
-			// Heading line
-			segments = append(segments, markdownSegment{
-				text:    trimmedLine + "\n",
-				heading: headingLevel,
-			})
+			lastWasHeading = true
+			// Heading line - parse inline formatting within heading text
+			// Note: Headings don't include trailing newline - they're standalone paragraphs
+			inlineSegs := parseSimpleFormatting(trimmedLine)
+			for i := range inlineSegs {
+				inlineSegs[i].heading = headingLevel
+			}
+			segments = append(segments, inlineSegs...)
 			continue
 		}
+
+		lastWasHeading = false
 
 		// Check for ordered list (e.g., "1. Item", "2. Item") with optional leading indent
 		if orderedListMatch := reOrderedList.FindStringSubmatch(line); orderedListMatch != nil {
 			depth := indentDepth(orderedListMatch[1])
 			listItemText := orderedListMatch[2]
-			inlineSegs := parseInlineFormatting(listItemText + "\n")
+			inlineSegs := parseSimpleFormatting(listItemText + "\n")
 			for i := range inlineSegs {
 				inlineSegs[i].orderedListItem = true
 				inlineSegs[i].listDepth = depth
@@ -661,7 +666,7 @@ func parseMarkdown(markdown string) []markdownSegment {
 		if unorderedListMatch := reUnorderedList.FindStringSubmatch(line); unorderedListMatch != nil {
 			depth := indentDepth(unorderedListMatch[1])
 			listItemText := unorderedListMatch[3]
-			inlineSegs := parseInlineFormatting(listItemText + "\n")
+			inlineSegs := parseSimpleFormatting(listItemText + "\n")
 			for i := range inlineSegs {
 				inlineSegs[i].unorderedListItem = true
 				inlineSegs[i].listDepth = depth
@@ -671,24 +676,92 @@ func parseMarkdown(markdown string) []markdownSegment {
 		}
 
 		// Parse inline formatting
-		segments = append(segments, parseInlineFormatting(line+"\n")...)
+		segments = append(segments, parseSimpleFormatting(line+"\n")...)
 	}
 
 	return segments
 }
 
-// parseInlineFormatting parses inline markdown formatting (bold, italic, links, smart chips, etc).
-func parseInlineFormatting(text string) []markdownSegment {
+// parseSimpleFormatting parses bold, italic, and underline formatting.
+func parseSimpleFormatting(text string) []markdownSegment {
 	var segments []markdownSegment
 	pos := 0
 
 	for pos < len(text) {
-		// Check for @date(YYYY-MM-DD) - must come before @today check
-		if dateMatch := reDateChip.FindStringSubmatchIndex(text[pos:]); dateMatch != nil {
-			// Add text before date field
-			if dateMatch[0] > 0 {
-				segments = append(segments, parseSimpleFormatting(text[pos:pos+dateMatch[0]])...)
+		// Check for **bold**
+		if strings.HasPrefix(text[pos:], "**") {
+			endPos := strings.Index(text[pos+2:], "**")
+			if endPos != -1 {
+				endPos += pos + 2
+				innerSegs := parseSimpleFormatting(text[pos+2 : endPos])
+				for i := range innerSegs {
+					innerSegs[i].bold = true
+				}
+				segments = append(segments, innerSegs...)
+				pos = endPos + 2
+				continue
 			}
+		}
+
+		// Check for __underline__
+		if strings.HasPrefix(text[pos:], "__") {
+			endPos := strings.Index(text[pos+2:], "__")
+			if endPos != -1 {
+				endPos += pos + 2
+				innerSegs := parseSimpleFormatting(text[pos+2 : endPos])
+				for i := range innerSegs {
+					innerSegs[i].underline = true
+				}
+				segments = append(segments, innerSegs...)
+				pos = endPos + 2
+				continue
+			}
+		}
+
+		// Check for *italic*
+		if strings.HasPrefix(text[pos:], "*") && !strings.HasPrefix(text[pos:], "**") {
+			endPos := strings.Index(text[pos+1:], "*")
+			if endPos != -1 {
+				endPos += pos + 1
+				// Make sure it's not part of **
+				if endPos+1 < len(text) && text[endPos+1] == '*' {
+					segments = append(segments, markdownSegment{text: text[pos : pos+1]})
+					pos++
+					continue
+				}
+				innerSegs := parseSimpleFormatting(text[pos+1 : endPos])
+				for i := range innerSegs {
+					innerSegs[i].italic = true
+				}
+				segments = append(segments, innerSegs...)
+				pos = endPos + 1
+				continue
+			}
+		}
+
+		// Check for _italic_ (single underscore, not double)
+		if strings.HasPrefix(text[pos:], "_") && !strings.HasPrefix(text[pos:], "__") {
+			endPos := strings.Index(text[pos+1:], "_")
+			if endPos != -1 {
+				endPos += pos + 1
+				// Make sure it's not part of __
+				if endPos+1 < len(text) && text[endPos+1] == '_' {
+					segments = append(segments, markdownSegment{text: text[pos : pos+1]})
+					pos++
+					continue
+				}
+				innerSegs := parseSimpleFormatting(text[pos+1 : endPos])
+				for i := range innerSegs {
+					innerSegs[i].italic = true
+				}
+				segments = append(segments, innerSegs...)
+				pos = endPos + 1
+				continue
+			}
+		}
+
+		// Check for @date(YYYY-MM-DD) - must come before @today check
+		if dateMatch := reDateChip.FindStringSubmatchIndex(text[pos:]); dateMatch != nil && dateMatch[0] == 0 {
 			// Add date field with specific date
 			dateValue := text[pos+dateMatch[2] : pos+dateMatch[3]]
 			segments = append(segments, markdownSegment{
@@ -712,11 +785,7 @@ func parseInlineFormatting(text string) []markdownSegment {
 		}
 
 		// Check for @(name or email) - person smart chip
-		if personMatch := rePersonChip.FindStringSubmatchIndex(text[pos:]); personMatch != nil {
-			// Add text before person field
-			if personMatch[0] > 0 {
-				segments = append(segments, parseSimpleFormatting(text[pos:pos+personMatch[0]])...)
-			}
+		if personMatch := rePersonChip.FindStringSubmatchIndex(text[pos:]); personMatch != nil && personMatch[0] == 0 {
 			// Add person field
 			identifier := text[pos+personMatch[2] : pos+personMatch[3]]
 			segments = append(segments, markdownSegment{
@@ -729,11 +798,7 @@ func parseInlineFormatting(text string) []markdownSegment {
 		}
 
 		// Check for link: [text](url)
-		if linkMatch := reLinkInline.FindStringSubmatchIndex(text[pos:]); linkMatch != nil {
-			// Add text before link
-			if linkMatch[0] > 0 {
-				segments = append(segments, parseSimpleFormatting(text[pos:pos+linkMatch[0]])...)
-			}
+		if linkMatch := reLinkInline.FindStringSubmatchIndex(text[pos:]); linkMatch != nil && linkMatch[0] == 0 {
 			// Add link
 			linkText := text[pos+linkMatch[2] : pos+linkMatch[3]]
 			linkURL := text[pos+linkMatch[4] : pos+linkMatch[5]]
@@ -743,88 +808,6 @@ func parseInlineFormatting(text string) []markdownSegment {
 			})
 			pos += linkMatch[1]
 			continue
-		}
-
-		// No more special formatting, process rest as simple formatting
-		segments = append(segments, parseSimpleFormatting(text[pos:])...)
-		break
-	}
-
-	return segments
-}
-
-// parseSimpleFormatting parses bold, italic, and underline formatting.
-func parseSimpleFormatting(text string) []markdownSegment {
-	var segments []markdownSegment
-	pos := 0
-
-	for pos < len(text) {
-		// Check for **bold**
-		if strings.HasPrefix(text[pos:], "**") {
-			endPos := strings.Index(text[pos+2:], "**")
-			if endPos != -1 {
-				endPos += pos + 2
-				segments = append(segments, markdownSegment{
-					text: text[pos+2 : endPos],
-					bold: true,
-				})
-				pos = endPos + 2
-				continue
-			}
-		}
-
-		// Check for __underline__
-		if strings.HasPrefix(text[pos:], "__") {
-			endPos := strings.Index(text[pos+2:], "__")
-			if endPos != -1 {
-				endPos += pos + 2
-				segments = append(segments, markdownSegment{
-					text:      text[pos+2 : endPos],
-					underline: true,
-				})
-				pos = endPos + 2
-				continue
-			}
-		}
-
-		// Check for *italic*
-		if strings.HasPrefix(text[pos:], "*") && !strings.HasPrefix(text[pos:], "**") {
-			endPos := strings.Index(text[pos+1:], "*")
-			if endPos != -1 {
-				endPos += pos + 1
-				// Make sure it's not part of **
-				if endPos+1 < len(text) && text[endPos+1] == '*' {
-					segments = append(segments, markdownSegment{text: text[pos : pos+1]})
-					pos++
-					continue
-				}
-				segments = append(segments, markdownSegment{
-					text:   text[pos+1 : endPos],
-					italic: true,
-				})
-				pos = endPos + 1
-				continue
-			}
-		}
-
-		// Check for _italic_ (single underscore, not double)
-		if strings.HasPrefix(text[pos:], "_") && !strings.HasPrefix(text[pos:], "__") {
-			endPos := strings.Index(text[pos+1:], "_")
-			if endPos != -1 {
-				endPos += pos + 1
-				// Make sure it's not part of __
-				if endPos+1 < len(text) && text[endPos+1] == '_' {
-					segments = append(segments, markdownSegment{text: text[pos : pos+1]})
-					pos++
-					continue
-				}
-				segments = append(segments, markdownSegment{
-					text:   text[pos+1 : endPos],
-					italic: true,
-				})
-				pos = endPos + 1
-				continue
-			}
 		}
 
 		// Plain character
@@ -877,6 +860,16 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 	// Merge consecutive segments with identical formatting to reduce API requests
 	segments = mergeSegments(segments)
 
+	// Remove trailing \n from the last text segment.
+	// The document already ends with \n, so our trailing \n
+	// would create an unwanted empty paragraph.
+	for i := len(segments) - 1; i >= 0; i-- {
+		if segments[i].text != "" && !segments[i].isDateField && !segments[i].isPersonField {
+			segments[i].text = strings.TrimSuffix(segments[i].text, "\n")
+			break
+		}
+	}
+
 	// Track list ranges for batch processing
 	type listRange struct {
 		startIndex int64
@@ -887,9 +880,20 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 	var currentListStart int64 = -1
 	var currentListIsOrdered bool
 
+	// Track text style requests for headings - we defer them until after UpdateParagraphStyle
+	// to prevent the paragraph style from wiping out the text formatting
+	var headingTextStyleRequests []*docs.Request
+	var inHeading bool
+
 	for i, seg := range segments {
 		if seg.text == "" && !seg.isDateField && !seg.isPersonField {
 			continue
+		}
+
+		// Detect start of a new heading
+		if seg.heading > 0 && (i == 0 || segments[i-1].heading != seg.heading) {
+			inHeading = true
+			headingTextStyleRequests = nil
 		}
 
 		var endIndex int64
@@ -965,6 +969,49 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 			// Date elements take 1 character in the document index
 			endIndex = currentIndex + 1
 			currentIndex = endIndex
+
+			// Apply paragraph style (heading or normal text)
+			// Always apply to prevent heading styles from persisting
+			var paragraphStyle string
+			if seg.heading > 0 {
+				paragraphStyle = fmt.Sprintf("HEADING_%d", seg.heading)
+			} else {
+				paragraphStyle = "NORMAL_TEXT"
+			}
+			requests = append(requests, &docs.Request{
+				UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
+					Range: &docs.Range{
+						StartIndex: currentIndex - 1,
+						EndIndex:   currentIndex,
+					},
+					ParagraphStyle: &docs.ParagraphStyle{
+						NamedStyleType: paragraphStyle,
+					},
+					Fields: "namedStyleType",
+				},
+			})
+
+			// Apply text formatting (bold, italic, underline) to the date chip
+			if seg.bold || seg.italic || seg.underline {
+				textStyle := &docs.TextStyle{
+					Bold:      seg.bold,
+					Italic:    seg.italic,
+					Underline: seg.underline,
+				}
+				fields := []string{"bold", "italic", "underline"}
+
+				requests = append(requests, &docs.Request{
+					UpdateTextStyle: &docs.UpdateTextStyleRequest{
+						Range: &docs.Range{
+							StartIndex: currentIndex - 1,
+							EndIndex:   currentIndex,
+						},
+						TextStyle: textStyle,
+						Fields:    strings.Join(fields, ","),
+					},
+				})
+			}
+
 			continue
 		}
 
@@ -1000,6 +1047,49 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 			// Person elements take 1 character in the index
 			endIndex = currentIndex + 1
 			currentIndex = endIndex
+
+			// Apply paragraph style (heading or normal text)
+			// Always apply to prevent heading styles from persisting
+			var paragraphStyle string
+			if seg.heading > 0 {
+				paragraphStyle = fmt.Sprintf("HEADING_%d", seg.heading)
+			} else {
+				paragraphStyle = "NORMAL_TEXT"
+			}
+			requests = append(requests, &docs.Request{
+				UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
+					Range: &docs.Range{
+						StartIndex: currentIndex - 1,
+						EndIndex:   currentIndex,
+					},
+					ParagraphStyle: &docs.ParagraphStyle{
+						NamedStyleType: paragraphStyle,
+					},
+					Fields: "namedStyleType",
+				},
+			})
+
+			// Apply text formatting (bold, italic, underline) to the person chip
+			if seg.bold || seg.italic || seg.underline {
+				textStyle := &docs.TextStyle{
+					Bold:      seg.bold,
+					Italic:    seg.italic,
+					Underline: seg.underline,
+				}
+				fields := []string{"bold", "italic", "underline"}
+
+				requests = append(requests, &docs.Request{
+					UpdateTextStyle: &docs.UpdateTextStyleRequest{
+						Range: &docs.Range{
+							StartIndex: currentIndex - 1,
+							EndIndex:   currentIndex,
+						},
+						TextStyle: textStyle,
+						Fields:    strings.Join(fields, ","),
+					},
+				})
+			}
+
 			continue
 		}
 
@@ -1056,6 +1146,17 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 			insertText = strings.Join(outLines, "\n")
 		}
 
+		// Append \n to headings only after the LAST segment of that heading level.
+		// Check if the next segment is NOT the same heading level (or doesn't exist).
+		// This ensures multi-segment headings (e.g., "# **Bold** Normal") stay as one paragraph.
+		if seg.heading > 0 && !strings.HasSuffix(insertText, "\n") {
+			isLastHeadingSegment := i == len(segments)-1 || segments[i+1].heading != seg.heading
+			// Don't add \n if this is the very last segment of the document
+			if isLastHeadingSegment && i < len(segments)-1 {
+				insertText += "\n"
+			}
+		}
+
 		// Insert the text
 		requests = append(requests, &docs.Request{
 			InsertText: &docs.InsertTextRequest{
@@ -1067,24 +1168,7 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 		// Use rune count, not byte length! Multi-byte UTF-8 characters need proper counting
 		endIndex = currentIndex + int64(utf8.RuneCountInString(insertText))
 
-		// Apply heading style
-		if seg.heading > 0 {
-			headingStyle := fmt.Sprintf("HEADING_%d", seg.heading)
-			requests = append(requests, &docs.Request{
-				UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
-					Range: &docs.Range{
-						StartIndex: currentIndex,
-						EndIndex:   endIndex,
-					},
-					ParagraphStyle: &docs.ParagraphStyle{
-						NamedStyleType: headingStyle,
-					},
-					Fields: "namedStyleType",
-				},
-			})
-		}
-
-		// Apply text formatting - ALWAYS apply to ensure formatting is explicitly reset
+		// Prepare text style request - ALWAYS apply to ensure formatting is explicitly reset
 		// This prevents bold/italic/underline from "sticking" to subsequent text
 		textStyle := &docs.TextStyle{
 			Bold:      seg.bold,
@@ -1104,7 +1188,7 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 			fields = append(fields, "link")
 		}
 
-		requests = append(requests, &docs.Request{
+		textStyleRequest := &docs.Request{
 			UpdateTextStyle: &docs.UpdateTextStyleRequest{
 				Range: &docs.Range{
 					StartIndex: currentIndex,
@@ -1113,7 +1197,42 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 				TextStyle: textStyle,
 				Fields:    strings.Join(fields, ","),
 			},
-		})
+		}
+
+		// For headings: defer text style requests until after UpdateParagraphStyle
+		// to prevent the paragraph style from wiping out text formatting
+		if inHeading {
+			headingTextStyleRequests = append(headingTextStyleRequests, textStyleRequest)
+		} else {
+			// For normal text: apply text style immediately
+			requests = append(requests, textStyleRequest)
+		}
+
+		// Apply heading style — only at the last segment of a heading.
+		// We apply UpdateParagraphStyle first, then all the deferred UpdateTextStyle
+		// requests, so that text formatting overrides the paragraph style defaults.
+		if seg.heading > 0 {
+			isLastHeadingSegment := i == len(segments)-1 || segments[i+1].heading != seg.heading
+			if isLastHeadingSegment {
+				headingStyle := fmt.Sprintf("HEADING_%d", seg.heading)
+				requests = append(requests, &docs.Request{
+					UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
+						Range: &docs.Range{
+							StartIndex: currentIndex,
+							EndIndex:   endIndex,
+						},
+						ParagraphStyle: &docs.ParagraphStyle{
+							NamedStyleType: headingStyle,
+						},
+						Fields: "namedStyleType",
+					},
+				})
+				// Now apply all deferred text styles for this heading
+				requests = append(requests, headingTextStyleRequests...)
+				inHeading = false
+				headingTextStyleRequests = nil
+			}
+		}
 
 		currentIndex = endIndex
 
@@ -1187,12 +1306,15 @@ func toolWriteText(params, _ json.RawMessage) (any, error) {
 
 	// Determine insertion index
 	insertIndex := p.InsertIndex
+	isAppendingToNonEmptyDoc := false
 	if p.AppendToEnd {
 		// Find the end of the document (before the final newline)
 		if doc.Body == nil || doc.Body.Content == nil || len(doc.Body.Content) == 0 {
 			return nil, fmt.Errorf("document body is empty or invalid")
 		}
 		insertIndex = doc.Body.Content[len(doc.Body.Content)-1].EndIndex - 1
+		// Check if document has existing content (insertIndex > 1 means non-empty)
+		isAppendingToNonEmptyDoc = insertIndex > 1
 	} else if insertIndex < 1 {
 		return nil, fmt.Errorf("insert_index must be >= 1 (got %d); set append_to_end=true to append", insertIndex)
 	}
@@ -1200,8 +1322,13 @@ func toolWriteText(params, _ json.RawMessage) (any, error) {
 	var requests []*docs.Request
 
 	if p.IsMarkdown {
+		// When appending to non-empty document, prepend newline to start new paragraph
+		textToInsert := p.Text
+		if isAppendingToNonEmptyDoc && !strings.HasPrefix(textToInsert, "\n") {
+			textToInsert = "\n" + textToInsert
+		}
 		// Parse markdown and convert to requests
-		segments := parseMarkdown(p.Text)
+		segments := parseMarkdown(textToInsert)
 		requests = convertMarkdownToRequests(segments, insertIndex)
 	} else {
 		// Plain text insertion
@@ -1270,18 +1397,27 @@ func toolWriteMarkdown(params, _ json.RawMessage) (any, error) {
 
 	// Determine insertion index
 	insertIndex := p.InsertIndex
+	isAppendingToNonEmptyDoc := false
 	if p.AppendToEnd {
 		// Find the end of the document (before the final newline)
 		if doc.Body == nil || doc.Body.Content == nil || len(doc.Body.Content) == 0 {
 			return nil, fmt.Errorf("document body is empty or invalid")
 		}
 		insertIndex = doc.Body.Content[len(doc.Body.Content)-1].EndIndex - 1
+		// Check if document has existing content (insertIndex > 1 means non-empty)
+		isAppendingToNonEmptyDoc = insertIndex > 1
 	} else if insertIndex < 1 {
 		return nil, fmt.Errorf("insert_index must be >= 1 (got %d); set append_to_end=true to append", insertIndex)
 	}
 
+	// When appending to non-empty document, prepend newline to start new paragraph
+	markdownToInsert := p.Markdown
+	if isAppendingToNonEmptyDoc && !strings.HasPrefix(markdownToInsert, "\n") {
+		markdownToInsert = "\n" + markdownToInsert
+	}
+
 	// Parse markdown and convert to requests
-	segments := parseMarkdown(p.Markdown)
+	segments := parseMarkdown(markdownToInsert)
 	requests := convertMarkdownToRequests(segments, insertIndex)
 
 	// Execute the batch update

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -66,10 +66,10 @@ func TestParseMarkdownHeadings(t *testing.T) {
 		wantHeading int
 		wantText    string
 	}{
-		{"h1", "# Title", 1, "Title\n"},
-		{"h2", "## Subtitle", 2, "Subtitle\n"},
-		{"h3", "### Section", 3, "Section\n"},
-		{"h6", "###### Deep", 6, "Deep\n"},
+		{"h1", "# Title", 1, "Title"},
+		{"h2", "## Subtitle", 2, "Subtitle"},
+		{"h3", "### Section", 3, "Section"},
+		{"h6", "###### Deep", 6, "Deep"},
 		{"not heading (no space)", "#NoSpace", 0, ""},
 	}
 
@@ -85,17 +85,20 @@ func TestParseMarkdownHeadings(t *testing.T) {
 				}
 				return
 			}
-			found := false
+			// Collect all heading segments and concatenate their text
+			var headingText string
+			foundHeading := false
 			for _, seg := range segments {
 				if seg.heading == tt.wantHeading {
-					found = true
-					if seg.text != tt.wantText {
-						t.Errorf("heading text = %q, want %q", seg.text, tt.wantText)
-					}
+					foundHeading = true
+					headingText += seg.text
 				}
 			}
-			if !found {
+			if !foundHeading {
 				t.Errorf("no segment with heading=%d found in %+v", tt.wantHeading, segments)
+			}
+			if headingText != tt.wantText {
+				t.Errorf("concatenated heading text = %q, want %q", headingText, tt.wantText)
 			}
 		})
 	}
@@ -145,29 +148,65 @@ func TestParseMarkdownLists(t *testing.T) {
 func TestParseSimpleFormatting(t *testing.T) {
 	t.Run("bold", func(t *testing.T) {
 		segments := parseSimpleFormatting("**bold**")
-		if len(segments) != 1 || !segments[0].bold || segments[0].text != "bold" {
-			t.Errorf("got %+v, want bold segment with text 'bold'", segments)
+		// Collect all bold segments and concatenate
+		var boldText string
+		foundBold := false
+		for _, seg := range segments {
+			if seg.bold {
+				foundBold = true
+				boldText += seg.text
+			}
+		}
+		if !foundBold || boldText != "bold" {
+			t.Errorf("got %+v, want bold segments concatenating to 'bold'", segments)
 		}
 	})
 
 	t.Run("italic with asterisk", func(t *testing.T) {
 		segments := parseSimpleFormatting("*italic*")
-		if len(segments) != 1 || !segments[0].italic || segments[0].text != "italic" {
-			t.Errorf("got %+v, want italic segment", segments)
+		// Collect all italic segments and concatenate
+		var italicText string
+		foundItalic := false
+		for _, seg := range segments {
+			if seg.italic {
+				foundItalic = true
+				italicText += seg.text
+			}
+		}
+		if !foundItalic || italicText != "italic" {
+			t.Errorf("got %+v, want italic segments concatenating to 'italic'", segments)
 		}
 	})
 
 	t.Run("italic with underscore", func(t *testing.T) {
 		segments := parseSimpleFormatting("_italic_")
-		if len(segments) != 1 || !segments[0].italic || segments[0].text != "italic" {
-			t.Errorf("got %+v, want italic segment", segments)
+		// Collect all italic segments and concatenate
+		var italicText string
+		foundItalic := false
+		for _, seg := range segments {
+			if seg.italic {
+				foundItalic = true
+				italicText += seg.text
+			}
+		}
+		if !foundItalic || italicText != "italic" {
+			t.Errorf("got %+v, want italic segments concatenating to 'italic'", segments)
 		}
 	})
 
 	t.Run("underline", func(t *testing.T) {
 		segments := parseSimpleFormatting("__underlined__")
-		if len(segments) != 1 || !segments[0].underline || segments[0].text != "underlined" {
-			t.Errorf("got %+v, want underline segment", segments)
+		// Collect all underline segments and concatenate
+		var underlineText string
+		foundUnderline := false
+		for _, seg := range segments {
+			if seg.underline {
+				foundUnderline = true
+				underlineText += seg.text
+			}
+		}
+		if !foundUnderline || underlineText != "underlined" {
+			t.Errorf("got %+v, want underline segments concatenating to 'underlined'", segments)
 		}
 	})
 
@@ -190,7 +229,7 @@ func TestParseSimpleFormatting(t *testing.T) {
 
 func TestParseInlineFormatting(t *testing.T) {
 	t.Run("link", func(t *testing.T) {
-		segments := parseInlineFormatting("[Google](https://google.com)")
+		segments := parseSimpleFormatting("[Google](https://google.com)")
 		found := false
 		for _, seg := range segments {
 			if seg.linkURL == "https://google.com" && seg.text == "Google" {
@@ -203,7 +242,7 @@ func TestParseInlineFormatting(t *testing.T) {
 	})
 
 	t.Run("date today", func(t *testing.T) {
-		segments := parseInlineFormatting("@today")
+		segments := parseSimpleFormatting("@today")
 		found := false
 		for _, seg := range segments {
 			if seg.isDateField && seg.dateValue == "" {
@@ -216,7 +255,7 @@ func TestParseInlineFormatting(t *testing.T) {
 	})
 
 	t.Run("date specific", func(t *testing.T) {
-		segments := parseInlineFormatting("@date(2026-01-15)")
+		segments := parseSimpleFormatting("@date(2026-01-15)")
 		found := false
 		for _, seg := range segments {
 			if seg.isDateField && seg.dateValue == "2026-01-15" {
@@ -229,7 +268,7 @@ func TestParseInlineFormatting(t *testing.T) {
 	})
 
 	t.Run("person chip", func(t *testing.T) {
-		segments := parseInlineFormatting("@(user@example.com)")
+		segments := parseSimpleFormatting("@(user@example.com)")
 		found := false
 		for _, seg := range segments {
 			if seg.isPersonField && seg.personIdentifier == "user@example.com" {
@@ -238,6 +277,329 @@ func TestParseInlineFormatting(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("person chip not found in %+v", segments)
+		}
+	})
+}
+
+func TestHeadingsWithInlineFormatting(t *testing.T) {
+	t.Run("heading with @today", func(t *testing.T) {
+		segments := parseMarkdown("# @today")
+		foundDate := false
+		for _, seg := range segments {
+			if seg.isDateField && seg.heading == 1 && seg.dateValue == "" {
+				foundDate = true
+			}
+		}
+		if !foundDate {
+			t.Errorf("@today with heading=1 not found in %+v", segments)
+		}
+	})
+
+	t.Run("heading with specific date", func(t *testing.T) {
+		segments := parseMarkdown("## Meeting @date(2026-04-07)")
+		var headingText string
+		foundDate := false
+		for _, seg := range segments {
+			if seg.heading == 2 {
+				if seg.isDateField && seg.dateValue == "2026-04-07" {
+					foundDate = true
+				} else if !seg.isDateField {
+					headingText += seg.text
+				}
+			}
+		}
+		// Headings no longer have trailing newlines
+		if headingText != "Meeting " {
+			t.Errorf("heading text = %q, want 'Meeting '", headingText)
+		}
+		if !foundDate {
+			t.Errorf("@date(2026-04-07) with heading=2 not found in %+v", segments)
+		}
+	})
+
+	t.Run("heading with person chip", func(t *testing.T) {
+		segments := parseMarkdown("### @(user@example.com)")
+		foundPerson := false
+		for _, seg := range segments {
+			if seg.isPersonField && seg.heading == 3 && seg.personIdentifier == "user@example.com" {
+				foundPerson = true
+			}
+		}
+		if !foundPerson {
+			t.Errorf("person chip with heading=3 not found in %+v", segments)
+		}
+	})
+
+	t.Run("heading with bold text", func(t *testing.T) {
+		segments := parseMarkdown("# **Important**")
+		var boldText string
+		for _, seg := range segments {
+			if seg.heading == 1 && seg.bold {
+				boldText += seg.text
+			}
+		}
+		if boldText != "Important" {
+			t.Errorf("bold text = %q, want 'Important'", boldText)
+		}
+	})
+
+	t.Run("heading with italic text", func(t *testing.T) {
+		segments := parseMarkdown("## *Emphasis*")
+		var italicText string
+		for _, seg := range segments {
+			if seg.heading == 2 && seg.italic {
+				italicText += seg.text
+			}
+		}
+		if italicText != "Emphasis" {
+			t.Errorf("italic text = %q, want 'Emphasis'", italicText)
+		}
+	})
+}
+
+func TestFormattedDateChips(t *testing.T) {
+	t.Run("bold @today", func(t *testing.T) {
+		segments := parseSimpleFormatting("**@today**")
+		foundBoldDate := false
+		for _, seg := range segments {
+			if seg.isDateField && seg.bold && seg.dateValue == "" {
+				foundBoldDate = true
+			}
+		}
+		if !foundBoldDate {
+			t.Errorf("bold @today not found in %+v", segments)
+		}
+	})
+
+	t.Run("italic date", func(t *testing.T) {
+		segments := parseSimpleFormatting("*@date(2026-01-15)*")
+		foundItalicDate := false
+		for _, seg := range segments {
+			if seg.isDateField && seg.italic && seg.dateValue == "2026-01-15" {
+				foundItalicDate = true
+			}
+		}
+		if !foundItalicDate {
+			t.Errorf("italic @date not found in %+v", segments)
+		}
+	})
+
+	t.Run("underline @today", func(t *testing.T) {
+		segments := parseSimpleFormatting("__@today__")
+		foundUnderlineDate := false
+		for _, seg := range segments {
+			if seg.isDateField && seg.underline && seg.dateValue == "" {
+				foundUnderlineDate = true
+			}
+		}
+		if !foundUnderlineDate {
+			t.Errorf("underline @today not found in %+v", segments)
+		}
+	})
+
+	t.Run("bold person chip", func(t *testing.T) {
+		segments := parseSimpleFormatting("**@(alice@example.com)**")
+		foundBoldPerson := false
+		for _, seg := range segments {
+			if seg.isPersonField && seg.bold && seg.personIdentifier == "alice@example.com" {
+				foundBoldPerson = true
+			}
+		}
+		if !foundBoldPerson {
+			t.Errorf("bold person chip not found in %+v", segments)
+		}
+	})
+}
+
+func TestHeadingsWithFormattedDateChips(t *testing.T) {
+	t.Run("heading with bold @today", func(t *testing.T) {
+		segments := parseMarkdown("## **@today**")
+		foundBoldDate := false
+		for _, seg := range segments {
+			if seg.isDateField && seg.heading == 2 && seg.bold && seg.dateValue == "" {
+				foundBoldDate = true
+			}
+		}
+		if !foundBoldDate {
+			t.Errorf("bold @today with heading=2 not found in %+v", segments)
+		}
+	})
+
+	t.Run("heading with italic date", func(t *testing.T) {
+		segments := parseMarkdown("# Report *@date(2026-04-07)*")
+		var headingText string
+		foundItalicDate := false
+		for _, seg := range segments {
+			if seg.heading == 1 {
+				if seg.isDateField && seg.italic && seg.dateValue == "2026-04-07" {
+					foundItalicDate = true
+				} else if !seg.isDateField && !seg.italic {
+					headingText += seg.text
+				}
+			}
+		}
+		// Headings no longer have trailing newlines
+		if headingText != "Report " {
+			t.Errorf("heading text = %q, want 'Report '", headingText)
+		}
+		if !foundItalicDate {
+			t.Errorf("italic @date with heading=1 not found in %+v", segments)
+		}
+	})
+
+	t.Run("heading with bold person chip", func(t *testing.T) {
+		segments := parseMarkdown("### Meeting with **@(bob@example.com)**")
+		var headingText string
+		foundBoldPerson := false
+		for _, seg := range segments {
+			if seg.heading == 3 {
+				if seg.isPersonField && seg.bold && seg.personIdentifier == "bob@example.com" {
+					foundBoldPerson = true
+				} else if !seg.isPersonField && !seg.bold {
+					headingText += seg.text
+				}
+			}
+		}
+		// Headings no longer have trailing newlines
+		if headingText != "Meeting with " {
+			t.Errorf("heading text = %q, want 'Meeting with '", headingText)
+		}
+		if !foundBoldPerson {
+			t.Errorf("bold person chip with heading=3 not found in %+v", segments)
+		}
+	})
+}
+
+func TestHeadingFollowedByNormalText(t *testing.T) {
+	t.Run("user example: heading with blank line then normal text", func(t *testing.T) {
+		// Test the exact user scenario
+		markdown := "# A heading\n\nA normal text"
+		segments := parseMarkdown(markdown)
+
+		// Verify we have heading segments and normal text segments
+		// Blank lines AFTER headings should be skipped
+		foundHeading := false
+		foundNormalText := false
+
+		// Count segments by type to verify structure
+		var headingCount, normalTextCount int
+
+		for _, seg := range segments {
+			if seg.heading == 1 {
+				foundHeading = true
+				headingCount++
+			}
+			if seg.heading == 0 && seg.text != "\n" {
+				foundNormalText = true
+				normalTextCount++
+			}
+		}
+
+		if !foundHeading {
+			t.Errorf("heading segment not found")
+		}
+		if !foundNormalText {
+			t.Errorf("normal text segment not found")
+		}
+
+		// We should have heading segments followed by normal text segments
+		// There should be NO segments between them from the blank line
+		// Verify by checking that all heading segments come before all normal text segments
+		lastHeadingIdx := -1
+		firstNormalIdx := len(segments)
+		for i, seg := range segments {
+			if seg.heading == 1 {
+				lastHeadingIdx = i
+			}
+			if seg.heading == 0 && seg.text != "\n" && firstNormalIdx == len(segments) {
+				firstNormalIdx = i
+			}
+		}
+
+		if lastHeadingIdx >= 0 && firstNormalIdx < len(segments) {
+			// Check if there are any segments between the last heading and first normal text
+			// (excluding the trailing \n from normal text)
+			betweenCount := firstNormalIdx - lastHeadingIdx - 1
+			if betweenCount > 0 {
+				t.Errorf("Found %d segments between heading and normal text (should be 0 - blank line should be skipped)", betweenCount)
+			}
+		}
+	})
+
+	t.Run("normal text after heading has heading=0", func(t *testing.T) {
+		segments := parseMarkdown("# Heading\nNormal text")
+
+		// Verify we have both heading and non-heading segments
+		foundHeading := false
+		foundNormalText := false
+
+		for _, seg := range segments {
+			if seg.heading == 1 {
+				foundHeading = true
+			}
+			if seg.heading == 0 && seg.text != "" && seg.text != "\n" {
+				foundNormalText = true
+			}
+		}
+
+		if !foundHeading {
+			t.Errorf("heading segment not found in %+v", segments)
+		}
+		if !foundNormalText {
+			t.Errorf("normal text segment (heading=0) not found in %+v", segments)
+		}
+	})
+
+	t.Run("convertMarkdownToRequests applies heading style but not NORMAL_TEXT", func(t *testing.T) {
+		segments := parseMarkdown("# Heading\nNormal text")
+		requests := convertMarkdownToRequests(segments, 1)
+
+		// Look for UpdateParagraphStyle requests
+		foundHeadingStyle := false
+		foundNormalTextStyle := false
+		var headingEndIndex int64
+		var normalTextStyleCount int
+
+		for _, req := range requests {
+			if req.UpdateParagraphStyle != nil {
+				style := req.UpdateParagraphStyle.ParagraphStyle.NamedStyleType
+				if style == "HEADING_1" {
+					foundHeadingStyle = true
+					headingEndIndex = req.UpdateParagraphStyle.Range.EndIndex
+				}
+				if style == "NORMAL_TEXT" {
+					foundNormalTextStyle = true
+					normalTextStyleCount++
+				}
+			}
+		}
+
+		if !foundHeadingStyle {
+			t.Errorf("HEADING_1 style not applied in requests")
+		}
+		if foundNormalTextStyle {
+			t.Errorf("NORMAL_TEXT style should NOT be applied (found %d instances), as it wipes run-level formatting", normalTextStyleCount)
+		}
+
+		// Verify that heading style range includes trailing newline
+		// "Heading" segment has no \n, but we add \n during insertion
+		// Inserted text "Heading\n" at index 1: endIndex = 1 + 8 = 9
+		// Heading style applied to [1, 9] (including the trailing \n)
+		if headingEndIndex != 9 {
+			t.Errorf("Heading style end index = %d, want 9 (including trailing newline)", headingEndIndex)
+		}
+
+		// Verify normal text gets UpdateTextStyle requests (for formatting)
+		foundTextStyle := false
+		for _, req := range requests {
+			if req.UpdateTextStyle != nil {
+				// Normal text should have text style applied
+				foundTextStyle = true
+				break
+			}
+		}
+		if !foundTextStyle {
+			t.Errorf("Normal text should have UpdateTextStyle applied for formatting")
 		}
 	})
 }
@@ -283,6 +645,426 @@ func TestMergeSegments(t *testing.T) {
 		merged := mergeSegments(nil)
 		if len(merged) != 0 {
 			t.Errorf("got %+v, want empty", merged)
+		}
+	})
+}
+
+func TestBlankLineBetweenNormalText(t *testing.T) {
+	t.Run("blank line creates double newline in merged text", func(t *testing.T) {
+		segments := parseMarkdown("line1\n\nline2")
+		merged := mergeSegments(segments)
+
+		// After merging, plain text segments combine into "line1\n\nline2\n"
+		// The double \n creates an empty paragraph in Google Docs
+		if len(merged) != 1 {
+			t.Errorf("Expected 1 merged segment, got %d: %+v", len(merged), merged)
+		}
+
+		expectedText := "line1\n\nline2\n"
+		if merged[0].text != expectedText {
+			t.Errorf("Merged text = %q, want %q", merged[0].text, expectedText)
+		}
+	})
+
+	t.Run("multiple blank lines create triple newline", func(t *testing.T) {
+		segments := parseMarkdown("line1\n\n\nline2")
+		merged := mergeSegments(segments)
+
+		// After merging, should have "line1\n\n\nline2\n"
+		if len(merged) != 1 {
+			t.Errorf("Expected 1 merged segment, got %d: %+v", len(merged), merged)
+		}
+
+		expectedText := "line1\n\n\nline2\n"
+		if merged[0].text != expectedText {
+			t.Errorf("Merged text = %q, want %q", merged[0].text, expectedText)
+		}
+	})
+}
+
+func TestBlankLineAfterHeadingSkipped(t *testing.T) {
+	t.Run("blank line after heading is skipped", func(t *testing.T) {
+		segments := parseMarkdown("# Heading\n\nText")
+		merged := mergeSegments(segments)
+
+		// Should NOT have a standalone "\n" segment between heading and text
+		// Check: heading segments, then text segments (no empty paragraph between)
+		foundEmptyParagraph := false
+		for _, seg := range merged {
+			// Look for standalone "\n" that is not part of heading or other formatted text
+			if seg.text == "\n" && !seg.isDateField && !seg.isPersonField && seg.heading == 0 &&
+				!seg.orderedListItem && !seg.unorderedListItem {
+				foundEmptyParagraph = true
+				break
+			}
+		}
+
+		if foundEmptyParagraph {
+			t.Errorf("Blank line after heading should be skipped, but found empty paragraph segment in: %+v", merged)
+		}
+	})
+
+	t.Run("multiple blank lines after heading all skipped", func(t *testing.T) {
+		segments := parseMarkdown("# Heading\n\n\nText")
+		merged := mergeSegments(segments)
+
+		// Should have NO standalone empty paragraph segments
+		emptyCount := 0
+		for _, seg := range merged {
+			// Look for standalone "\n" segments
+			if seg.text == "\n" && !seg.isDateField && !seg.isPersonField && seg.heading == 0 &&
+				!seg.orderedListItem && !seg.unorderedListItem {
+				emptyCount++
+			}
+		}
+
+		if emptyCount > 0 {
+			t.Errorf("All blank lines after heading should be skipped, but found %d empty paragraph segments in: %+v", emptyCount, merged)
+		}
+	})
+
+	t.Run("blank line before heading creates double newline", func(t *testing.T) {
+		segments := parseMarkdown("Text\n\n# Heading")
+		merged := mergeSegments(segments)
+
+		// Should have 2 segments: normal text with double \n, and heading
+		if len(merged) != 2 {
+			t.Errorf("Expected 2 merged segments, got %d: %+v", len(merged), merged)
+		}
+
+		// First segment should be normal text with double newline
+		if merged[0].heading != 0 {
+			t.Errorf("First segment should be normal text (heading=0), got heading=%d", merged[0].heading)
+		}
+		expectedText := "Text\n\n"
+		if merged[0].text != expectedText {
+			t.Errorf("First segment text = %q, want %q", merged[0].text, expectedText)
+		}
+
+		// Second segment should be heading
+		if merged[1].heading != 1 {
+			t.Errorf("Second segment should be heading (heading=1), got heading=%d", merged[1].heading)
+		}
+		if merged[1].text != "Heading" {
+			t.Errorf("Second segment text = %q, want %q", merged[1].text, "Heading")
+		}
+	})
+}
+
+func TestNoTrailingEmptyParagraph(t *testing.T) {
+	t.Run("last text segment has no trailing newline", func(t *testing.T) {
+		segments := parseMarkdown("# Heading\n\nText")
+		requests := convertMarkdownToRequests(segments, 1)
+
+		// Find the last InsertText request
+		var lastInsertText string
+		for _, req := range requests {
+			if req.InsertText != nil {
+				lastInsertText = req.InsertText.Text
+			}
+		}
+
+		if strings.HasSuffix(lastInsertText, "\n") {
+			t.Errorf("Last InsertText should not end with \\n, got: %q", lastInsertText)
+		}
+	})
+
+	t.Run("heading only document has no trailing newline", func(t *testing.T) {
+		segments := parseMarkdown("# Only heading")
+		requests := convertMarkdownToRequests(segments, 1)
+
+		// Find the InsertText request
+		var insertText string
+		for _, req := range requests {
+			if req.InsertText != nil {
+				insertText = req.InsertText.Text
+				break
+			}
+		}
+
+		if insertText != "Only heading" {
+			t.Errorf("Heading-only InsertText = %q, want %q", insertText, "Only heading")
+		}
+	})
+
+	t.Run("normal text only document has no trailing newline", func(t *testing.T) {
+		segments := parseMarkdown("Just text")
+		requests := convertMarkdownToRequests(segments, 1)
+
+		// Find the InsertText request
+		var insertText string
+		for _, req := range requests {
+			if req.InsertText != nil {
+				insertText = req.InsertText.Text
+				break
+			}
+		}
+
+		if insertText != "Just text" {
+			t.Errorf("Text-only InsertText = %q, want %q", insertText, "Just text")
+		}
+	})
+}
+
+func TestCRLFNormalization(t *testing.T) {
+	t.Run("CRLF produces same segments as LF", func(t *testing.T) {
+		segmentsLF := parseMarkdown("line1\nline2")
+		segmentsCRLF := parseMarkdown("line1\r\nline2")
+
+		mergedLF := mergeSegments(segmentsLF)
+		mergedCRLF := mergeSegments(segmentsCRLF)
+
+		if len(mergedLF) != len(mergedCRLF) {
+			t.Errorf("Segment count mismatch: LF=%d, CRLF=%d", len(mergedLF), len(mergedCRLF))
+		}
+
+		// Compare text content
+		for i := 0; i < len(mergedLF) && i < len(mergedCRLF); i++ {
+			if mergedLF[i].text != mergedCRLF[i].text {
+				t.Errorf("Segment %d text mismatch: LF=%q, CRLF=%q", i, mergedLF[i].text, mergedCRLF[i].text)
+			}
+		}
+	})
+
+	t.Run("CR only produces same segments as LF", func(t *testing.T) {
+		segmentsLF := parseMarkdown("line1\nline2")
+		segmentsCR := parseMarkdown("line1\rline2")
+
+		mergedLF := mergeSegments(segmentsLF)
+		mergedCR := mergeSegments(segmentsCR)
+
+		if len(mergedLF) != len(mergedCR) {
+			t.Errorf("Segment count mismatch: LF=%d, CR=%d", len(mergedLF), len(mergedCR))
+		}
+
+		// Compare text content
+		for i := 0; i < len(mergedLF) && i < len(mergedCR); i++ {
+			if mergedLF[i].text != mergedCR[i].text {
+				t.Errorf("Segment %d text mismatch: LF=%q, CR=%q", i, mergedLF[i].text, mergedCR[i].text)
+			}
+		}
+	})
+
+	t.Run("mixed line endings are normalized", func(t *testing.T) {
+		segments := parseMarkdown("line1\r\nline2\nline3\rline4")
+		merged := mergeSegments(segments)
+
+		// All lines should be separated by \n
+		fullText := ""
+		for _, seg := range merged {
+			fullText += seg.text
+		}
+
+		expected := "line1\nline2\nline3\nline4\n"
+		if fullText != expected {
+			t.Errorf("Normalized text = %q, want %q", fullText, expected)
+		}
+	})
+}
+
+func TestHeadingWithFormattedText(t *testing.T) {
+	t.Run("heading with bold text creates single heading", func(t *testing.T) {
+		segments := parseMarkdown("# **Bold** Normal")
+		requests := convertMarkdownToRequests(segments, 1)
+
+		// Count InsertText requests - should only insert text that will form ONE heading paragraph
+		var insertTexts []string
+		for _, req := range requests {
+			if req.InsertText != nil {
+				insertTexts = append(insertTexts, req.InsertText.Text)
+			}
+		}
+
+		// Should have exactly 2 insert requests: "Bold" and " Normal"
+		// The newline should only be added after the LAST heading segment
+		if len(insertTexts) != 2 {
+			t.Errorf("Expected 2 InsertText requests, got %d: %v", len(insertTexts), insertTexts)
+		}
+
+		// First segment should NOT have trailing newline (it's not the last heading segment)
+		if strings.HasSuffix(insertTexts[0], "\n") {
+			t.Errorf("First heading segment should not have trailing \\n, got: %q", insertTexts[0])
+		}
+
+		// Second segment should have trailing newline (it's the last heading segment and not last overall)
+		// Actually, if there are no more segments after the heading, it won't have \n
+		// Let's check the actual behavior
+	})
+
+	t.Run("heading with formatted text followed by normal text", func(t *testing.T) {
+		segments := parseMarkdown("# **Bold** Normal\n\nText")
+		requests := convertMarkdownToRequests(segments, 1)
+
+		// Count heading-styled paragraphs
+		headingStyleCount := 0
+		for _, req := range requests {
+			if req.UpdateParagraphStyle != nil &&
+				strings.HasPrefix(req.UpdateParagraphStyle.ParagraphStyle.NamedStyleType, "HEADING_") {
+				headingStyleCount++
+			}
+		}
+
+		// Should have exactly 2 heading segments but they should be styled together as one heading
+		// Actually, each segment gets its own UpdateParagraphStyle request
+		// What matters is that they're contiguous and form one visual heading
+		// Let's verify the InsertText calls instead
+		var insertTexts []string
+		for _, req := range requests {
+			if req.InsertText != nil {
+				insertTexts = append(insertTexts, req.InsertText.Text)
+			}
+		}
+
+		// Verify: "Bold", " Normal\n", "Text"
+		// The \n should only appear after the LAST segment of the heading
+		expectedInserts := 3
+		if len(insertTexts) != expectedInserts {
+			t.Errorf("Expected %d InsertText requests, got %d: %v", expectedInserts, len(insertTexts), insertTexts)
+		}
+	})
+
+	t.Run("normal text with formatting preserves formatting", func(t *testing.T) {
+		segments := parseMarkdown("**Bold** and *italic*")
+		merged := mergeSegments(segments)
+
+		// Should have 3 segments: bold, plain " and ", italic
+		// After merging: bold segment, plain segment, italic segment
+		foundBold := false
+		foundItalic := false
+
+		for _, seg := range merged {
+			if seg.bold && seg.text == "Bold" {
+				foundBold = true
+			}
+			if seg.italic && seg.text == "italic" {
+				foundItalic = true
+			}
+		}
+
+		if !foundBold {
+			t.Errorf("Bold formatting lost in merged segments: %+v", merged)
+		}
+		if !foundItalic {
+			t.Errorf("Italic formatting lost in merged segments: %+v", merged)
+		}
+	})
+
+	t.Run("complex formatted text creates correct requests", func(t *testing.T) {
+		markdown := "**This is** some _heavily_ __formatted__ text."
+		segments := parseMarkdown(markdown)
+		requests := convertMarkdownToRequests(segments, 1)
+
+		// Verify we have InsertText and UpdateTextStyle requests
+		var insertCount, boldStyleCount, italicStyleCount, underlineStyleCount int
+
+		for _, req := range requests {
+			if req.InsertText != nil {
+				insertCount++
+			}
+			if req.UpdateTextStyle != nil {
+				if req.UpdateTextStyle.TextStyle.Bold {
+					boldStyleCount++
+				}
+				if req.UpdateTextStyle.TextStyle.Italic {
+					italicStyleCount++
+				}
+				if req.UpdateTextStyle.TextStyle.Underline {
+					underlineStyleCount++
+				}
+			}
+		}
+
+		// Should have multiple insert requests (one per formatting change)
+		if insertCount < 3 {
+			t.Errorf("Expected at least 3 InsertText requests, got %d", insertCount)
+		}
+
+		// Should have style requests for bold, italic, and underline
+		if boldStyleCount < 1 {
+			t.Errorf("Expected at least 1 bold style request, got %d", boldStyleCount)
+		}
+		if italicStyleCount < 1 {
+			t.Errorf("Expected at least 1 italic style request, got %d", italicStyleCount)
+		}
+		if underlineStyleCount < 1 {
+			t.Errorf("Expected at least 1 underline style request, got %d", underlineStyleCount)
+		}
+	})
+}
+
+func TestAppendToNonEmptyDocument(t *testing.T) {
+	t.Run("appending to non-empty creates new paragraph", func(t *testing.T) {
+		// Simulate appending "New text" to a document that already has content
+		// When insertIndex > 1, we're appending to non-empty doc
+		// The markdown should get a prepended \n
+
+		// This simulates what the tool functions do
+		markdown := "New text"
+		insertIndex := int64(10) // Simulates non-empty document
+		isAppendingToNonEmptyDoc := insertIndex > 1
+
+		markdownToInsert := markdown
+		if isAppendingToNonEmptyDoc && !strings.HasPrefix(markdownToInsert, "\n") {
+			markdownToInsert = "\n" + markdownToInsert
+		}
+
+		segments := parseMarkdown(markdownToInsert)
+		merged := mergeSegments(segments)
+
+		// Should have leading newline
+		if len(merged) != 1 {
+			t.Errorf("Expected 1 merged segment, got %d", len(merged))
+		}
+
+		expectedText := "\nNew text\n"
+		if merged[0].text != expectedText {
+			t.Errorf("Merged text = %q, want %q", merged[0].text, expectedText)
+		}
+	})
+
+	t.Run("appending to empty document does not add extra newline", func(t *testing.T) {
+		// When insertIndex == 1, document is empty
+		markdown := "New text"
+		insertIndex := int64(1) // Simulates empty document
+		isAppendingToNonEmptyDoc := insertIndex > 1
+
+		markdownToInsert := markdown
+		if isAppendingToNonEmptyDoc && !strings.HasPrefix(markdownToInsert, "\n") {
+			markdownToInsert = "\n" + markdownToInsert
+		}
+
+		segments := parseMarkdown(markdownToInsert)
+		merged := mergeSegments(segments)
+
+		// Should NOT have leading newline
+		if len(merged) != 1 {
+			t.Errorf("Expected 1 merged segment, got %d", len(merged))
+		}
+
+		expectedText := "New text\n"
+		if merged[0].text != expectedText {
+			t.Errorf("Merged text = %q, want %q", merged[0].text, expectedText)
+		}
+	})
+
+	t.Run("appending markdown that already starts with newline", func(t *testing.T) {
+		// If markdown already starts with \n, don't add another
+		markdown := "\nNew text"
+		insertIndex := int64(10) // Non-empty document
+		isAppendingToNonEmptyDoc := insertIndex > 1
+
+		markdownToInsert := markdown
+		if isAppendingToNonEmptyDoc && !strings.HasPrefix(markdownToInsert, "\n") {
+			markdownToInsert = "\n" + markdownToInsert
+		}
+
+		segments := parseMarkdown(markdownToInsert)
+		merged := mergeSegments(segments)
+
+		// Should only have single leading newline (not double)
+		expectedText := "\nNew text\n"
+		if merged[0].text != expectedText {
+			t.Errorf("Merged text = %q, want %q", merged[0].text, expectedText)
 		}
 	})
 }


### PR DESCRIPTION
The Google Docs API resets run-level text properties (bold, italic, underline) when UpdateParagraphStyle is applied. Fixed by removing NORMAL_TEXT paragraph style for normal text (unnecessary, inherits document defaults) and deferring heading text styles until after paragraph style application so formatting overrides style defaults.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>