### PR TITLE
Add Syntax Highlighting to code blocks.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,9 @@ require (
 	cloud.google.com/go/auth v0.18.2 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/JohannesKaufmann/dom v0.2.0 // indirect
+	github.com/alecthomas/chroma/v2 v2.23.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=
@@ -12,6 +14,8 @@ github.com/LeGambiArt/oauth2flow v0.2.0 h1:7/3Igz5VTXRWysfK+tebGCjPTDe5TD4gd5rJj
 github.com/LeGambiArt/oauth2flow v0.2.0/go.mod h1:+3JjnqbsY7CRai/Zr2fMmcAbVUV3oGnmCQLKkhzBPT4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=
+github.com/alecthomas/chroma/v2 v2.23.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
 github.com/alpkeskin/gotoon v0.1.1 h1:GQOVwMfWKINnfEA6slrXHJaJYDwnUFmrPlXOtnuja1w=
 github.com/alpkeskin/gotoon v0.1.1/go.mod h1:XRTz8RM4tz8M2nB37MNRN8rHF4YgeYd8nIXmoU0B0+M=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
@@ -61,6 +65,8 @@ github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=

--- a/plugins/google-docs/context.md
+++ b/plugins/google-docs/context.md
@@ -335,6 +335,83 @@ Creates separate paragraph with Courier New font. Language identifiers (e.g., ` 
 - Entire paragraphs with monospace font become code blocks (` ``` `)
 - Partial monospace text runs within paragraphs become inline code (`` ` ``)
 
+### Syntax Highlighting
+
+Code blocks with language identifiers support syntax highlighting with colors and formatting.
+
+**Supported Languages:**
+- Python, TypeScript, Go, Rust, Bash
+- C, C++, YAML, TOML, JSON
+
+**Example:**
+````markdown
+```python
+def hello(name):
+    """Greet someone."""
+    print(f"Hello, {name}!")
+    return True
+```
+````
+
+**Result:** Code rendered with:
+- Keywords (def, return) in purple-red + bold
+- Strings in dark blue
+- Comments in gray + italic
+- Functions in purple + bold
+- Default GitHub color scheme
+
+**Customizing Colors:**
+
+Create config files in `~/.config/wtmcp/assets/google-docs/highlights/`:
+
+```bash
+mkdir -p ~/.config/wtmcp/assets/google-docs/highlights/
+```
+
+Example `python.toml`:
+```toml
+language = "python"
+
+[styles.keyword]
+color = "#FF0000"  # Red keywords
+bold = true
+
+[styles.string]
+color = "#00FF00"  # Green strings
+bold = false
+
+[styles.comment]
+color = "#808080"  # Gray comments
+italic = true
+```
+
+**Available Style Types:**
+- `keyword` - Language keywords (def, class, if, return, etc.)
+- `string` - String literals
+- `comment` - Comments
+- `number` - Numeric literals
+- `operator` - Operators (+, -, *, /, ==, etc.)
+- `function` - Function names
+- `type` - Type names and built-in types
+- `variable` - Variable names
+- `constant` - Constants
+- `default` - Fallback for unrecognized tokens
+
+**Color Format:** Hex RGB (e.g., `"#D73A49"`)
+
+**Troubleshooting:**
+
+- **Code block not highlighted:** Check language identifier is spelled correctly
+- **Colors not applying:** Verify TOML syntax is valid
+- **Language not supported:** Check if chroma library supports the language
+- **Fallback to monospace:** Invalid config falls back gracefully, check logs
+
+**Notes:**
+- Code blocks without language identifiers use basic monospace formatting
+- Highlighting is applied when writing to Google Docs
+- User configs override embedded defaults
+- Invalid user configs automatically fall back to defaults
+
 ### Feature Support Matrix
 
 | Feature | Supported | Notes |
@@ -351,7 +428,7 @@ Creates separate paragraph with Courier New font. Language identifiers (e.g., ` 
 | Date chips (`@date(YYYY-MM-DD)`) | ✅ Yes | Specific date |
 | Person chips (`@(email)`) | ✅ Yes | |
 | Tables | ✅ Yes | Standard markdown syntax with optional headers (headerless extension), rich text in cells, headers auto-bolded |
-| Code blocks (` ``` `) | ✅ Yes | Converted to/from monospace font (Courier New) |
+| Code blocks (` ``` `) | ✅ Yes | Converted to/from monospace font with syntax highlighting (10 languages supported) |
 | Inline code (`` ` ``) | ✅ Yes | Converted to/from monospace font (Courier New) |
 | Blockquotes | ❌ No | Not yet supported |
 | Strikethrough (`~~text~~`) | ✅ Yes | Standard markdown strikethrough |

--- a/plugins/google-docs/highlighter/colors.go
+++ b/plugins/google-docs/highlighter/colors.go
@@ -1,0 +1,39 @@
+// Package highlighter provides syntax highlighting for code blocks in Google Docs.
+package highlighter
+
+import (
+	"fmt"
+	"strconv"
+
+	"google.golang.org/api/docs/v1"
+)
+
+// ParseColor converts a hex color string to Google Docs RGB format.
+// Hex format: #RRGGBB (e.g., "#D73A49")
+// Returns RGB with values 0.0-1.0 for use with Google Docs API.
+func ParseColor(hex string) (*docs.RgbColor, error) {
+	if len(hex) != 7 || hex[0] != '#' {
+		return nil, fmt.Errorf("invalid hex color format: %s (expected #RRGGBB)", hex)
+	}
+
+	r, err := strconv.ParseUint(hex[1:3], 16, 8)
+	if err != nil {
+		return nil, fmt.Errorf("invalid red component in %s: %w", hex, err)
+	}
+
+	g, err := strconv.ParseUint(hex[3:5], 16, 8)
+	if err != nil {
+		return nil, fmt.Errorf("invalid green component in %s: %w", hex, err)
+	}
+
+	b, err := strconv.ParseUint(hex[5:7], 16, 8)
+	if err != nil {
+		return nil, fmt.Errorf("invalid blue component in %s: %w", hex, err)
+	}
+
+	return &docs.RgbColor{
+		Red:   float64(r) / 255.0,
+		Green: float64(g) / 255.0,
+		Blue:  float64(b) / 255.0,
+	}, nil
+}

--- a/plugins/google-docs/highlighter/colors_test.go
+++ b/plugins/google-docs/highlighter/colors_test.go
@@ -1,0 +1,93 @@
+package highlighter
+
+import (
+	"testing"
+)
+
+func TestParseColor(t *testing.T) {
+	tests := []struct {
+		name    string
+		hex     string
+		wantR   float64
+		wantG   float64
+		wantB   float64
+		wantErr bool
+	}{
+		{
+			name:  "valid purple-red",
+			hex:   "#D73A49",
+			wantR: 0.843137,
+			wantG: 0.227451,
+			wantB: 0.286275,
+		},
+		{
+			name:  "valid dark blue",
+			hex:   "#032F62",
+			wantR: 0.011765,
+			wantG: 0.184314,
+			wantB: 0.384314,
+		},
+		{
+			name:  "valid black",
+			hex:   "#000000",
+			wantR: 0.0,
+			wantG: 0.0,
+			wantB: 0.0,
+		},
+		{
+			name:  "valid white",
+			hex:   "#FFFFFF",
+			wantR: 1.0,
+			wantG: 1.0,
+			wantB: 1.0,
+		},
+		{
+			name:    "invalid format",
+			hex:     "D73A49",
+			wantErr: true,
+		},
+		{
+			name:    "invalid length",
+			hex:     "#D73A4",
+			wantErr: true,
+		},
+		{
+			name:    "invalid characters",
+			hex:     "#GGGGGG",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rgb, err := ParseColor(tt.hex)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseColor() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParseColor() unexpected error: %v", err)
+				return
+			}
+			// Allow small floating point differences
+			if abs(rgb.Red-tt.wantR) > 0.001 {
+				t.Errorf("ParseColor() Red = %v, want %v", rgb.Red, tt.wantR)
+			}
+			if abs(rgb.Green-tt.wantG) > 0.001 {
+				t.Errorf("ParseColor() Green = %v, want %v", rgb.Green, tt.wantG)
+			}
+			if abs(rgb.Blue-tt.wantB) > 0.001 {
+				t.Errorf("ParseColor() Blue = %v, want %v", rgb.Blue, tt.wantB)
+			}
+		})
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/plugins/google-docs/highlighter/config.go
+++ b/plugins/google-docs/highlighter/config.go
@@ -1,0 +1,63 @@
+package highlighter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config represents a language highlighting configuration.
+type Config struct {
+	Language    string           `toml:"language"`
+	Description string           `toml:"description"`
+	Styles      map[string]Style `toml:"styles"`
+}
+
+// Style defines the visual appearance for a token type.
+type Style struct {
+	Color  string `toml:"color"`
+	Bold   bool   `toml:"bold"`
+	Italic bool   `toml:"italic"`
+}
+
+// LoadConfig loads the highlighting configuration for a language.
+// Checks user override first (~/.config/wtmcp/assets/google-docs/highlights/),
+// then falls back to embedded default.
+func LoadConfig(language string) (*Config, error) {
+	// Try user override first
+	userConfigPath := getUserConfigPath(language)
+	//nolint:gosec // Path is constructed from user home dir and fixed structure, safe to use
+	if data, err := os.ReadFile(userConfigPath); err == nil {
+		var cfg Config
+		if err := toml.Unmarshal(data, &cfg); err != nil {
+			// Invalid user config, log and fall through to embedded
+			fmt.Fprintf(os.Stderr, "WARN: Invalid user config for %s: %v, using default\n", language, err)
+		} else {
+			return &cfg, nil
+		}
+	}
+
+	// Fall back to embedded default
+	data, err := GetEmbeddedConfig(language)
+	if err != nil {
+		return nil, fmt.Errorf("no config available for language %s: %w", language, err)
+	}
+
+	var cfg Config
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse embedded config for %s: %w", language, err)
+	}
+
+	return &cfg, nil
+}
+
+// getUserConfigPath returns the path to user config file for a language.
+func getUserConfigPath(language string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "wtmcp", "assets", "google-docs", "highlights", language+".toml")
+}

--- a/plugins/google-docs/highlighter/config_test.go
+++ b/plugins/google-docs/highlighter/config_test.go
@@ -1,0 +1,82 @@
+package highlighter
+
+import (
+	"testing"
+)
+
+func TestGetEmbeddedConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		wantErr  bool
+	}{
+		{"python exists", "python", false},
+		{"typescript exists", "typescript", false},
+		{"go exists", "go", false},
+		{"rust exists", "rust", false},
+		{"bash exists", "bash", false},
+		{"c exists", "c", false},
+		{"cpp exists", "cpp", false},
+		{"yaml exists", "yaml", false},
+		{"toml exists", "toml", false},
+		{"json exists", "json", false},
+		{"unsupported language", "ruby", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := GetEmbeddedConfig(tt.language)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("GetEmbeddedConfig() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("GetEmbeddedConfig() unexpected error: %v", err)
+				return
+			}
+			if len(data) == 0 {
+				t.Errorf("GetEmbeddedConfig() returned empty data")
+			}
+		})
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		wantErr  bool
+	}{
+		{"python config loads", "python", false},
+		{"go config loads", "go", false},
+		{"unsupported falls back gracefully", "ruby", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadConfig(tt.language)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("LoadConfig() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("LoadConfig() unexpected error: %v", err)
+				return
+			}
+			if cfg.Language != tt.language {
+				t.Errorf("LoadConfig() language = %v, want %v", cfg.Language, tt.language)
+			}
+			// Verify essential styles exist
+			requiredStyles := []string{"keyword", "string", "comment", "default"}
+			for _, style := range requiredStyles {
+				if _, ok := cfg.Styles[style]; !ok {
+					t.Errorf("LoadConfig() missing required style: %s", style)
+				}
+			}
+		})
+	}
+}

--- a/plugins/google-docs/highlighter/defaults/bash.toml
+++ b/plugins/google-docs/highlighter/defaults/bash.toml
@@ -1,0 +1,52 @@
+language = "bash"
+description = "Bash/Shell syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/c.toml
+++ b/plugins/google-docs/highlighter/defaults/c.toml
@@ -1,0 +1,52 @@
+language = "c"
+description = "C syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/cpp.toml
+++ b/plugins/google-docs/highlighter/defaults/cpp.toml
@@ -1,0 +1,52 @@
+language = "cpp"
+description = "C++ syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/go.toml
+++ b/plugins/google-docs/highlighter/defaults/go.toml
@@ -1,0 +1,52 @@
+language = "go"
+description = "Go syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/json.toml
+++ b/plugins/google-docs/highlighter/defaults/json.toml
@@ -1,0 +1,52 @@
+language = "json"
+description = "JSON syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/python.toml
+++ b/plugins/google-docs/highlighter/defaults/python.toml
@@ -1,0 +1,52 @@
+language = "python"
+description = "Python syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/rust.toml
+++ b/plugins/google-docs/highlighter/defaults/rust.toml
@@ -1,0 +1,52 @@
+language = "rust"
+description = "Rust syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/toml.toml
+++ b/plugins/google-docs/highlighter/defaults/toml.toml
@@ -1,0 +1,52 @@
+language = "toml"
+description = "TOML syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/typescript.toml
+++ b/plugins/google-docs/highlighter/defaults/typescript.toml
@@ -1,0 +1,52 @@
+language = "typescript"
+description = "TypeScript syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/defaults/yaml.toml
+++ b/plugins/google-docs/highlighter/defaults/yaml.toml
@@ -1,0 +1,52 @@
+language = "yaml"
+description = "YAML syntax highlighting with GitHub color scheme"
+
+[styles.keyword]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.string]
+color = "#032F62"
+bold = false
+italic = false
+
+[styles.comment]
+color = "#6A737D"
+bold = false
+italic = true
+
+[styles.number]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.operator]
+color = "#D73A49"
+bold = true
+italic = false
+
+[styles.function]
+color = "#6F42C1"
+bold = true
+italic = false
+
+[styles.type]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.variable]
+color = "#24292E"
+bold = false
+italic = false
+
+[styles.constant]
+color = "#005CC5"
+bold = false
+italic = false
+
+[styles.default]
+color = "#24292E"
+bold = false
+italic = false

--- a/plugins/google-docs/highlighter/embedded.go
+++ b/plugins/google-docs/highlighter/embedded.go
@@ -1,0 +1,19 @@
+package highlighter
+
+import (
+	"embed"
+	"fmt"
+)
+
+//go:embed defaults/*.toml
+var defaultConfigs embed.FS
+
+// GetEmbeddedConfig retrieves an embedded default config by language name.
+func GetEmbeddedConfig(language string) ([]byte, error) {
+	path := fmt.Sprintf("defaults/%s.toml", language)
+	data, err := defaultConfigs.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("embedded config not found for language %s: %w", language, err)
+	}
+	return data, nil
+}

--- a/plugins/google-docs/highlighter/highlighter.go
+++ b/plugins/google-docs/highlighter/highlighter.go
@@ -1,0 +1,122 @@
+package highlighter
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"google.golang.org/api/docs/v1"
+)
+
+// FormattedSegment represents a piece of code with applied styling.
+type FormattedSegment struct {
+	Text   string
+	Color  *docs.RgbColor
+	Bold   bool
+	Italic bool
+}
+
+// HighlightCode applies syntax highlighting to code text using the specified language config.
+func HighlightCode(code, language string, config *Config) ([]FormattedSegment, error) {
+	// Get chroma lexer for the language
+	lexer := lexers.Get(language)
+	if lexer == nil {
+		return nil, fmt.Errorf("unsupported language: %s", language)
+	}
+
+	// Tokenize the code
+	iterator, err := lexer.Tokenise(nil, code)
+	if err != nil {
+		return nil, fmt.Errorf("tokenization failed: %w", err)
+	}
+
+	// Convert tokens to formatted segments
+	segments := []FormattedSegment{}
+	for _, token := range iterator.Tokens() {
+		// Map token type to config style
+		style := mapTokenToStyle(token.Type, config)
+
+		// Convert hex color to RGB
+		rgb, err := ParseColor(style.Color)
+		if err != nil {
+			// Fallback to default color on parse error
+			rgb = &docs.RgbColor{
+				Red:   0.141176, // #24292E
+				Green: 0.160784,
+				Blue:  0.180392,
+			}
+		}
+
+		segments = append(segments, FormattedSegment{
+			Text:   token.Value,
+			Color:  rgb,
+			Bold:   style.Bold,
+			Italic: style.Italic,
+		})
+	}
+
+	return segments, nil
+}
+
+// mapTokenToStyle maps a chroma token type to a config style.
+func mapTokenToStyle(tokenType chroma.TokenType, config *Config) Style {
+	// Check for specific token types and map to config styles
+	// Use IsSubType to check token hierarchy
+	switch {
+	case isTokenType(tokenType, chroma.Keyword):
+		if style, ok := config.Styles["keyword"]; ok {
+			return style
+		}
+	case isTokenType(tokenType, chroma.String):
+		if style, ok := config.Styles["string"]; ok {
+			return style
+		}
+	case isTokenType(tokenType, chroma.Comment):
+		if style, ok := config.Styles["comment"]; ok {
+			return style
+		}
+	case isTokenType(tokenType, chroma.Number):
+		if style, ok := config.Styles["number"]; ok {
+			return style
+		}
+	case isTokenType(tokenType, chroma.Operator):
+		if style, ok := config.Styles["operator"]; ok {
+			return style
+		}
+	case isTokenType(tokenType, chroma.NameFunction):
+		if style, ok := config.Styles["function"]; ok {
+			return style
+		}
+	case isTokenType(tokenType, chroma.NameClass):
+		if style, ok := config.Styles["type"]; ok {
+			return style
+		}
+	case isTokenType(tokenType, chroma.NameConstant):
+		if style, ok := config.Styles["constant"]; ok {
+			return style
+		}
+	case isTokenType(tokenType, chroma.Name):
+		if style, ok := config.Styles["variable"]; ok {
+			return style
+		}
+	}
+
+	// Default style for unrecognized tokens
+	if style, ok := config.Styles["default"]; ok {
+		return style
+	}
+
+	// Hardcoded fallback
+	return Style{Color: "#24292E", Bold: false, Italic: false}
+}
+
+// isTokenType checks if a token type matches or is a subtype of the target type.
+func isTokenType(tokenType, target chroma.TokenType) bool {
+	for tokenType != chroma.None && tokenType != 0 {
+		if tokenType == target {
+			return true
+		}
+		tokenType = tokenType.Parent()
+	}
+	return false
+}

--- a/plugins/google-docs/highlighter/highlighter_test.go
+++ b/plugins/google-docs/highlighter/highlighter_test.go
@@ -1,0 +1,63 @@
+package highlighter
+
+import (
+	"testing"
+)
+
+func TestHighlightCode(t *testing.T) {
+	// Load Python config for testing
+	cfg, err := LoadConfig("python")
+	if err != nil {
+		t.Fatalf("LoadConfig() failed: %v", err)
+	}
+
+	code := `def hello(name):
+    """Say hello."""
+    print(f"Hello, {name}!")
+    return True
+`
+
+	segments, err := HighlightCode(code, "python", cfg)
+	if err != nil {
+		t.Fatalf("HighlightCode() failed: %v", err)
+	}
+
+	if len(segments) == 0 {
+		t.Errorf("HighlightCode() returned no segments")
+	}
+
+	// Verify some segments have color applied
+	hasColor := false
+	for _, seg := range segments {
+		if seg.Color.Red > 0 || seg.Color.Green > 0 || seg.Color.Blue > 0 {
+			hasColor = true
+			break
+		}
+	}
+	if !hasColor {
+		t.Errorf("HighlightCode() no segments have color applied")
+	}
+
+	// Verify text reconstruction
+	var reconstructed string
+	for _, seg := range segments {
+		reconstructed += seg.Text
+	}
+	if reconstructed != code {
+		t.Errorf("HighlightCode() text mismatch\ngot:  %q\nwant: %q", reconstructed, code)
+	}
+}
+
+func TestHighlightCodeUnsupportedLanguage(t *testing.T) {
+	cfg := &Config{
+		Language: "unknown",
+		Styles: map[string]Style{
+			"default": {Color: "#24292E", Bold: false, Italic: false},
+		},
+	}
+
+	_, err := HighlightCode("some code", "unknownlang", cfg)
+	if err == nil {
+		t.Errorf("HighlightCode() expected error for unsupported language, got nil")
+	}
+}

--- a/plugins/google-docs/plugin.yaml
+++ b/plugins/google-docs/plugin.yaml
@@ -1,5 +1,5 @@
 name: google-docs
-version: "0.2.0"
+version: "0.3.0"
 description: "Google Docs — retrieve, summarize, and write to documents"
 
 execution: persistent

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -3,14 +3,17 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
+	"github.com/LeGambiArt/wtmcp/plugins/google-docs/highlighter"
 	"google.golang.org/api/docs/v1"
 )
 
@@ -30,6 +33,35 @@ var (
 	reTableRow       = regexp.MustCompile(`^\s*\|(.+\|)+\s*$`)
 	reTableSeparator = regexp.MustCompile(`^\s*\|[\s\-:]*\-[\s\-:]*(\|[\s\-:]*\-[\s\-:]*)*\|\s*$`)
 )
+
+// Config cache for syntax highlighting
+var (
+	highlightConfigCache = make(map[string]*highlighter.Config)
+	highlightConfigMutex sync.RWMutex
+)
+
+// getHighlightConfig retrieves or loads a highlighting config for a language.
+func getHighlightConfig(language string) (*highlighter.Config, error) {
+	highlightConfigMutex.RLock()
+	if cfg, ok := highlightConfigCache[language]; ok {
+		highlightConfigMutex.RUnlock()
+		return cfg, nil
+	}
+	highlightConfigMutex.RUnlock()
+
+	// Load config
+	cfg, err := highlighter.LoadConfig(language)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache it
+	highlightConfigMutex.Lock()
+	highlightConfigCache[language] = cfg
+	highlightConfigMutex.Unlock()
+
+	return cfg, nil
+}
 
 // extractDocumentID extracts a Google Docs document ID from a URL.
 func extractDocumentID(input string) string {
@@ -1769,7 +1801,7 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 			continue
 		}
 
-		// Handle code blocks (triple backticks) - insert text then apply Courier New font
+		// Handle code blocks (triple backticks) - insert text then apply syntax highlighting
 		if seg.isCodeBlock {
 			// Close any open list before code block
 			if currentListStart >= 0 {
@@ -1796,27 +1828,7 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 
 			endIndex := currentIndex + int64(utf8.RuneCountInString(insertText))
 
-			// Apply Courier New font and clear formatting flags
-			requests = append(requests, &docs.Request{
-				UpdateTextStyle: &docs.UpdateTextStyleRequest{
-					Range: &docs.Range{
-						StartIndex: currentIndex,
-						EndIndex:   endIndex,
-					},
-					TextStyle: &docs.TextStyle{
-						WeightedFontFamily: &docs.WeightedFontFamily{
-							FontFamily: "Courier New",
-						},
-						Bold:          false,
-						Italic:        false,
-						Underline:     false,
-						Strikethrough: false,
-					},
-					Fields: "weightedFontFamily,bold,italic,underline,strikethrough",
-				},
-			})
-
-			// Set paragraph style to NORMAL_TEXT
+			// Set paragraph style to NORMAL_TEXT FIRST to prevent it from wiping out text formatting
 			requests = append(requests, &docs.Request{
 				UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
 					ParagraphStyle: &docs.ParagraphStyle{
@@ -1829,6 +1841,106 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 					Fields: "namedStyleType",
 				},
 			})
+
+			// Apply syntax highlighting if language specified
+			if seg.codeLanguage != "" {
+				cfg, err := getHighlightConfig(seg.codeLanguage)
+				if err == nil {
+					// Apply highlighting
+					highlighted, err := highlighter.HighlightCode(insertText, seg.codeLanguage, cfg)
+					if err == nil {
+						// Apply highlighting segment by segment
+						segIndex := currentIndex
+						for _, hseg := range highlighted {
+							segLen := int64(utf8.RuneCountInString(hseg.Text))
+
+							requests = append(requests, &docs.Request{
+								UpdateTextStyle: &docs.UpdateTextStyleRequest{
+									Range: &docs.Range{
+										StartIndex: segIndex,
+										EndIndex:   segIndex + segLen,
+									},
+									TextStyle: &docs.TextStyle{
+										WeightedFontFamily: &docs.WeightedFontFamily{
+											FontFamily: "Courier New",
+										},
+										ForegroundColor: &docs.OptionalColor{
+											Color: &docs.Color{
+												RgbColor: hseg.Color,
+											},
+										},
+										Bold:      hseg.Bold,
+										Italic:    hseg.Italic,
+										Underline: false,
+									},
+									Fields: "weightedFontFamily,foregroundColor,bold,italic,underline",
+								},
+							})
+
+							segIndex += segLen
+						}
+					} else {
+						// Highlighting failed, fall back to basic Courier New
+						log.Printf("INFO: Highlighting failed for %s: %v, using basic monospace", seg.codeLanguage, err)
+						requests = append(requests, &docs.Request{
+							UpdateTextStyle: &docs.UpdateTextStyleRequest{
+								Range: &docs.Range{
+									StartIndex: currentIndex,
+									EndIndex:   endIndex,
+								},
+								TextStyle: &docs.TextStyle{
+									WeightedFontFamily: &docs.WeightedFontFamily{
+										FontFamily: "Courier New",
+									},
+									Bold:      false,
+									Italic:    false,
+									Underline: false,
+								},
+								Fields: "weightedFontFamily,bold,italic,underline",
+							},
+						})
+					}
+				} else {
+					// No config available, fall back to basic Courier New
+					log.Printf("INFO: No highlighting config for %s: %v, using basic monospace", seg.codeLanguage, err)
+					requests = append(requests, &docs.Request{
+						UpdateTextStyle: &docs.UpdateTextStyleRequest{
+							Range: &docs.Range{
+								StartIndex: currentIndex,
+								EndIndex:   endIndex,
+							},
+							TextStyle: &docs.TextStyle{
+								WeightedFontFamily: &docs.WeightedFontFamily{
+									FontFamily: "Courier New",
+								},
+								Bold:      false,
+								Italic:    false,
+								Underline: false,
+							},
+							Fields: "weightedFontFamily,bold,italic,underline",
+						},
+					})
+				}
+			} else {
+				// No language specified, use basic Courier New
+				requests = append(requests, &docs.Request{
+					UpdateTextStyle: &docs.UpdateTextStyleRequest{
+						Range: &docs.Range{
+							StartIndex: currentIndex,
+							EndIndex:   endIndex,
+						},
+						TextStyle: &docs.TextStyle{
+							WeightedFontFamily: &docs.WeightedFontFamily{
+								FontFamily: "Courier New",
+							},
+							Bold:      false,
+							Italic:    false,
+							Underline: false,
+						},
+						Fields: "weightedFontFamily,bold,italic,underline",
+					},
+				})
+			}
 
 			currentIndex = endIndex
 			continue

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -4330,3 +4330,123 @@ func TestRoundTrip_InlineCode(t *testing.T) {
 	// Also verify original markdown parses correctly
 	_ = parseMarkdown(originalMarkdown)
 }
+
+func TestWriteMarkdownWithHighlightedPython(t *testing.T) {
+	markdown := `# Python Example
+
+Here is some Python code:
+
+` + "```python" + `
+def greet(name):
+    """Say hello."""
+    return f"Hello, {name}!"
+
+result = greet("World")
+print(result)
+` + "```" + `
+
+End of example.
+`
+
+	segments := parseMarkdown(markdown)
+
+	// Verify we have a code block
+	hasCodeBlock := false
+	var codeBlockSeg *markdownSegment
+	for i := range segments {
+		if segments[i].isCodeBlock && segments[i].codeLanguage == "python" {
+			hasCodeBlock = true
+			codeBlockSeg = &segments[i]
+			break
+		}
+	}
+
+	if !hasCodeBlock {
+		t.Fatalf("Expected Python code block in segments")
+	}
+
+	// Verify code block has language set
+	if codeBlockSeg.codeLanguage != "python" {
+		t.Errorf("Expected language 'python', got %q", codeBlockSeg.codeLanguage)
+	}
+
+	// Verify code block contains expected code
+	if !strings.Contains(codeBlockSeg.text, "def greet") {
+		t.Errorf("Code block missing expected content")
+	}
+}
+
+func TestWriteMarkdownWithHighlightedGo(t *testing.T) {
+	markdown := `# Go Example
+
+` + "```go" + `
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, World!")
+}
+` + "```" + `
+`
+
+	segments := parseMarkdown(markdown)
+
+	// Verify we have a code block with Go language
+	hasGoBlock := false
+	for i := range segments {
+		if segments[i].isCodeBlock && segments[i].codeLanguage == "go" {
+			hasGoBlock = true
+			break
+		}
+	}
+
+	if !hasGoBlock {
+		t.Fatalf("Expected Go code block in segments")
+	}
+}
+
+func TestWriteMarkdownCodeBlockNoLanguage(t *testing.T) {
+	markdown := "```\nplain code block\n```"
+
+	segments := parseMarkdown(markdown)
+
+	// Verify code block exists without language
+	hasCodeBlock := false
+	for i := range segments {
+		if segments[i].isCodeBlock {
+			hasCodeBlock = true
+			if segments[i].codeLanguage != "" {
+				t.Errorf("Expected empty language, got %q", segments[i].codeLanguage)
+			}
+			break
+		}
+	}
+
+	if !hasCodeBlock {
+		t.Fatalf("Expected code block in segments")
+	}
+}
+
+func TestAllSupportedLanguages(t *testing.T) {
+	languages := []string{"python", "typescript", "go", "rust", "bash", "c", "cpp", "yaml", "toml", "json"}
+
+	for _, lang := range languages {
+		t.Run(lang, func(t *testing.T) {
+			markdown := "```" + lang + "\ntest code\n```"
+			segments := parseMarkdown(markdown)
+
+			found := false
+			for i := range segments {
+				if segments[i].isCodeBlock && segments[i].codeLanguage == lang {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("Failed to parse %s code block", lang)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for syntax highlighting in Markdown code blocks for Google Docs.

It adds chroma, toml and regex Go dependencies to the MCP.

The supported languages/formats are:
- bash
- C
- C++
- Go
- JSON
- Python
- Rust
- TOML
- TypeScript
- YAML

This PR depends on changes provided by PR #23.