### PR TITLE
feat: add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "wtmcp",
+  "description": "MCP server with plugins for Jira, Confluence, GitLab, Google Calendar, Gmail, Google Drive, Google Docs, Testing Farm, Snyk, and GitHub",
+  "author": {
+    "name": "Sergio Correia",
+    "email": "scorreia@redhat.com"
+  },
+  "repository": "https://github.com/LeGambiArt/wtmcp",
+  "homepage": "https://github.com/LeGambiArt/wtmcp",
+  "license": "GPLv3",
+  "keywords": ["jira", "confluence", "gitlab", "calendar", "gmail", "drive", "google", "atlassian", "github", "snyk", "testing-farm"],
+  "mcpServers": {
+    "wtmcp": {
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/LeGambiArt/wtmcp/cmd/wtmcp@latest"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add a plugin manifest to register the wtmcp project as a Claude Code plugin. This configuration includes project metadata such as the name, description, and repository details, and defines the server launch command via the Go toolchain.