### PR TITLE
Add support for tables in Google Docs

### DIFF
--- a/plugins/google-docs/context.md
+++ b/plugins/google-docs/context.md
@@ -203,6 +203,72 @@ Nested items are rendered at the correct indentation level in Google Docs. The o
 
 When using nested lists, the inner list format might not match the expected one due to Google Docs management of inner lists.
 
+### Tables
+
+Standard markdown table syntax with pipe delimiters:
+
+```markdown
+| Header 1 | Header 2 | Header 3 |
+| -------- | -------- | -------- |
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+```
+
+**Headerless Tables (Extension):**
+
+As an extension to standard Markdown, tables can be created without a header row by starting with the separator line:
+
+```markdown
+| -------- | -------- | -------- |
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+```
+
+This creates a table with only data rows, no header. Useful for simple data displays where column headers aren't needed.
+
+**Table Requirements:**
+- Separator row with hyphens: `| --- | --- |` (required)
+- Header row (optional) - if present, appears before separator and is rendered in **bold**
+- One or more data rows (required)
+- Consistent column count across all rows (required)
+
+**Rich Text in Cells:**
+
+All inline formatting works inside table cells:
+
+```markdown
+| Name | Status | Link |
+| ---- | ------ | ---- |
+| **Bold Name** | *Italic* | [Google](https://google.com) |
+| __Underlined__ | ~~Strike~~ | Regular text |
+```
+
+**Smart Chips in Cells:**
+
+Date and person chips work in table cells:
+
+```markdown
+| Task | Assignee | Due Date |
+| ---- | -------- | -------- |
+| Design | @(alice@company.com) | @date(2026-05-01) |
+| Testing | @(bob@company.com) | @today |
+```
+
+**Empty Cells:**
+
+Empty cells are supported and will render as empty in the table:
+
+```markdown
+| A | B | C |
+| --- | --- | --- |
+| Content |  | More |
+```
+
+**Limitations:**
+- Column alignment syntax (`:---`, `:---:`, `---:`) is ignored
+- Pipe character (`|`) inside cell content is not supported
+- Merged cells and nested tables are not supported
+
 ### Smart Chips
 
 Smart chips are interactive Google Docs elements that provide rich functionality.
@@ -284,7 +350,7 @@ Creates separate paragraph with Courier New font. Language identifiers (e.g., ` 
 | Date chips (`@today`) | ✅ Yes | Current date |
 | Date chips (`@date(YYYY-MM-DD)`) | ✅ Yes | Specific date |
 | Person chips (`@(email)`) | ✅ Yes | |
-| Tables | ❌ No | Not yet supported |
+| Tables | ✅ Yes | Standard markdown syntax with optional headers (headerless extension), rich text in cells, headers auto-bolded |
 | Code blocks (` ``` `) | ✅ Yes | Converted to/from monospace font (Courier New) |
 | Inline code (`` ` ``) | ✅ Yes | Converted to/from monospace font (Courier New) |
 | Blockquotes | ❌ No | Not yet supported |
@@ -326,6 +392,30 @@ Creates separate paragraph with Courier New font. Language identifiers (e.g., ` 
   "append_to_end": true
 }
 ```
+
+### Write table with headers to a document
+```json
+{
+  "document_id_or_url": "https://docs.google.com/document/d/ABC123/edit",
+  "text": "# Project Status\n\n| Task | Owner | Status | Due |\n| ---- | ----- | ------ | --- |\n| Design | **Alice** | ✅ Complete | @date(2026-04-01) |\n| Development | @(bob@company.com) | 🔄 In Progress | @date(2026-05-15) |\n| Testing | **Charlie** | ⏸️ Not Started | @date(2026-06-01) |\n",
+  "is_markdown": true,
+  "append_to_end": true
+}
+```
+
+**Note:** Header row (Task, Owner, Status, Due) is automatically rendered in **bold**.
+
+### Write headerless table to a document
+```json
+{
+  "document_id_or_url": "https://docs.google.com/document/d/ABC123/edit",
+  "text": "# Employee Directory\n\n| ---- | ---- | -------- |\n| John | Manager | New York |\n| Anne | Employee | Los Angeles |\n| Michael | Employee | Chicago |\n",
+  "is_markdown": true,
+  "append_to_end": true
+}
+```
+
+**Note:** Starting with the separator row creates a table without headers.
 
 ### Write plain text to a document
 ```json
@@ -382,7 +472,9 @@ Files are saved with permissions `0600` (owner read/write only).
 
 This is an **initial implementation** of document creation and modification support. The markdown-to-Google Docs formatting conversion has the following limitations:
 
-- **Tables**: Markdown tables are not converted to Google Docs table structures
+- **Table column alignment**: Column alignment syntax (`:---`, `:---:`, `---:`) is ignored
+- **Pipe characters in cells**: Literal pipe character (`|`) in cell content is not supported (would require escaping)
+- **Advanced table features**: Merged cells and nested tables are not supported
 - **Blockquotes**: Blockquotes are not converted to Google Docs quote styling
 - **Images**: Inline images cannot be inserted via markdown
 

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -26,6 +26,9 @@ var (
 	reDateChip      = regexp.MustCompile(`@date\((\d{4}-\d{2}-\d{2})\)`)
 	rePersonChip    = regexp.MustCompile(`@\(([^)]+)\)`)
 	reLinkInline    = regexp.MustCompile(`\[([^\]]+)\]\(([^\)]+)\)`)
+	// Table detection patterns
+	reTableRow       = regexp.MustCompile(`^\s*\|(.+\|)+\s*$`)
+	reTableSeparator = regexp.MustCompile(`^\s*\|[\s\-:]*\-[\s\-:]*(\|[\s\-:]*\-[\s\-:]*)*\|\s*$`)
 )
 
 // extractDocumentID extracts a Google Docs document ID from a URL.
@@ -624,6 +627,26 @@ type markdownSegment struct {
 	isInlineCode      bool   // true if text should be wrapped in single backticks
 	isCodeBlock       bool   // true if text is part of a code block (triple backticks)
 	codeLanguage      string // language identifier for code block (e.g., ```language syntax)
+	// Table support
+	isTable bool
+	table   *tableSegment // Non-nil when isTable=true
+}
+
+// tableCell represents a single cell in a markdown table.
+type tableCell struct {
+	segments []markdownSegment // Cell content as formatted segments
+}
+
+// tableRow represents a single row in a markdown table.
+type tableRow struct {
+	cells []tableCell
+}
+
+// tableSegment represents a parsed markdown table.
+type tableSegment struct {
+	rows       []tableRow
+	numColumns int
+	isTable    bool // Always true, used for type discrimination
 }
 
 // CodeAnnotations holds code detection results for a document.
@@ -775,11 +798,31 @@ func parseMarkdown(markdown string) []markdownSegment {
 	var codeBlockLines []string
 	var codeLanguage string
 
+	// Table buffering state
+	var tableBuffer []string
+	inTable := false
+
 	for _, line := range lines {
 		trimmedLine := strings.TrimSpace(line)
 
 		// Check for code fence boundaries (``` with optional language)
 		if strings.HasPrefix(trimmedLine, "```") {
+			// Close any open table before code block
+			if inTable {
+				inTable = false
+				if table := parseMarkdownTable(tableBuffer); table != nil {
+					segments = append(segments, markdownSegment{
+						isTable: true,
+						table:   table,
+					})
+				} else {
+					for _, bufferedLine := range tableBuffer {
+						segments = append(segments, parseSimpleFormatting(bufferedLine+"\n")...)
+					}
+				}
+				tableBuffer = nil
+			}
+
 			if !inCodeBlock {
 				// Opening fence: start accumulating code block lines
 				inCodeBlock = true
@@ -812,10 +855,42 @@ func parseMarkdown(markdown string) []markdownSegment {
 			continue
 		}
 
+		// Check if this line looks like a table row
+		isTableRow := reTableRow.MatchString(line)
+
+		if isTableRow {
+			// Start or continue buffering table lines
+			if !inTable {
+				inTable = true
+				tableBuffer = []string{}
+			}
+			tableBuffer = append(tableBuffer, line)
+			continue
+		}
+
+		// Not a table row - process any buffered table
+		if inTable {
+			inTable = false
+			// Try to parse buffered lines as a table
+			if table := parseMarkdownTable(tableBuffer); table != nil {
+				// Valid table
+				segments = append(segments, markdownSegment{
+					isTable: true,
+					table:   table,
+				})
+			} else {
+				// Invalid table - treat as plain text paragraphs
+				for _, bufferedLine := range tableBuffer {
+					segments = append(segments, parseSimpleFormatting(bufferedLine+"\n")...)
+				}
+			}
+			tableBuffer = nil
+		}
+
+		// Process non-table line normally
 		if trimmedLine == "" {
 			if lastWasHeading {
-				// Skip blank lines immediately after headings —
-				// headings create their own paragraph break via \n
+				// Skip blank lines immediately after headings
 				continue
 			}
 			// Preserve blank lines between normal text as empty paragraphs
@@ -827,12 +902,12 @@ func parseMarkdown(markdown string) []markdownSegment {
 		headingLevel := 0
 		if strings.HasPrefix(trimmedLine, "#") {
 		loop:
-			for i, ch := range trimmedLine {
+			for j, ch := range trimmedLine {
 				switch ch {
 				case '#':
 					headingLevel++
 				case ' ':
-					trimmedLine = trimmedLine[i+1:]
+					trimmedLine = trimmedLine[j+1:]
 					break loop
 				default:
 					headingLevel = 0
@@ -843,14 +918,12 @@ func parseMarkdown(markdown string) []markdownSegment {
 
 		if headingLevel > 0 && headingLevel <= 6 {
 			lastWasHeading = true
-			// Heading line - parse inline formatting within heading text
-			// Note: Headings don't include trailing newline - they're standalone paragraphs
 			inlineSegs := parseSimpleFormatting(trimmedLine)
 			lineID := nextHeadingLineID
 			nextHeadingLineID++
-			for i := range inlineSegs {
-				inlineSegs[i].heading = headingLevel
-				inlineSegs[i].headingLineID = lineID
+			for j := range inlineSegs {
+				inlineSegs[j].heading = headingLevel
+				inlineSegs[j].headingLineID = lineID
 			}
 			segments = append(segments, inlineSegs...)
 			continue
@@ -858,27 +931,27 @@ func parseMarkdown(markdown string) []markdownSegment {
 
 		lastWasHeading = false
 
-		// Check for ordered list (e.g., "1. Item", "2. Item") with optional leading indent
+		// Check for ordered list
 		if orderedListMatch := reOrderedList.FindStringSubmatch(line); orderedListMatch != nil {
 			depth := indentDepth(orderedListMatch[1])
 			listItemText := orderedListMatch[2]
 			inlineSegs := parseSimpleFormatting(listItemText + "\n")
-			for i := range inlineSegs {
-				inlineSegs[i].orderedListItem = true
-				inlineSegs[i].listDepth = depth
+			for j := range inlineSegs {
+				inlineSegs[j].orderedListItem = true
+				inlineSegs[j].listDepth = depth
 			}
 			segments = append(segments, inlineSegs...)
 			continue
 		}
 
-		// Check for unordered list (e.g., "- Item", "* Item", "+ Item") with optional leading indent
+		// Check for unordered list
 		if unorderedListMatch := reUnorderedList.FindStringSubmatch(line); unorderedListMatch != nil {
 			depth := indentDepth(unorderedListMatch[1])
 			listItemText := unorderedListMatch[3]
 			inlineSegs := parseSimpleFormatting(listItemText + "\n")
-			for i := range inlineSegs {
-				inlineSegs[i].unorderedListItem = true
-				inlineSegs[i].listDepth = depth
+			for j := range inlineSegs {
+				inlineSegs[j].unorderedListItem = true
+				inlineSegs[j].listDepth = depth
 			}
 			segments = append(segments, inlineSegs...)
 			continue
@@ -898,7 +971,116 @@ func parseMarkdown(markdown string) []markdownSegment {
 		})
 	}
 
+	// Process any remaining buffered table at end of document
+	if inTable {
+		if table := parseMarkdownTable(tableBuffer); table != nil {
+			segments = append(segments, markdownSegment{
+				isTable: true,
+				table:   table,
+			})
+		} else {
+			for _, bufferedLine := range tableBuffer {
+				segments = append(segments, parseSimpleFormatting(bufferedLine+"\n")...)
+			}
+		}
+	}
+
 	return segments
+}
+
+// parseMarkdownTable parses a markdown table from buffered lines.
+// Returns nil if the lines don't form a valid table.
+func parseMarkdownTable(lines []string) *tableSegment {
+	// Minimum: separator + at least one data row
+	if len(lines) < 2 {
+		return nil
+	}
+
+	var rows []tableRow
+	var numColumns int
+	var dataStartIdx int
+
+	// Check if first line is a separator (table without header)
+	if reTableSeparator.MatchString(lines[0]) {
+		// Table without header - get column count from separator
+		separatorCells := splitTableRow(lines[0])
+		numColumns = len(separatorCells)
+		dataStartIdx = 1
+	} else {
+		// Table with header - second line should be separator
+		if len(lines) < 3 {
+			return nil
+		}
+		if !reTableSeparator.MatchString(lines[1]) {
+			return nil
+		}
+
+		// Parse header row
+		headerCells := splitTableRow(lines[0])
+		if len(headerCells) == 0 {
+			return nil
+		}
+		numColumns = len(headerCells)
+
+		// Add header row with bold formatting
+		headerRow := tableRow{cells: make([]tableCell, 0, numColumns)}
+		for _, cellText := range headerCells {
+			segments := parseSimpleFormatting(strings.TrimSpace(cellText))
+			// Make all header segments bold
+			for i := range segments {
+				segments[i].bold = true
+			}
+			segments = mergeSegments(segments)
+			headerRow.cells = append(headerRow.cells, tableCell{segments: segments})
+		}
+		rows = append(rows, headerRow)
+		dataStartIdx = 2
+	}
+
+	// Parse data rows
+	for i := dataStartIdx; i < len(lines); i++ {
+		cells := splitTableRow(lines[i])
+		if len(cells) != numColumns {
+			// Inconsistent column count
+			return nil
+		}
+
+		dataRow := tableRow{cells: make([]tableCell, 0, numColumns)}
+		for _, cellText := range cells {
+			segments := parseSimpleFormatting(strings.TrimSpace(cellText))
+			segments = mergeSegments(segments)
+			dataRow.cells = append(dataRow.cells, tableCell{segments: segments})
+		}
+		rows = append(rows, dataRow)
+	}
+
+	return &tableSegment{
+		rows:       rows,
+		numColumns: numColumns,
+		isTable:    true,
+	}
+}
+
+// splitTableRow splits a table row by pipe delimiters.
+// Returns cell contents without the leading/trailing pipes.
+func splitTableRow(line string) []string {
+	// Remove leading/trailing whitespace
+	line = strings.TrimSpace(line)
+
+	// Remove leading and trailing pipes
+	line = strings.TrimPrefix(line, "|")
+	line = strings.TrimSuffix(line, "|")
+
+	// Split by pipe
+	parts := strings.Split(line, "|")
+
+	// Trim whitespace from each part
+	cells := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cells = append(cells, strings.TrimSpace(part))
+	}
+
+	return cells
 }
 
 // parseSimpleFormatting parses bold, italic, underline, and strikethrough formatting.
@@ -1129,7 +1311,8 @@ func mergeSegments(segments []markdownSegment) []markdownSegment {
 			!curr.isPersonField && !prev.isPersonField &&
 			curr.isInlineCode == prev.isInlineCode &&
 			curr.isCodeBlock == prev.isCodeBlock &&
-			curr.codeLanguage == prev.codeLanguage {
+			curr.codeLanguage == prev.codeLanguage &&
+			!curr.isTable && !prev.isTable {
 			// Merge by concatenating text
 			prev.text += curr.text
 		} else {
@@ -1139,6 +1322,404 @@ func mergeSegments(segments []markdownSegment) []markdownSegment {
 	}
 
 	return merged
+}
+
+// convertTableToRequests converts a table segment to Google Docs API requests.
+// convertTableToRequests creates just the empty table structure.
+// Cell content must be populated in a separate batch after querying the document.
+func convertTableToRequests(table *tableSegment, startIndex int64) []*docs.Request {
+	return []*docs.Request{
+		{
+			InsertTable: &docs.InsertTableRequest{
+				Rows:     int64(len(table.rows)),
+				Columns:  int64(table.numColumns),
+				Location: &docs.Location{Index: startIndex},
+			},
+		},
+	}
+}
+
+// insertMarkdownWithTables handles insertion of markdown segments that may contain tables.
+// It properly creates and populates tables using the multi-phase approach:
+// 1. Create empty table structure
+// 2. Query document to get cell indices
+// 3. Populate all cells in a single batch
+// Returns a result map with document info and status.
+func insertMarkdownWithTables(docID string, segments []markdownSegment, insertIndex int64) (map[string]any, error) {
+	// Get the document to retrieve title
+	doc, err := docsSvc.Documents.Get(docID).Do()
+	if err != nil {
+		return nil, fmt.Errorf("get document: %w", err)
+	}
+
+	// Check if there are any table segments
+	hasTable := false
+	var tableSegments []*tableSegment
+	for _, seg := range segments {
+		if seg.isTable && seg.table != nil {
+			hasTable = true
+			tableSegments = append(tableSegments, seg.table)
+		}
+	}
+
+	if hasTable {
+		// Process each table completely (create + populate) before moving to next table
+		// This avoids index confusion when multiple tables are present
+		currentIndex := insertIndex
+		tableIdx := 0
+
+		for _, seg := range segments {
+			if seg.isTable && seg.table != nil {
+				// Create this table structure
+				tableRequests := convertTableToRequests(seg.table, currentIndex)
+				batchUpdateReq := &docs.BatchUpdateDocumentRequest{Requests: tableRequests}
+				_, err := docsSvc.Documents.BatchUpdate(docID, batchUpdateReq).Do()
+				if err != nil {
+					return nil, fmt.Errorf("create table %d: %w", tableIdx, err)
+				}
+
+				// Query document to get the table we just created
+				doc, err = docsSvc.Documents.Get(docID).Do()
+				if err != nil {
+					return nil, fmt.Errorf("get document after creating table %d: %w", tableIdx, err)
+				}
+				if doc.Body == nil {
+					return nil, fmt.Errorf("document body is nil after creating table %d", tableIdx)
+				}
+
+				// Find the table we just created (it's the last table at or after currentIndex)
+				var elem *docs.StructuralElement
+				for _, e := range doc.Body.Content {
+					if e.Table != nil && e.StartIndex >= currentIndex {
+						elem = e
+						break
+					}
+				}
+
+				if elem == nil || elem.Table == nil {
+					return nil, fmt.Errorf("table %d not found after creation", tableIdx)
+				}
+
+				// Validate table dimensions match what was requested
+				expectedRows := len(seg.table.rows)
+				actualRows := len(elem.Table.TableRows)
+				if actualRows < expectedRows {
+					return nil, fmt.Errorf("table %d dimension mismatch: requested %d rows, API returned %d", tableIdx, expectedRows, actualRows)
+				}
+
+				// Populate cells one-by-one with a re-query after each cell.
+				// In a freshly created empty table, even cells within the same row have
+				// overlapping Content[0].StartIndex values. We must process cells sequentially,
+				// re-querying after each to get updated indices for the next cell.
+				for rowIdx, row := range seg.table.rows {
+					for colIdx, cell := range row.cells {
+						// Re-validate table structure on each iteration
+						if rowIdx >= len(elem.Table.TableRows) {
+							return nil, fmt.Errorf("table %d row %d: index out of bounds (table has %d rows)", tableIdx, rowIdx, len(elem.Table.TableRows))
+						}
+						tableRow := elem.Table.TableRows[rowIdx]
+
+						if colIdx >= len(tableRow.TableCells) {
+							return nil, fmt.Errorf("table %d cell[%d,%d]: index out of bounds (row has %d columns)", tableIdx, rowIdx, colIdx, len(tableRow.TableCells))
+						}
+						tableCell := tableRow.TableCells[colIdx]
+
+						if len(tableCell.Content) == 0 {
+							continue
+						}
+
+						cellStartIndex := tableCell.Content[0].StartIndex
+						cellReqs := populateTableCell(&cell, cellStartIndex)
+
+						// Execute this cell's requests
+						if len(cellReqs) > 0 {
+							batchUpdateReq := &docs.BatchUpdateDocumentRequest{Requests: cellReqs}
+							_, err = docsSvc.Documents.BatchUpdate(docID, batchUpdateReq).Do()
+							if err != nil {
+								return nil, fmt.Errorf("populate table %d cell[%d,%d]: %w", tableIdx, rowIdx, colIdx, err)
+							}
+
+							// Re-query to get updated table structure for next cell.
+							// Skip if this is the last cell to save one API call.
+							isLastCell := (rowIdx == len(seg.table.rows)-1) && (colIdx == len(row.cells)-1)
+							if !isLastCell {
+								doc, err = docsSvc.Documents.Get(docID).Do()
+								if err != nil {
+									return nil, fmt.Errorf("get document after table %d cell[%d,%d]: %w", tableIdx, rowIdx, colIdx, err)
+								}
+								if doc.Body == nil {
+									return nil, fmt.Errorf("document body is nil after table %d cell[%d,%d]", tableIdx, rowIdx, colIdx)
+								}
+
+								// Re-find the table for next iteration
+								elem = nil
+								for _, e := range doc.Body.Content {
+									if e.Table != nil && e.StartIndex >= currentIndex {
+										elem = e
+										break
+									}
+								}
+								if elem == nil || elem.Table == nil {
+									return nil, fmt.Errorf("table %d not found after populating cell[%d,%d]", tableIdx, rowIdx, colIdx)
+								}
+							}
+						}
+					}
+				}
+
+				// Update currentIndex to after this table for next segment
+				// Re-query one more time to get final table structure
+				doc, err = docsSvc.Documents.Get(docID).Do()
+				if err != nil {
+					return nil, fmt.Errorf("get document after completing table %d: %w", tableIdx, err)
+				}
+				if doc.Body == nil {
+					return nil, fmt.Errorf("document body is nil after completing table %d", tableIdx)
+				}
+
+				// Reset elem to nil before searching to avoid retaining stale value
+				elem = nil
+				for _, e := range doc.Body.Content {
+					if e.Table != nil && e.StartIndex >= currentIndex {
+						elem = e
+						currentIndex = e.EndIndex
+						break
+					}
+				}
+
+				// Validate we found the table
+				if elem == nil {
+					return nil, fmt.Errorf("table %d not found after populating cells", tableIdx)
+				}
+
+				tableIdx++
+			} else {
+				// Handle non-table segments
+				segRequests := convertMarkdownToRequests([]markdownSegment{seg}, currentIndex)
+				if len(segRequests) > 0 {
+					batchUpdateReq := &docs.BatchUpdateDocumentRequest{Requests: segRequests}
+					_, err := docsSvc.Documents.BatchUpdate(docID, batchUpdateReq).Do()
+					if err != nil {
+						return nil, fmt.Errorf("insert content: %w", err)
+					}
+
+					// Update currentIndex - track all content insertions
+					for _, req := range segRequests {
+						switch {
+						case req.InsertText != nil:
+							currentIndex += int64(utf8.RuneCountInString(req.InsertText.Text))
+						case req.InsertDate != nil:
+							// Date chips take 1 character in the index
+							currentIndex++
+						case req.InsertPerson != nil:
+							// Person chips take 1 character in the index
+							currentIndex++
+						}
+					}
+				}
+			}
+		}
+
+		return map[string]any{
+			"document_id":  docID,
+			"title":        doc.Title,
+			"status":       "success",
+			"insert_index": insertIndex,
+			"tables":       len(tableSegments),
+		}, nil
+	}
+
+	// No tables - use single-batch insertion via convertMarkdownToRequests
+	requests := convertMarkdownToRequests(segments, insertIndex)
+	batchUpdateReq := &docs.BatchUpdateDocumentRequest{Requests: requests}
+	_, err = docsSvc.Documents.BatchUpdate(docID, batchUpdateReq).Do()
+	if err != nil {
+		return nil, fmt.Errorf("batch update: %w", err)
+	}
+
+	return map[string]any{
+		"document_id":  docID,
+		"title":        doc.Title,
+		"status":       "success",
+		"insert_index": insertIndex,
+	}, nil
+}
+
+// populateTableCell creates requests to populate a single table cell with content.
+func populateTableCell(cell *tableCell, cellStartIndex int64) []*docs.Request {
+	var requests []*docs.Request
+
+	// Skip empty cells - Google Docs already creates cells with an empty paragraph containing \n
+	if len(cell.segments) == 0 || (len(cell.segments) == 1 && cell.segments[0].text == "") {
+		return requests
+	}
+
+	// Table cells are created with an empty paragraph containing just '\n' at cellStartIndex.
+	// Insert content at cellStartIndex, which pushes the newline forward.
+	// This places content inside the cell paragraph before the newline.
+	currentIndex := cellStartIndex
+	for _, seg := range cell.segments {
+		if seg.text == "" && !seg.isDateField && !seg.isPersonField {
+			continue
+		}
+
+		// Handle date chips
+		if seg.isDateField {
+			// Parse the date value and create RFC3339 timestamp
+			var timestamp string
+			if seg.dateValue == "" {
+				// @today - RFC3339 format ending with Z (required by protobuf Timestamp)
+				timestamp = time.Now().UTC().Format(time.RFC3339)
+			} else {
+				// @date(YYYY-MM-DD) - parse and format as RFC3339 with Z suffix
+				dateParts := strings.Split(seg.dateValue, "-")
+				if len(dateParts) == 3 {
+					year, _ := strconv.Atoi(dateParts[0])
+					month, _ := strconv.Atoi(dateParts[1])
+					day, _ := strconv.Atoi(dateParts[2])
+					specificDate := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+					timestamp = specificDate.UTC().Format(time.RFC3339)
+				} else {
+					// Invalid date format, fall back to current date
+					timestamp = time.Now().UTC().Format(time.RFC3339)
+				}
+			}
+
+			// Insert the date chip
+			requests = append(requests, &docs.Request{
+				InsertDate: &docs.InsertDateRequest{
+					Location: &docs.Location{Index: currentIndex},
+					DateElementProperties: &docs.DateElementProperties{
+						Timestamp:  timestamp,
+						DateFormat: "DATE_FORMAT_MONTH_DAY_YEAR_ABBREVIATED",
+					},
+				},
+			})
+
+			// Date elements take 1 character in the document index
+			currentIndex++
+
+			// Apply text formatting to the date chip if needed
+			if seg.bold || seg.italic || seg.underline || seg.strikethrough {
+				textStyle := &docs.TextStyle{
+					Bold:          seg.bold,
+					Italic:        seg.italic,
+					Underline:     seg.underline,
+					Strikethrough: seg.strikethrough,
+				}
+
+				fields := []string{"bold", "italic", "underline", "strikethrough"}
+
+				requests = append(requests, &docs.Request{
+					UpdateTextStyle: &docs.UpdateTextStyleRequest{
+						Range: &docs.Range{
+							StartIndex: currentIndex - 1,
+							EndIndex:   currentIndex,
+						},
+						TextStyle: textStyle,
+						Fields:    strings.Join(fields, ","),
+					},
+				})
+			}
+
+			continue
+		}
+
+		// Handle person chips
+		if seg.isPersonField {
+			// Check if the identifier is an email (contains @)
+			personProps := &docs.PersonProperties{}
+			if strings.Contains(seg.personIdentifier, "@") {
+				// It's an email address
+				personProps.Email = seg.personIdentifier
+			} else {
+				// It's a name - set both name and use it as email placeholder
+				personProps.Name = seg.personIdentifier
+				personProps.Email = seg.personIdentifier
+			}
+
+			requests = append(requests, &docs.Request{
+				InsertPerson: &docs.InsertPersonRequest{
+					Location:         &docs.Location{Index: currentIndex},
+					PersonProperties: personProps,
+				},
+			})
+
+			// Person elements take 1 character in the index
+			currentIndex++
+
+			// Apply text formatting to the person chip if needed
+			if seg.bold || seg.italic || seg.underline || seg.strikethrough {
+				textStyle := &docs.TextStyle{
+					Bold:          seg.bold,
+					Italic:        seg.italic,
+					Underline:     seg.underline,
+					Strikethrough: seg.strikethrough,
+				}
+
+				fields := []string{"bold", "italic", "underline", "strikethrough"}
+
+				requests = append(requests, &docs.Request{
+					UpdateTextStyle: &docs.UpdateTextStyleRequest{
+						Range: &docs.Range{
+							StartIndex: currentIndex - 1,
+							EndIndex:   currentIndex,
+						},
+						TextStyle: textStyle,
+						Fields:    strings.Join(fields, ","),
+					},
+				})
+			}
+
+			continue
+		}
+
+		// Insert regular text
+		requests = append(requests, &docs.Request{
+			InsertText: &docs.InsertTextRequest{
+				Text:     seg.text,
+				Location: &docs.Location{Index: currentIndex},
+			},
+		})
+
+		segLength := int64(utf8.RuneCountInString(seg.text))
+		segEndIndex := currentIndex + segLength
+
+		// Apply text formatting if needed
+		if seg.bold || seg.italic || seg.underline || seg.strikethrough || seg.linkURL != "" {
+			textStyle := &docs.TextStyle{
+				Bold:          seg.bold,
+				Italic:        seg.italic,
+				Underline:     seg.underline,
+				Strikethrough: seg.strikethrough,
+			}
+
+			if seg.linkURL != "" {
+				textStyle.Link = &docs.Link{Url: seg.linkURL}
+			}
+
+			// Build fields list
+			fields := []string{"bold", "italic", "underline", "strikethrough"}
+			if seg.linkURL != "" {
+				fields = append(fields, "link")
+			}
+
+			requests = append(requests, &docs.Request{
+				UpdateTextStyle: &docs.UpdateTextStyleRequest{
+					Range: &docs.Range{
+						StartIndex: currentIndex,
+						EndIndex:   segEndIndex,
+					},
+					TextStyle: textStyle,
+					Fields:    strings.Join(fields, ","),
+				},
+			})
+		}
+
+		currentIndex = segEndIndex
+	}
+
+	return requests
 }
 
 // convertMarkdownToRequests converts markdown segments to Google Docs API requests.
@@ -1176,6 +1757,14 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64) []*
 	var currentHeadingLineID int
 
 	for i, seg := range segments {
+		// Table segments should never reach this function - they're handled by insertMarkdownWithTables.
+		// If we encounter one, it's a programming error.
+		if seg.isTable && seg.table != nil {
+			// This should never happen - insertMarkdownWithTables handles all table processing.
+			// If we get here, it means the caller didn't properly filter table segments.
+			panic("convertMarkdownToRequests called with table segment - tables must be handled by insertMarkdownWithTables")
+		}
+
 		if seg.text == "" && !seg.isDateField && !seg.isPersonField {
 			continue
 		}
@@ -1708,8 +2297,6 @@ func toolWriteText(params, _ json.RawMessage) (any, error) {
 		return nil, fmt.Errorf("insert_index must be >= 1 (got %d); set append_to_end=true to append", insertIndex)
 	}
 
-	var requests []*docs.Request
-
 	if p.IsMarkdown {
 		// When appending to non-empty document, prepend newline to start new paragraph
 		textToInsert := p.Text
@@ -1718,17 +2305,26 @@ func toolWriteText(params, _ json.RawMessage) (any, error) {
 		}
 		// Parse markdown and convert to requests
 		segments := parseMarkdown(textToInsert)
-		requests = convertMarkdownToRequests(segments, insertIndex)
-	} else {
-		// Plain text insertion
-		requests = []*docs.Request{
-			{
-				InsertText: &docs.InsertTextRequest{
-					Text:     p.Text,
-					Location: &docs.Location{Index: insertIndex},
-				},
-			},
+
+		// Use the shared helper for handling markdown with potential tables
+		result, err := insertMarkdownWithTables(docID, segments, insertIndex)
+		if err != nil {
+			return nil, err
 		}
+
+		// Add character count to result
+		result["characters"] = len(p.Text)
+		return result, nil
+	}
+
+	// Plain text insertion
+	requests := []*docs.Request{
+		{
+			InsertText: &docs.InsertTextRequest{
+				Text:     p.Text,
+				Location: &docs.Location{Index: insertIndex},
+			},
+		},
 	}
 
 	// Execute the batch update
@@ -1805,28 +2401,16 @@ func toolWriteMarkdown(params, _ json.RawMessage) (any, error) {
 		markdownToInsert = "\n" + markdownToInsert
 	}
 
-	// Parse markdown and convert to requests
+	// Parse markdown and use the shared helper for handling tables
 	segments := parseMarkdown(markdownToInsert)
-	requests := convertMarkdownToRequests(segments, insertIndex)
-
-	// Execute the batch update
-	batchUpdateReq := &docs.BatchUpdateDocumentRequest{
-		Requests: requests,
-	}
-
-	resp, err := docsSvc.Documents.BatchUpdate(docID, batchUpdateReq).Do()
+	result, err := insertMarkdownWithTables(docID, segments, insertIndex)
 	if err != nil {
-		return nil, fmt.Errorf("batch update: %w", err)
+		return nil, err
 	}
 
-	return map[string]any{
-		"document_id":  docID,
-		"title":        doc.Title,
-		"status":       "success",
-		"insert_index": insertIndex,
-		"characters":   len(p.Markdown),
-		"replies":      len(resp.Replies),
-	}, nil
+	// Add character count to result
+	result["characters"] = len(p.Markdown)
+	return result, nil
 }
 
 type createDocumentParams struct {

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -1016,6 +1016,24 @@ func TestHeadingFollowedByNormalText(t *testing.T) {
 }
 
 func TestMergeSegments(t *testing.T) {
+	t.Run("no merge table segments", func(t *testing.T) {
+		segments := []markdownSegment{
+			{text: "Before table\n"},
+			{isTable: true, table: &tableSegment{numColumns: 2, rows: []tableRow{}}},
+			{text: "After table\n"},
+		}
+		merged := mergeSegments(segments)
+		if len(merged) != 3 {
+			t.Errorf("expected 3 segments, got %d", len(merged))
+		}
+		if !merged[1].isTable {
+			t.Error("table segment lost isTable flag after merge")
+		}
+		if merged[1].table == nil {
+			t.Error("table segment lost table pointer after merge")
+		}
+	})
+
 	t.Run("merge adjacent plain", func(t *testing.T) {
 		segments := []markdownSegment{
 			{text: "a"},
@@ -1692,6 +1710,150 @@ func TestIsMonospaceFont(t *testing.T) {
 			result := isMonospaceFont(tt.font)
 			if result != tt.expected {
 				t.Errorf("isMonospaceFont(%q) = %v, want %v", tt.font, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTableDataStructures(t *testing.T) {
+	// Test tableCell creation
+	cell := tableCell{
+		segments: []markdownSegment{
+			{text: "Hello", bold: true},
+		},
+	}
+	if len(cell.segments) != 1 {
+		t.Errorf("expected 1 segment, got %d", len(cell.segments))
+	}
+
+	// Test tableRow creation
+	row := tableRow{
+		cells: []tableCell{cell, cell},
+	}
+	if len(row.cells) != 2 {
+		t.Errorf("expected 2 cells, got %d", len(row.cells))
+	}
+
+	// Test tableSegment creation
+	table := tableSegment{
+		rows:       []tableRow{row},
+		numColumns: 2,
+		isTable:    true,
+	}
+	if !table.isTable {
+		t.Error("expected isTable to be true")
+	}
+	if table.numColumns != 2 {
+		t.Errorf("expected 2 columns, got %d", table.numColumns)
+	}
+
+	// Test markdownSegment with table
+	seg := markdownSegment{
+		isTable: true,
+		table:   &table,
+	}
+	if !seg.isTable {
+		t.Error("expected isTable to be true")
+	}
+	if seg.table == nil {
+		t.Error("expected table to be non-nil")
+	}
+}
+
+func TestTableRegexPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		input   string
+		want    bool
+	}{
+		// reTableRow tests
+		{
+			name:    "valid table row with 2 columns",
+			pattern: "tableRow",
+			input:   "| Cell 1 | Cell 2 |",
+			want:    true,
+		},
+		{
+			name:    "valid table row with spaces",
+			pattern: "tableRow",
+			input:   "  | Cell 1 | Cell 2 |  ",
+			want:    true,
+		},
+		{
+			name:    "valid table row with 3 columns",
+			pattern: "tableRow",
+			input:   "| A | B | C |",
+			want:    true,
+		},
+		{
+			name:    "invalid - no leading pipe",
+			pattern: "tableRow",
+			input:   "Cell 1 | Cell 2 |",
+			want:    false,
+		},
+		{
+			name:    "invalid - no trailing pipe",
+			pattern: "tableRow",
+			input:   "| Cell 1 | Cell 2",
+			want:    false,
+		},
+		{
+			name:    "invalid - single pipe",
+			pattern: "tableRow",
+			input:   "|",
+			want:    false,
+		},
+		// reTableSeparator tests
+		{
+			name:    "valid separator with 2 columns",
+			pattern: "tableSeparator",
+			input:   "| --- | --- |",
+			want:    true,
+		},
+		{
+			name:    "valid separator with varied dashes",
+			pattern: "tableSeparator",
+			input:   "| ---- | ------ |",
+			want:    true,
+		},
+		{
+			name:    "valid separator with colons (ignored)",
+			pattern: "tableSeparator",
+			input:   "| :--- | :---: | ---: |",
+			want:    true,
+		},
+		{
+			name:    "valid separator with spaces",
+			pattern: "tableSeparator",
+			input:   "|  ---  |  ---  |",
+			want:    true,
+		},
+		{
+			name:    "invalid separator - contains letters",
+			pattern: "tableSeparator",
+			input:   "| abc | def |",
+			want:    false,
+		},
+		{
+			name:    "invalid separator - no dashes",
+			pattern: "tableSeparator",
+			input:   "| | |",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got bool
+			switch tt.pattern {
+			case "tableRow":
+				got = reTableRow.MatchString(tt.input)
+			case "tableSeparator":
+				got = reTableSeparator.MatchString(tt.input)
+			}
+			if got != tt.want {
+				t.Errorf("pattern %s on %q: got %v, want %v", tt.pattern, tt.input, got, tt.want)
 			}
 		})
 	}
@@ -3365,31 +3527,21 @@ func TestConvertMarkdownToRequests_InlineCode(t *testing.T) {
 	})
 
 	t.Run("non-code text does not get Courier New", func(t *testing.T) {
-		markdown := "Use `code` here"
+		markdown := "Regular text without code"
 		segments := parseMarkdown(markdown)
 		requests := convertMarkdownToRequests(segments, 1)
 
-		// Count how many UpdateTextStyle requests have Courier New
-		courierCount := 0
-		totalStyleCount := 0
 		for _, req := range requests {
-			if req.UpdateTextStyle != nil {
-				totalStyleCount++
-				if req.UpdateTextStyle.TextStyle.WeightedFontFamily != nil &&
-					req.UpdateTextStyle.TextStyle.WeightedFontFamily.FontFamily == "Courier New" {
-					courierCount++
-				}
+			if req.UpdateTextStyle != nil &&
+				req.UpdateTextStyle.TextStyle.WeightedFontFamily != nil &&
+				req.UpdateTextStyle.TextStyle.WeightedFontFamily.FontFamily == "Courier New" {
+				t.Errorf("non-code text should not have Courier New font")
 			}
-		}
-
-		// Only the inline code segment should have Courier New
-		if courierCount != 1 {
-			t.Errorf("expected exactly 1 Courier New style request, got %d (out of %d total)", courierCount, totalStyleCount)
 		}
 	})
 
 	t.Run("inline code in heading applies Courier New", func(t *testing.T) {
-		markdown := "# The `main` function"
+		markdown := "# Heading with `code`"
 		segments := parseMarkdown(markdown)
 		requests := convertMarkdownToRequests(segments, 1)
 
@@ -3403,6 +3555,615 @@ func TestConvertMarkdownToRequests_InlineCode(t *testing.T) {
 		}
 		if !foundCourierNew {
 			t.Errorf("expected Courier New font for inline code in heading")
+		}
+	})
+}
+
+func TestParseMarkdownTable(t *testing.T) {
+	tests := []struct {
+		name    string
+		lines   []string
+		want    *tableSegment
+		wantNil bool
+	}{
+		{
+			name: "basic 2x2 table",
+			lines: []string{
+				"| A | B |",
+				"| --- | --- |",
+				"| 1 | 2 |",
+			},
+			want: &tableSegment{
+				numColumns: 2,
+				isTable:    true,
+				rows: []tableRow{
+					{cells: []tableCell{
+						{segments: []markdownSegment{{text: "A"}}},
+						{segments: []markdownSegment{{text: "B"}}},
+					}},
+					{cells: []tableCell{
+						{segments: []markdownSegment{{text: "1"}}},
+						{segments: []markdownSegment{{text: "2"}}},
+					}},
+				},
+			},
+		},
+		{
+			name: "table with 3 columns and 2 data rows",
+			lines: []string{
+				"| Name | Age | City |",
+				"| ---- | --- | ---- |",
+				"| Alice | 30 | NYC |",
+				"| Bob | 25 | LA |",
+			},
+			want: &tableSegment{
+				numColumns: 3,
+				isTable:    true,
+				rows: []tableRow{
+					{cells: []tableCell{
+						{segments: []markdownSegment{{text: "Name"}}},
+						{segments: []markdownSegment{{text: "Age"}}},
+						{segments: []markdownSegment{{text: "City"}}},
+					}},
+					{cells: []tableCell{
+						{segments: []markdownSegment{{text: "Alice"}}},
+						{segments: []markdownSegment{{text: "30"}}},
+						{segments: []markdownSegment{{text: "NYC"}}},
+					}},
+					{cells: []tableCell{
+						{segments: []markdownSegment{{text: "Bob"}}},
+						{segments: []markdownSegment{{text: "25"}}},
+						{segments: []markdownSegment{{text: "LA"}}},
+					}},
+				},
+			},
+		},
+		{
+			name: "invalid - missing separator",
+			lines: []string{
+				"| A | B |",
+				"| 1 | 2 |",
+			},
+			wantNil: true,
+		},
+		{
+			name: "invalid - inconsistent columns",
+			lines: []string{
+				"| A | B |",
+				"| --- | --- |",
+				"| 1 | 2 | 3 |",
+			},
+			wantNil: true,
+		},
+		{
+			name: "invalid - no data rows",
+			lines: []string{
+				"| A | B |",
+				"| --- | --- |",
+			},
+			wantNil: true,
+		},
+		{
+			name:    "invalid - too few lines",
+			lines:   []string{"| A | B |"},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMarkdownTable(tt.lines)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("expected non-nil result")
+			}
+
+			if got.numColumns != tt.want.numColumns {
+				t.Errorf("numColumns: got %d, want %d", got.numColumns, tt.want.numColumns)
+			}
+			if got.isTable != tt.want.isTable {
+				t.Errorf("isTable: got %v, want %v", got.isTable, tt.want.isTable)
+			}
+			if len(got.rows) != len(tt.want.rows) {
+				t.Errorf("rows: got %d, want %d", len(got.rows), len(tt.want.rows))
+			}
+
+			// Check first row cells
+			if len(got.rows) > 0 && len(tt.want.rows) > 0 {
+				gotRow := got.rows[0]
+				wantRow := tt.want.rows[0]
+				if len(gotRow.cells) != len(wantRow.cells) {
+					t.Errorf("row 0 cells: got %d, want %d", len(gotRow.cells), len(wantRow.cells))
+				}
+				// Check first cell content
+				if len(gotRow.cells) > 0 && len(wantRow.cells) > 0 {
+					gotCell := gotRow.cells[0]
+					wantCell := wantRow.cells[0]
+					if len(gotCell.segments) > 0 && len(wantCell.segments) > 0 {
+						if gotCell.segments[0].text != wantCell.segments[0].text {
+							t.Errorf("cell[0][0] text: got %q, want %q",
+								gotCell.segments[0].text, wantCell.segments[0].text)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTableParsingWithFormatting(t *testing.T) {
+	tests := []struct {
+		name      string
+		lines     []string
+		checkCell struct {
+			row  int
+			col  int
+			want []markdownSegment
+		}
+	}{
+		{
+			name: "bold text in cell",
+			lines: []string{
+				"| Name |",
+				"| ---- |",
+				"| **Alice** |",
+			},
+			checkCell: struct {
+				row  int
+				col  int
+				want []markdownSegment
+			}{
+				row: 1,
+				col: 0,
+				want: []markdownSegment{
+					{text: "Alice", bold: true},
+				},
+			},
+		},
+		{
+			name: "italic text in cell",
+			lines: []string{
+				"| Status |",
+				"| ------ |",
+				"| *Active* |",
+			},
+			checkCell: struct {
+				row  int
+				col  int
+				want []markdownSegment
+			}{
+				row: 1,
+				col: 0,
+				want: []markdownSegment{
+					{text: "Active", italic: true},
+				},
+			},
+		},
+		{
+			name: "link in cell",
+			lines: []string{
+				"| Link |",
+				"| ---- |",
+				"| [Google](https://google.com) |",
+			},
+			checkCell: struct {
+				row  int
+				col  int
+				want []markdownSegment
+			}{
+				row: 1,
+				col: 0,
+				want: []markdownSegment{
+					{text: "Google", linkURL: "https://google.com"},
+				},
+			},
+		},
+		{
+			name: "mixed formatting in cell",
+			lines: []string{
+				"| Text |",
+				"| ---- |",
+				"| **Bold** and *italic* |",
+			},
+			checkCell: struct {
+				row  int
+				col  int
+				want []markdownSegment
+			}{
+				row: 1,
+				col: 0,
+				want: []markdownSegment{
+					{text: "Bold", bold: true},
+					{text: " and "},
+					{text: "italic", italic: true},
+				},
+			},
+		},
+		{
+			name: "empty cell",
+			lines: []string{
+				"| A | B |",
+				"| --- | --- |",
+				"| Content |  |",
+			},
+			checkCell: struct {
+				row  int
+				col  int
+				want []markdownSegment
+			}{
+				row:  1,
+				col:  1,
+				want: []markdownSegment{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := parseMarkdownTable(tt.lines)
+			if table == nil {
+				t.Fatal("expected non-nil table")
+			}
+
+			if tt.checkCell.row >= len(table.rows) {
+				t.Fatalf("row %d out of bounds (have %d rows)", tt.checkCell.row, len(table.rows))
+			}
+
+			row := table.rows[tt.checkCell.row]
+			if tt.checkCell.col >= len(row.cells) {
+				t.Fatalf("col %d out of bounds (have %d cols)", tt.checkCell.col, len(row.cells))
+			}
+
+			cell := row.cells[tt.checkCell.col]
+			got := cell.segments
+
+			if len(got) != len(tt.checkCell.want) {
+				t.Fatalf("segments count: got %d, want %d", len(got), len(tt.checkCell.want))
+			}
+
+			for i, wantSeg := range tt.checkCell.want {
+				gotSeg := got[i]
+				if gotSeg.text != wantSeg.text {
+					t.Errorf("segment[%d].text: got %q, want %q", i, gotSeg.text, wantSeg.text)
+				}
+				if gotSeg.bold != wantSeg.bold {
+					t.Errorf("segment[%d].bold: got %v, want %v", i, gotSeg.bold, wantSeg.bold)
+				}
+				if gotSeg.italic != wantSeg.italic {
+					t.Errorf("segment[%d].italic: got %v, want %v", i, gotSeg.italic, wantSeg.italic)
+				}
+				if gotSeg.linkURL != wantSeg.linkURL {
+					t.Errorf("segment[%d].linkURL: got %q, want %q", i, gotSeg.linkURL, wantSeg.linkURL)
+				}
+			}
+		})
+	}
+}
+
+func TestParseMarkdownWithTables(t *testing.T) {
+	tests := []struct {
+		name           string
+		markdown       string
+		wantTableCount int
+		checkSegment   int
+		wantIsTable    bool
+	}{
+		{
+			name: "simple table",
+			markdown: `| A | B |
+| --- | --- |
+| 1 | 2 |`,
+			wantTableCount: 1,
+			checkSegment:   0,
+			wantIsTable:    true,
+		},
+		{
+			name: "table with text before and after",
+			markdown: `Some text
+
+| A | B |
+| --- | --- |
+| 1 | 2 |
+
+More text`,
+			wantTableCount: 1,
+			checkSegment:   1, // Table is second segment (after "Some text\n")
+			wantIsTable:    true,
+		},
+		{
+			name: "multiple tables",
+			markdown: `| A | B |
+| --- | --- |
+| 1 | 2 |
+
+| C | D |
+| --- | --- |
+| 3 | 4 |`,
+			wantTableCount: 2,
+			checkSegment:   0,
+			wantIsTable:    true,
+		},
+		{
+			name: "malformed table - no separator",
+			markdown: `| A | B |
+| 1 | 2 |`,
+			wantTableCount: 0,
+			checkSegment:   0,
+			wantIsTable:    false,
+		},
+		{
+			name: "malformed table - inconsistent columns",
+			markdown: `| A | B |
+| --- | --- |
+| 1 | 2 | 3 |`,
+			wantTableCount: 0,
+			checkSegment:   0,
+			wantIsTable:    false,
+		},
+		{
+			name: "table with heading",
+			markdown: `# Title
+
+| A | B |
+| --- | --- |
+| 1 | 2 |`,
+			wantTableCount: 1,
+			checkSegment:   1, // After heading
+			wantIsTable:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			segments := parseMarkdown(tt.markdown)
+
+			// Count table segments
+			tableCount := 0
+			for _, seg := range segments {
+				if seg.isTable {
+					tableCount++
+				}
+			}
+
+			if tableCount != tt.wantTableCount {
+				t.Errorf("table count: got %d, want %d", tableCount, tt.wantTableCount)
+			}
+
+			// If expecting a table, verify at least one table segment exists with non-nil table
+			if tt.wantIsTable {
+				foundTable := false
+				for _, seg := range segments {
+					if seg.isTable && seg.table != nil {
+						foundTable = true
+						break
+					}
+				}
+				if !foundTable {
+					t.Error("expected to find at least one table segment with non-nil table")
+				}
+			}
+		})
+	}
+}
+
+func TestConvertTableToRequests(t *testing.T) {
+	table := &tableSegment{
+		numColumns: 2,
+		isTable:    true,
+		rows: []tableRow{
+			{cells: []tableCell{
+				{segments: []markdownSegment{{text: "Header1"}}},
+				{segments: []markdownSegment{{text: "Header2"}}},
+			}},
+			{cells: []tableCell{
+				{segments: []markdownSegment{{text: "Data1"}}},
+				{segments: []markdownSegment{{text: "Data2"}}},
+			}},
+		},
+	}
+
+	startIndex := int64(1)
+
+	requests := convertTableToRequests(table, startIndex)
+
+	// Should have exactly one request (InsertTable only, no cell content)
+	if len(requests) != 1 {
+		t.Fatalf("expected exactly 1 request (InsertTable only), got %d", len(requests))
+	}
+
+	// First request should be InsertTable
+	if requests[0].InsertTable == nil {
+		t.Fatal("first request should be InsertTable")
+	}
+
+	insertTable := requests[0].InsertTable
+	if insertTable.Rows != int64(len(table.rows)) {
+		t.Errorf("rows: got %d, want %d", insertTable.Rows, len(table.rows))
+	}
+	if insertTable.Columns != int64(table.numColumns) {
+		t.Errorf("columns: got %d, want %d", insertTable.Columns, table.numColumns)
+	}
+	if insertTable.Location.Index != startIndex {
+		t.Errorf("location index: got %d, want %d", insertTable.Location.Index, startIndex)
+	}
+}
+
+// TestConvertMarkdownToRequestsWithTable was removed because convertMarkdownToRequests
+// no longer handles table segments - all table processing is done by insertMarkdownWithTables.
+// Table segments reaching convertMarkdownToRequests is now a programming error (panic).
+
+func TestTableEdgeCases(t *testing.T) {
+	t.Run("table with leading newline", func(t *testing.T) {
+		// Simulates appending to non-empty document
+		markdown := "\n| Name | Nick | Know for |\n| ---- | ---- | -------- |\n| Sergio | impossible to write | wtmcp, refactor, keylime, ... |\n| Igor   | mrisca | bragai, Lola... |\n| Rafael | rafasgj | talking to much... |"
+
+		segments := parseMarkdown(markdown)
+
+		// Verify a table was found
+		foundTable := false
+		for _, seg := range segments {
+			if seg.isTable {
+				foundTable = true
+				if len(seg.table.rows) != 4 {
+					t.Errorf("expected 4 rows, got %d", len(seg.table.rows))
+				}
+				if seg.table.numColumns != 3 {
+					t.Errorf("expected 3 columns, got %d", seg.table.numColumns)
+				}
+				break
+			}
+		}
+
+		if !foundTable {
+			t.Error("expected to find a table segment with leading newline")
+		}
+	})
+
+	t.Run("empty cells", func(t *testing.T) {
+		markdown := `| A | B |
+| --- | --- |
+| Content |  |`
+
+		segments := parseMarkdown(markdown)
+		if len(segments) == 0 || !segments[0].isTable {
+			t.Fatal("expected table segment")
+		}
+
+		table := segments[0].table
+		if len(table.rows) < 2 {
+			t.Fatal("expected at least 2 rows")
+		}
+
+		// Check empty cell
+		emptyCell := table.rows[1].cells[1]
+		if len(emptyCell.segments) != 0 {
+			t.Error("empty cell should have no segments")
+		}
+	})
+
+	t.Run("multiple tables", func(t *testing.T) {
+		markdown := `| A |
+| --- |
+| 1 |
+
+| B |
+| --- |
+| 2 |`
+
+		segments := parseMarkdown(markdown)
+		tableCount := 0
+		for _, seg := range segments {
+			if seg.isTable {
+				tableCount++
+			}
+		}
+
+		if tableCount != 2 {
+			t.Errorf("expected 2 tables, got %d", tableCount)
+		}
+	})
+
+	t.Run("table with other content", func(t *testing.T) {
+		markdown := `# Heading
+
+| Table |
+| ----- |
+| Data  |
+
+Paragraph`
+
+		segments := parseMarkdown(markdown)
+
+		hasHeading := false
+		hasTable := false
+		var allText strings.Builder
+
+		for _, seg := range segments {
+			if seg.heading > 0 {
+				hasHeading = true
+			}
+			if seg.isTable {
+				hasTable = true
+			}
+			allText.WriteString(seg.text)
+		}
+
+		hasParagraph := strings.Contains(allText.String(), "Paragraph")
+
+		if !hasHeading {
+			t.Error("expected heading")
+		}
+		if !hasTable {
+			t.Error("expected table")
+		}
+		if !hasParagraph {
+			t.Error("expected paragraph")
+		}
+	})
+
+	t.Run("malformed table - missing separator", func(t *testing.T) {
+		markdown := `| A | B |
+| 1 | 2 |`
+
+		segments := parseMarkdown(markdown)
+
+		// Should be treated as plain text, not a table
+		for _, seg := range segments {
+			if seg.isTable {
+				t.Error("malformed table should not be parsed as table")
+			}
+		}
+	})
+
+	t.Run("malformed table - inconsistent columns", func(t *testing.T) {
+		markdown := `| A | B |
+| --- | --- |
+| 1 | 2 | 3 |`
+
+		segments := parseMarkdown(markdown)
+
+		// Should be treated as plain text
+		for _, seg := range segments {
+			if seg.isTable {
+				t.Error("inconsistent table should not be parsed as table")
+			}
+		}
+	})
+
+	t.Run("table with smart chips", func(t *testing.T) {
+		markdown := `| Date |
+| ---- |
+| @today |`
+
+		segments := parseMarkdown(markdown)
+		if len(segments) == 0 || !segments[0].isTable {
+			t.Fatal("expected table segment")
+		}
+
+		table := segments[0].table
+		if len(table.rows) < 2 {
+			t.Fatal("expected at least 2 rows")
+		}
+
+		// Check for date field in data row
+		cell := table.rows[1].cells[0]
+		foundDateField := false
+		for _, seg := range cell.segments {
+			if seg.isDateField {
+				foundDateField = true
+				break
+			}
+		}
+
+		if !foundDateField {
+			t.Error("expected date field in cell")
 		}
 	})
 }


### PR DESCRIPTION
Add support for adding tables to Google Docs. Tables are created and
then the cell content is adde one by one. Each step requires a batch
execution of the Google Docs API.
    
The format support is the same as standard Markdown tables, no cell
merging is supported. Table headers are written in bold by default.
    
An extension to the Markdown table format implement is to render tables
without the table header by starting the table definition with the
header separator as in:

``` 
|----|----|
| A1 | A2 |
| B1 | B2 |
```

The resulting table is rendered without a table header.