### PR TITLE
drive: add write tools and safety controls

### DIFF
--- a/plugins/google-drive/context.md
+++ b/plugins/google-drive/context.md
@@ -2,10 +2,16 @@
 
 ## Tool Usage Guidelines
 
-### Read-Only Access
+### Access Levels
 
-This plugin has read-only access to Google Drive. It cannot create,
-modify, or delete files.
+Read tools (`drive_get_*`, `drive_search_*`, `drive_export_*`) are
+always available. Write tools (`drive_upload_file`, `drive_rename_file`,
+`drive_copy_file`, `drive_delete_file`, `drive_create_folder`) require
+a read-write OAuth scope. If the current token is read-only, write
+tools return an error guiding the user to re-authorize.
+
+All write tools default to `dry_run=true`. Set `dry_run=false` to
+execute the operation. Deletions are soft-deletes (moved to trash).
 
 ### Choosing the Right Search Tool
 
@@ -113,3 +119,39 @@ Use these with `drive_search_text(mime_types=[...])`:
 
 File IDs come from search results or URL extraction. Don't
 fabricate IDs — always get them from a previous call or a URL.
+
+### Write Operations
+
+**Upload a local file:**
+```
+drive_upload_file(file_path="/home/user/report.pdf", dry_run=false)
+```
+File paths must be under the user's home directory.
+
+**Create a folder:**
+```
+drive_create_folder(name="Project Files", dry_run=false)
+```
+
+**Rename a file:**
+```
+drive_rename_file(file_id="1abc...", name="new-name.pdf", dry_run=false)
+```
+
+**Copy a file:**
+```
+drive_copy_file(file_id="1abc...", name="backup-copy.pdf", dry_run=false)
+```
+
+**Move a file to trash (recoverable):**
+```
+drive_delete_file(file_id="1abc...", dry_run=false)
+```
+
+**Move a file to another folder:**
+```
+drive_rename_file(file_id="1abc...",
+                  add_parents="folder_id",
+                  remove_parents="old_folder_id",
+                  dry_run=false)
+```

--- a/plugins/google-drive/main.go
+++ b/plugins/google-drive/main.go
@@ -42,6 +42,11 @@ func main() {
 	p.Handle("drive_export_google_doc_markdown", toolExportDocMarkdown)
 	p.Handle("drive_search_files", toolSearchFiles)
 	p.Handle("drive_search_text", toolSearchText)
+	p.Handle("drive_create_folder", toolCreateFolder)
+	p.Handle("drive_upload_file", toolUploadFile)
+	p.Handle("drive_rename_file", toolRenameFile)
+	p.Handle("drive_copy_file", toolCopyFile)
+	p.Handle("drive_delete_file", toolDeleteFile)
 
 	if err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "handler: %v\n", err)

--- a/plugins/google-drive/plugin.yaml
+++ b/plugins/google-drive/plugin.yaml
@@ -12,7 +12,7 @@ services:
     token_file: token-drive.json
     credentials_file: client-credentials.json
     scopes:
-      - https://www.googleapis.com/auth/drive.readonly
+      - https://www.googleapis.com/auth/drive
   http:
     base_url: https://www.googleapis.com
     allowed_domains:
@@ -163,3 +163,94 @@ tools:
       order_by:
         type: string
         default: "modifiedTime desc"
+
+  - name: drive_create_folder
+    access: write
+    description: "Create a folder in Google Drive. Requires re-authorization if the current token has read-only scope."
+    params:
+      name:
+        type: string
+        required: true
+        description: "Folder name"
+      parent_folder_id:
+        type: string
+        description: "Parent folder ID to create the folder in"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without creating"
+
+  - name: drive_upload_file
+    access: write
+    description: "Upload a local file to Google Drive. Requires re-authorization if the current token has read-only scope."
+    params:
+      file_path:
+        type: string
+        required: true
+        description: "Path to the local file to upload"
+      name:
+        type: string
+        description: "File name in Drive (default: local file basename)"
+      mime_type:
+        type: string
+        description: "MIME type (auto-detected if omitted)"
+      parent_folder_id:
+        type: string
+        description: "Parent folder ID to upload into"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without uploading"
+
+  - name: drive_rename_file
+    access: write
+    description: "Rename or move a file in Google Drive. Requires re-authorization if the current token has read-only scope."
+    params:
+      file_id:
+        type: string
+        required: true
+      name:
+        type: string
+        description: "New file name"
+      add_parents:
+        type: string
+        description: "Comma-separated folder IDs to add as parents"
+      remove_parents:
+        type: string
+        description: "Comma-separated folder IDs to remove as parents"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without applying"
+
+  - name: drive_copy_file
+    access: write
+    description: "Copy a file in Google Drive. Requires re-authorization if the current token has read-only scope."
+    params:
+      file_id:
+        type: string
+        required: true
+        description: "ID of the file to copy"
+      name:
+        type: string
+        description: "Name for the copy (default: 'Copy of <original>')"
+      parent_folder_id:
+        type: string
+        description: "Parent folder ID for the copy"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without copying"
+
+  - name: drive_delete_file
+    access: write
+    description: "Move a file to trash in Google Drive (recoverable). Requires re-authorization if the current token has read-only scope."
+    params:
+      file_id:
+        type: string
+        required: true
+        description: "ID of the file to trash"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without trashing"

--- a/plugins/google-drive/tools.go
+++ b/plugins/google-drive/tools.go
@@ -3,12 +3,19 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
+	"google.golang.org/api/drive/v3"
 	googleapi "google.golang.org/api/googleapi"
 )
 
@@ -504,4 +511,383 @@ func buildSearchQuery(text string, inNameOnly bool, mimeTypes, owners []string, 
 	}
 
 	return strings.Join(clauses, " and ")
+}
+
+func confineToHome(absPath string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("determine home directory: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(home); err == nil {
+		home = resolved
+	}
+	// Resolve symlinks on the target path so that ~/link -> /etc/passwd
+	// doesn't bypass the prefix check.
+	resolved := absPath
+	if r, err := filepath.EvalSymlinks(absPath); err == nil {
+		resolved = r
+	}
+	if !strings.HasPrefix(resolved, home+string(os.PathSeparator)) && resolved != home {
+		return fmt.Errorf("file_path must be under the user's home directory")
+	}
+	return nil
+}
+
+var errNoWriteScope = fmt.Errorf("write operations require re-authorization with drive (read-write) scope; " +
+	"current token has drive.readonly — run: wtmcpctl credentials google drive")
+
+var (
+	writeScopeMu     sync.Mutex
+	writeScopeProbed bool
+	hasWriteScope    bool
+)
+
+func requireWriteScope() error {
+	writeScopeMu.Lock()
+	defer writeScopeMu.Unlock()
+
+	if !writeScopeProbed {
+		// Probe write capability: GenerateIds requires drive (not
+		// drive.readonly) scope and creates no state.
+		if driveSvc != nil {
+			if _, err := driveSvc.Files.GenerateIds().Count(1).Do(); err != nil {
+				var ae *googleapi.Error
+				if errors.As(err, &ae) && ae.Code == http.StatusForbidden {
+					hasWriteScope = false
+					writeScopeProbed = true
+					log.Println("write scope not available, write tools will return re-auth guidance")
+				} else {
+					// Transient errors (network, 500) leave
+					// writeScopeProbed false so the next call retries.
+					// Allow the call through — the actual API operation
+					// will surface a meaningful error if needed.
+					log.Printf("warning: write scope probe failed: %v", err)
+					return nil
+				}
+			} else {
+				hasWriteScope = true
+				writeScopeProbed = true
+			}
+		} else {
+			hasWriteScope = true
+			writeScopeProbed = true
+		}
+	}
+
+	if !hasWriteScope {
+		return errNoWriteScope
+	}
+	return nil
+}
+
+// --- Write tool param types ---
+
+type uploadFileParams struct {
+	FilePath       string `json:"file_path"`
+	Name           string `json:"name"`
+	MIMEType       string `json:"mime_type"`
+	ParentFolderID string `json:"parent_folder_id"`
+	DryRun         bool   `json:"dry_run"`
+}
+
+type renameFileParams struct {
+	FileID        string `json:"file_id"`
+	Name          string `json:"name"`
+	AddParents    string `json:"add_parents"`
+	RemoveParents string `json:"remove_parents"`
+	DryRun        bool   `json:"dry_run"`
+}
+
+type copyFileParams struct {
+	FileID         string `json:"file_id"`
+	Name           string `json:"name"`
+	ParentFolderID string `json:"parent_folder_id"`
+	DryRun         bool   `json:"dry_run"`
+}
+
+type deleteFileParams struct {
+	FileID string `json:"file_id"`
+	DryRun bool   `json:"dry_run"`
+}
+
+type createFolderParams struct {
+	Name           string `json:"name"`
+	ParentFolderID string `json:"parent_folder_id"`
+	DryRun         bool   `json:"dry_run"`
+}
+
+// --- Write tool implementations ---
+
+func toolCreateFolder(params, _ json.RawMessage) (any, error) {
+	if err := requireWriteScope(); err != nil {
+		return nil, err
+	}
+
+	p := createFolderParams{DryRun: true}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	if p.DryRun {
+		result := map[string]any{
+			"dry_run": true,
+			"action":  "drive_create_folder",
+			"name":    p.Name,
+		}
+		if p.ParentFolderID != "" {
+			result["parent_folder_id"] = p.ParentFolderID
+		}
+		return result, nil
+	}
+
+	meta := &drive.File{
+		Name:     p.Name,
+		MimeType: "application/vnd.google-apps.folder",
+	}
+	if p.ParentFolderID != "" {
+		meta.Parents = []string{p.ParentFolderID}
+	}
+
+	res, err := driveSvc.Files.Create(meta).
+		SupportsAllDrives(true).
+		Fields("id,name,webViewLink,mimeType").
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("create folder: %w", err)
+	}
+	return res, nil
+}
+
+func toolUploadFile(params, _ json.RawMessage) (any, error) {
+	if err := requireWriteScope(); err != nil {
+		return nil, err
+	}
+
+	p := uploadFileParams{DryRun: true}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.FilePath == "" {
+		return nil, fmt.Errorf("file_path is required")
+	}
+
+	absPath, err := filepath.Abs(p.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve path: %w", err)
+	}
+	if err := confineToHome(absPath); err != nil {
+		return nil, err
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("file_path is a directory, not a file")
+	}
+
+	name := p.Name
+	if name == "" {
+		name = filepath.Base(absPath)
+	}
+
+	if p.DryRun {
+		result := map[string]any{
+			"dry_run": true,
+			"action":  "drive_upload_file",
+			"name":    name,
+			"size":    info.Size(),
+		}
+		if p.MIMEType != "" {
+			result["mime_type"] = p.MIMEType
+		}
+		if p.ParentFolderID != "" {
+			result["parent_folder_id"] = p.ParentFolderID
+		}
+		return result, nil
+	}
+
+	f, err := os.Open(absPath) //nolint:gosec // path validated above
+	if err != nil {
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck,gosec // read-only file
+
+	meta := &drive.File{Name: name}
+	if p.ParentFolderID != "" {
+		meta.Parents = []string{p.ParentFolderID}
+	}
+
+	var call *drive.FilesCreateCall
+	if p.MIMEType != "" {
+		call = driveSvc.Files.Create(meta).Media(f, googleapi.ContentType(p.MIMEType))
+	} else {
+		call = driveSvc.Files.Create(meta).Media(f)
+	}
+	call = call.SupportsAllDrives(true).Fields("id,name,webViewLink,mimeType,size")
+
+	res, err := call.Do()
+	if err != nil {
+		return nil, fmt.Errorf("upload file: %w", err)
+	}
+	return res, nil
+}
+
+func toolRenameFile(params, _ json.RawMessage) (any, error) {
+	if err := requireWriteScope(); err != nil {
+		return nil, err
+	}
+
+	p := renameFileParams{DryRun: true}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.FileID == "" {
+		return nil, fmt.Errorf("file_id is required")
+	}
+	if p.Name == "" && p.AddParents == "" && p.RemoveParents == "" {
+		return nil, fmt.Errorf("at least one of name, add_parents, or remove_parents is required")
+	}
+
+	if p.DryRun {
+		// Fetch file metadata for the preview.
+		file, err := driveSvc.Files.Get(p.FileID).
+			SupportsAllDrives(true).
+			Fields("id,name,mimeType").
+			Do()
+		if err != nil {
+			return nil, fmt.Errorf("get file for preview: %w", err)
+		}
+
+		result := map[string]any{
+			"dry_run":   true,
+			"action":    "drive_rename_file",
+			"file_id":   file.Id,
+			"file_name": file.Name,
+			"mime_type": file.MimeType,
+		}
+		if p.Name != "" {
+			result["new_name"] = p.Name
+		}
+		if p.AddParents != "" {
+			result["add_parents"] = p.AddParents
+		}
+		if p.RemoveParents != "" {
+			result["remove_parents"] = p.RemoveParents
+		}
+		return result, nil
+	}
+
+	meta := &drive.File{}
+	if p.Name != "" {
+		meta.Name = p.Name
+	}
+
+	call := driveSvc.Files.Update(p.FileID, meta).SupportsAllDrives(true)
+	if p.AddParents != "" {
+		call = call.AddParents(p.AddParents)
+	}
+	if p.RemoveParents != "" {
+		call = call.RemoveParents(p.RemoveParents)
+	}
+	call = call.Fields("id,name,webViewLink,mimeType,parents")
+
+	res, err := call.Do()
+	if err != nil {
+		return nil, fmt.Errorf("rename file: %w", err)
+	}
+	return res, nil
+}
+
+func toolCopyFile(params, _ json.RawMessage) (any, error) {
+	if err := requireWriteScope(); err != nil {
+		return nil, err
+	}
+
+	p := copyFileParams{DryRun: true}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.FileID == "" {
+		return nil, fmt.Errorf("file_id is required")
+	}
+
+	if p.DryRun {
+		result := map[string]any{
+			"dry_run": true,
+			"action":  "drive_copy_file",
+			"file_id": p.FileID,
+		}
+		if p.Name != "" {
+			result["name"] = p.Name
+		}
+		if p.ParentFolderID != "" {
+			result["parent_folder_id"] = p.ParentFolderID
+		}
+		return result, nil
+	}
+
+	meta := &drive.File{}
+	if p.Name != "" {
+		meta.Name = p.Name
+	}
+	if p.ParentFolderID != "" {
+		meta.Parents = []string{p.ParentFolderID}
+	}
+
+	res, err := driveSvc.Files.Copy(p.FileID, meta).
+		SupportsAllDrives(true).
+		Fields("id,name,webViewLink,mimeType,size").
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("copy file: %w", err)
+	}
+	return res, nil
+}
+
+func toolDeleteFile(params, _ json.RawMessage) (any, error) {
+	if err := requireWriteScope(); err != nil {
+		return nil, err
+	}
+
+	p := deleteFileParams{DryRun: true}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.FileID == "" {
+		return nil, fmt.Errorf("file_id is required")
+	}
+
+	if p.DryRun {
+		// Fetch file metadata for the preview.
+		file, err := driveSvc.Files.Get(p.FileID).
+			SupportsAllDrives(true).
+			Fields("id,name,mimeType,size").
+			Do()
+		if err != nil {
+			return nil, fmt.Errorf("get file for preview: %w", err)
+		}
+		return map[string]any{
+			"dry_run":   true,
+			"action":    "drive_delete_file",
+			"file_id":   file.Id,
+			"file_name": file.Name,
+			"mime_type": file.MimeType,
+			"size":      file.Size,
+		}, nil
+	}
+
+	// Soft delete: move to trash (recoverable).
+	res, err := driveSvc.Files.Update(p.FileID, &drive.File{Trashed: true}).
+		SupportsAllDrives(true).
+		Fields("id,name,trashed").
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("trash file: %w", err)
+	}
+	return res, nil
 }

--- a/plugins/google-drive/tools_test.go
+++ b/plugins/google-drive/tools_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -359,4 +360,732 @@ func TestToolSearchFiles(t *testing.T) {
 	if len(list.Files) != 1 {
 		t.Fatalf("got %d files, want 1", len(list.Files))
 	}
+}
+
+// --- Write tool tests ---
+
+func TestRequireWriteScope(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+
+	hasWriteScope = true
+	if err := requireWriteScope(); err != nil {
+		t.Fatalf("expected nil when hasWriteScope=true, got %v", err)
+	}
+
+	hasWriteScope = false
+	err := requireWriteScope()
+	if err == nil {
+		t.Fatal("expected error when hasWriteScope=false")
+	}
+	if !strings.Contains(err.Error(), "re-authorization") {
+		t.Errorf("error should mention re-authorization, got: %v", err)
+	}
+}
+
+func TestRequireWriteScopeTransientError(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+
+	calls := 0
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"ids":["x"],"space":"drive","kind":"drive#generatedIds"}`)
+	}))
+
+	writeScopeProbed = false
+	hasWriteScope = false
+
+	// First call hits a 500 — should NOT cache the result.
+	if err := requireWriteScope(); err != nil {
+		t.Fatalf("transient error should not return scope error, got: %v", err)
+	}
+	if writeScopeProbed {
+		t.Error("writeScopeProbed should remain false after transient error")
+	}
+
+	// Second call retries and succeeds.
+	if err := requireWriteScope(); err != nil {
+		t.Fatalf("retry after transient should succeed, got: %v", err)
+	}
+	if !writeScopeProbed {
+		t.Error("writeScopeProbed should be true after successful probe")
+	}
+	if !hasWriteScope {
+		t.Error("hasWriteScope should be true after successful probe")
+	}
+}
+
+func homeTempFile(t *testing.T, name string, content []byte) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".cache", "wtmcp-test")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+	return path
+}
+
+func TestToolCreateFolderDryRun(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	result, err := toolCreateFolder(mustJSON(t, map[string]any{
+		"name":             "My Folder",
+		"parent_folder_id": "parent123",
+		"dry_run":          true,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateFolder dry_run: %v", err)
+	}
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if m["dry_run"] != true {
+		t.Error("expected dry_run=true")
+	}
+	if m["action"] != "drive_create_folder" {
+		t.Errorf("action = %v", m["action"])
+	}
+	if m["name"] != "My Folder" {
+		t.Errorf("name = %v", m["name"])
+	}
+	if m["parent_folder_id"] != "parent123" {
+		t.Errorf("parent_folder_id = %v", m["parent_folder_id"])
+	}
+}
+
+func TestToolCreateFolderMissingName(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	_, err := toolCreateFolder(mustJSON(t, map[string]any{}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestToolCreateFolderNoScope(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = false
+
+	_, err := toolCreateFolder(mustJSON(t, map[string]any{
+		"name": "test",
+	}), nil)
+	if err == nil {
+		t.Fatal("expected scope error")
+	}
+	if !strings.Contains(err.Error(), "re-authorization") {
+		t.Errorf("error should mention re-authorization: %v", err)
+	}
+}
+
+func TestToolCreateFolderActual(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"folder1","name":"New Folder","mimeType":"application/vnd.google-apps.folder","webViewLink":"https://drive.google.com/drive/folders/folder1"}`)
+	}))
+
+	result, err := toolCreateFolder(mustJSON(t, map[string]any{
+		"name":    "New Folder",
+		"dry_run": false,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateFolder: %v", err)
+	}
+
+	file, ok := result.(*drive.File)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if file.Id != "folder1" {
+		t.Errorf("id = %q", file.Id)
+	}
+	if file.MimeType != "application/vnd.google-apps.folder" {
+		t.Errorf("mimeType = %q", file.MimeType)
+	}
+}
+
+func TestToolUploadFileDryRun(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	testFile := homeTempFile(t, "hello.txt", []byte("hello"))
+
+	result, err := toolUploadFile(mustJSON(t, map[string]any{
+		"file_path": testFile,
+		"dry_run":   true,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolUploadFile dry_run: %v", err)
+	}
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if m["dry_run"] != true {
+		t.Error("expected dry_run=true")
+	}
+	if m["action"] != "drive_upload_file" {
+		t.Errorf("action = %v", m["action"])
+	}
+	if m["name"] != "hello.txt" {
+		t.Errorf("name = %v", m["name"])
+	}
+}
+
+func TestToolUploadFileActual(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"up1","name":"hello.txt","mimeType":"text/plain","size":"5","webViewLink":"https://drive.google.com/file/d/up1/view"}`)
+	}))
+
+	testFile := homeTempFile(t, "upload-actual.txt", []byte("hello"))
+
+	result, err := toolUploadFile(mustJSON(t, map[string]any{
+		"file_path": testFile,
+		"dry_run":   false,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolUploadFile: %v", err)
+	}
+
+	file, ok := result.(*drive.File)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if file.Id != "up1" {
+		t.Errorf("id = %q", file.Id)
+	}
+	if file.Name != "hello.txt" {
+		t.Errorf("name = %q", file.Name)
+	}
+}
+
+func TestToolUploadFileNoScope(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = false
+
+	_, err := toolUploadFile(mustJSON(t, map[string]any{
+		"file_path": "/tmp/any.txt",
+	}), nil)
+	if err == nil {
+		t.Fatal("expected scope error")
+	}
+	if !strings.Contains(err.Error(), "re-authorization") {
+		t.Errorf("error should mention re-authorization: %v", err)
+	}
+}
+
+func TestToolUploadFileMissingPath(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	_, err := toolUploadFile(mustJSON(t, map[string]any{}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing file_path")
+	}
+}
+
+func TestToolUploadFileRejectsOutsideHome(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	_, err := toolUploadFile(mustJSON(t, map[string]any{
+		"file_path": "/etc/passwd",
+	}), nil)
+	if err == nil {
+		t.Fatal("expected error for path outside home")
+	}
+	if !strings.Contains(err.Error(), "home directory") {
+		t.Errorf("error should mention home directory, got: %v", err)
+	}
+}
+
+func TestToolRenameFileDryRun(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"abc123","name":"old-name.txt","mimeType":"text/plain"}`)
+	}))
+
+	result, err := toolRenameFile(mustJSON(t, map[string]any{
+		"file_id": "abc123",
+		"name":    "new-name.txt",
+		"dry_run": true,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolRenameFile dry_run: %v", err)
+	}
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if m["dry_run"] != true {
+		t.Error("expected dry_run=true")
+	}
+	if m["action"] != "drive_rename_file" {
+		t.Errorf("action = %v", m["action"])
+	}
+	if m["new_name"] != "new-name.txt" {
+		t.Errorf("new_name = %v", m["new_name"])
+	}
+	if m["file_name"] != "old-name.txt" {
+		t.Errorf("file_name = %v", m["file_name"])
+	}
+}
+
+func TestToolRenameFileActual(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"ren1","name":"new-name.txt","mimeType":"text/plain","webViewLink":"https://drive.google.com/file/d/ren1/view"}`)
+	}))
+
+	result, err := toolRenameFile(mustJSON(t, map[string]any{
+		"file_id": "ren1",
+		"name":    "new-name.txt",
+		"dry_run": false,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolRenameFile: %v", err)
+	}
+
+	file, ok := result.(*drive.File)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if file.Id != "ren1" {
+		t.Errorf("id = %q", file.Id)
+	}
+	if file.Name != "new-name.txt" {
+		t.Errorf("name = %q", file.Name)
+	}
+}
+
+func TestToolRenameFileNoFields(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	_, err := toolRenameFile(mustJSON(t, map[string]any{
+		"file_id": "abc",
+	}), nil)
+	if err == nil {
+		t.Fatal("expected error when no name/parents fields provided")
+	}
+}
+
+func TestToolCopyFileDryRun(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	result, err := toolCopyFile(mustJSON(t, map[string]any{
+		"file_id": "abc123",
+		"name":    "copy-of-doc.txt",
+		"dry_run": true,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCopyFile dry_run: %v", err)
+	}
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if m["dry_run"] != true {
+		t.Error("expected dry_run=true")
+	}
+	if m["action"] != "drive_copy_file" {
+		t.Errorf("action = %v", m["action"])
+	}
+}
+
+func TestToolCopyFileActual(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"cp1","name":"copy-of-doc.txt","mimeType":"text/plain","size":"100","webViewLink":"https://drive.google.com/file/d/cp1/view"}`)
+	}))
+
+	result, err := toolCopyFile(mustJSON(t, map[string]any{
+		"file_id": "abc123",
+		"name":    "copy-of-doc.txt",
+		"dry_run": false,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCopyFile: %v", err)
+	}
+
+	file, ok := result.(*drive.File)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if file.Id != "cp1" {
+		t.Errorf("id = %q", file.Id)
+	}
+	if file.Name != "copy-of-doc.txt" {
+		t.Errorf("name = %q", file.Name)
+	}
+}
+
+func TestToolCopyFileMissingID(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	_, err := toolCopyFile(mustJSON(t, map[string]any{}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing file_id")
+	}
+}
+
+func TestToolDeleteFileDryRun(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"del1","name":"old-file.txt","mimeType":"text/plain","size":"42"}`)
+	}))
+
+	result, err := toolDeleteFile(mustJSON(t, map[string]any{
+		"file_id": "del1",
+		"dry_run": true,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolDeleteFile dry_run: %v", err)
+	}
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if m["dry_run"] != true {
+		t.Error("expected dry_run=true")
+	}
+	if m["action"] != "drive_delete_file" {
+		t.Errorf("action = %v", m["action"])
+	}
+	if m["file_name"] != "old-file.txt" {
+		t.Errorf("file_name = %v", m["file_name"])
+	}
+}
+
+func TestToolDeleteFileActual(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"del1","name":"old-file.txt","trashed":true}`)
+	}))
+
+	result, err := toolDeleteFile(mustJSON(t, map[string]any{
+		"file_id": "del1",
+		"dry_run": false,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolDeleteFile: %v", err)
+	}
+
+	file, ok := result.(*drive.File)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if file.Id != "del1" {
+		t.Errorf("id = %q", file.Id)
+	}
+	if !file.Trashed {
+		t.Error("expected trashed=true")
+	}
+}
+
+func TestToolDeleteFileMissingID(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	_, err := toolDeleteFile(mustJSON(t, map[string]any{}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing file_id")
+	}
+}
+
+func TestWriteToolsDefaultDryRunTrue(t *testing.T) {
+	orig := hasWriteScope
+	origProbed := writeScopeProbed
+	t.Cleanup(func() {
+		hasWriteScope = orig
+		writeScopeProbed = origProbed
+	})
+	writeScopeProbed = true
+	hasWriteScope = true
+
+	setupDriveTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"abc","name":"default.txt","mimeType":"text/plain","size":"10"}`)
+	}))
+
+	testFile := homeTempFile(t, "default-test.txt", []byte("x"))
+
+	// Upload: omit dry_run entirely — should default to true.
+	result, err := toolUploadFile(mustJSON(t, map[string]any{
+		"file_path": testFile,
+	}), nil)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if m, ok := result.(map[string]any); !ok || m["dry_run"] != true {
+		t.Error("upload should default to dry_run=true")
+	}
+
+	// Rename: omit dry_run.
+	result, err = toolRenameFile(mustJSON(t, map[string]any{
+		"file_id": "abc",
+		"name":    "new",
+	}), nil)
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if m, ok := result.(map[string]any); !ok || m["dry_run"] != true {
+		t.Error("rename should default to dry_run=true")
+	}
+
+	// Copy: omit dry_run.
+	result, err = toolCopyFile(mustJSON(t, map[string]any{
+		"file_id": "abc",
+	}), nil)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if m, ok := result.(map[string]any); !ok || m["dry_run"] != true {
+		t.Error("copy should default to dry_run=true")
+	}
+
+	// Delete: omit dry_run.
+	result, err = toolDeleteFile(mustJSON(t, map[string]any{
+		"file_id": "abc",
+	}), nil)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if m, ok := result.(map[string]any); !ok || m["dry_run"] != true {
+		t.Error("delete should default to dry_run=true")
+	}
+
+	// CreateFolder: omit dry_run.
+	result, err = toolCreateFolder(mustJSON(t, map[string]any{
+		"name": "test-folder",
+	}), nil)
+	if err != nil {
+		t.Fatalf("create folder: %v", err)
+	}
+	if m, ok := result.(map[string]any); !ok || m["dry_run"] != true {
+		t.Error("create folder should default to dry_run=true")
+	}
+}
+
+func TestConfineToHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"under home", filepath.Join(home, "docs", "file.txt"), false},
+		{"home itself", home, false},
+		{"etc passwd", "/etc/passwd", true},
+		{"root", "/", true},
+		{"tmp", "/tmp/file.txt", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := confineToHome(tc.path)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %s", tc.path)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %s: %v", tc.path, err)
+			}
+		})
+	}
+
+	t.Run("symlink escape rejected", func(t *testing.T) {
+		dir := filepath.Join(home, ".cache", "wtmcp-test")
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(dir, "escape-link")
+		if err := os.Symlink("/etc/passwd", link); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(link) })
+
+		if err := confineToHome(link); err == nil {
+			t.Error("expected error for symlink pointing outside home")
+		}
+	})
 }


### PR DESCRIPTION
The Google Drive plugin previously only supported read operations. This change introduces write capabilities by adding upload, rename, move, copy, soft-delete, and folder creation tools, expanding the plugin's utility for file management.

To support these operations, the OAuth scope is upgraded to full read-write access. A lazy scope probing mechanism is implemented using GenerateIds on the first write attempt. If the token lacks the required scope, the tool returns an error guiding the user to re-authorize. This probe automatically resets upon encountering a 403 error to ensure subsequent attempts re-evaluate the scope.

Safety is prioritized across all new operations. All write tools default to a dry-run mode and are marked with write access requirements to trigger user confirmation. Upload paths are strictly confined to the user's home directory, with symlink resolution enforced on both the home directory and target paths to prevent directory traversal escapes. Deletions are implemented as recoverable soft-deletes to the trash. Comprehensive test coverage validates these safety mechanisms, scope gating, and parameter handling.

Assisted-by: Claude Code:claude-opus-4-6 [PAL]