### PR TITLE
feat(wtmcpctl): implement check command (#55)

### DIFF
--- a/README-wtmcpctl.md
+++ b/README-wtmcpctl.md
@@ -22,6 +22,23 @@ This creates `wtmcpctl` in the repository root.
 
 ## Commands
 
+### check
+
+Print diagnostic info about configuration, credentials, and
+discovered plugins. Use this to verify your setup before
+connecting an AI client.
+
+```bash
+wtmcpctl check                         # Check default workdir
+wtmcpctl check --workdir /custom/path  # Check specific workdir
+```
+
+Output includes: version, workdir path, plugin mode, vault
+password status, env groups, plugin search path (with ok/missing
+status), and discovered plugins with tool counts.
+
+---
+
 ### agent
 
 Configure wtmcp as an MCP server for AI agents.

--- a/cmd/wtmcp/main.go
+++ b/cmd/wtmcp/main.go
@@ -390,4 +390,3 @@ func runCheck() error {
 
 	return nil
 }
-

--- a/cmd/wtmcp/main.go
+++ b/cmd/wtmcp/main.go
@@ -20,11 +20,11 @@ import (
 	"github.com/LeGambiArt/wtmcp/internal/auth"
 	"github.com/LeGambiArt/wtmcp/internal/cache"
 	"github.com/LeGambiArt/wtmcp/internal/config"
+	"github.com/LeGambiArt/wtmcp/internal/diagnostic"
 	"github.com/LeGambiArt/wtmcp/internal/plugin"
 	"github.com/LeGambiArt/wtmcp/internal/proxy"
 	"github.com/LeGambiArt/wtmcp/internal/ratelimit"
 	"github.com/LeGambiArt/wtmcp/internal/sandbox"
-	"github.com/LeGambiArt/wtmcp/internal/secrets/vault"
 	"github.com/LeGambiArt/wtmcp/internal/server"
 	"github.com/LeGambiArt/wtmcp/internal/stats"
 )
@@ -327,51 +327,41 @@ func runCheck() error {
 	if err != nil {
 		return err
 	}
+	defer result.Close()
 
-	// CLI flag escalates to read-only.
 	if readOnly {
 		result.Config.ReadOnly = true
 	}
 
-	fmt.Printf("wtmcp %s\n", Version)
-	fmt.Printf("sandbox: %v\n", sandbox.Built())
-	fmt.Printf("workdir: %s\n", result.Workdir)
+	w := os.Stdout
+
+	fmt.Fprintf(w, "wtmcp %s\n", Version)
+	fmt.Fprintf(w, "sandbox: %v\n", sandbox.Built())
+	fmt.Fprintf(w, "workdir: %s\n", result.Workdir)
 	if result.Config.ReadOnly {
-		fmt.Printf("read-only: true (write tools will not be registered)\n")
+		fmt.Fprintf(w, "read-only: true (write tools will not be registered)\n")
 	}
 	if len(result.Config.Plugins.Enabled) > 0 {
-		fmt.Printf("plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
+		fmt.Fprintf(w, "plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
 	} else {
-		fmt.Printf("plugin mode: default\n")
+		fmt.Fprintf(w, "plugin mode: default\n")
 	}
-	fmt.Printf("user plugins: %v\n", result.Config.Plugins.UserPlugins)
+	fmt.Fprintf(w, "user plugins: %v\n", result.Config.Plugins.UserPlugins)
 
-	printVaultStatus(result)
+	diagnostic.PrintVaultStatus(w, result)
+	diagnostic.PrintEnvGroups(w, result)
 
-	fmt.Printf("env groups: %d\n", len(result.EnvGroups))
-	for group := range result.EnvGroups {
-		fmt.Printf("  - %s\n", group)
-	}
-	if result.EnvDirError != "" {
-		fmt.Printf("env.d directory error: %s\n", result.EnvDirError)
-	}
-	if len(result.EnvErrors) > 0 {
-		fmt.Printf("env group errors: %d\n", len(result.EnvErrors))
-		for group, msg := range result.EnvErrors {
-			fmt.Printf("  - %s: %s\n", group, msg)
-		}
-	}
-	fmt.Printf("\nplugin search path:\n")
+	fmt.Fprintf(w, "\nplugin search path:\n")
 	for i, dir := range result.Config.PluginDirs {
 		exists := "missing"
 		if info, statErr := os.Stat(dir); statErr == nil && info.IsDir() {
 			exists = "ok"
 		}
-		fmt.Printf("  %d. %s [%s]\n", i+1, dir, exists)
+		fmt.Fprintf(w, "  %d. %s [%s]\n", i+1, dir, exists)
 	}
 
 	manifests := result.Manager.Manifests()
-	fmt.Printf("\ndiscovered plugins: %d\n", len(manifests))
+	fmt.Fprintf(w, "\ndiscovered plugins: %d\n", len(manifests))
 	var totalPrimary, totalDeferred int
 	for _, m := range manifests {
 		var primaryCount, deferredCount int
@@ -384,180 +374,20 @@ func runCheck() error {
 		}
 		totalPrimary += primaryCount
 		totalDeferred += deferredCount
-		fmt.Printf("  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
-		fmt.Printf("    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
+		fmt.Fprintf(w, "  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
+		fmt.Fprintf(w, "    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
 			m.Handler, m.Execution, len(m.Tools), primaryCount, deferredCount)
 	}
 
-	fmt.Printf("\ntool discovery: %s\n", result.Config.Tools.Discovery)
-	fmt.Printf("primary tools: %d\n", totalPrimary)
-	fmt.Printf("deferred tools: %d\n", totalDeferred)
+	fmt.Fprintf(w, "\ntool discovery: %s\n", result.Config.Tools.Discovery)
+	fmt.Fprintf(w, "primary tools: %d\n", totalPrimary)
+	fmt.Fprintf(w, "deferred tools: %d\n", totalDeferred)
 
 	if len(manifests) == 0 {
-		fmt.Println("\nno plugins found. check that plugin directories contain")
-		fmt.Println("subdirectories with plugin.yaml files.")
+		fmt.Fprintln(w, "\nno plugins found. check that plugin directories contain")
+		fmt.Fprintln(w, "subdirectories with plugin.yaml files.")
 	}
 
 	return nil
 }
 
-// printVaultStatus reports vault password configuration and per-group
-// encryption status for the check command.
-func printVaultStatus(result *plugin.DiscoveryResult) {
-	cfg := result.Config
-
-	passwordSource := "not configured"
-	switch {
-	case cfg.Secrets.VaultPasswordFile != "":
-		passwordSource = fmt.Sprintf("file (%s)", cfg.Secrets.VaultPasswordFile)
-	case len(cfg.Secrets.VaultIDs) > 0:
-		passwordSource = "vault IDs" //nolint:gosec // status label, not a credential
-	default:
-		if result.VaultResolver != nil {
-			if pw, err := result.VaultResolver(""); err == nil {
-				vault.ZeroBytes(pw)
-				passwordSource = "env var" //nolint:gosec // status label, not a credential
-			}
-		}
-	}
-	fmt.Printf("vault password: %s\n", passwordSource)
-
-	if len(cfg.Secrets.VaultIDs) > 0 {
-		fmt.Printf("vault IDs: %d configured\n", len(cfg.Secrets.VaultIDs))
-	}
-
-	if result.EnvDir == "" || result.EnvDirError != "" {
-		return
-	}
-
-	entries, err := os.ReadDir(result.EnvDir)
-	if err != nil {
-		return
-	}
-
-	resolve := result.VaultResolver
-	if resolve == nil {
-		return
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".env") {
-			continue
-		}
-		group := strings.TrimSuffix(entry.Name(), ".env")
-		path := filepath.Join(result.EnvDir, entry.Name())
-
-		data, err := os.ReadFile(path) //nolint:gosec // check path from config
-		if err != nil {
-			continue
-		}
-
-		if !vault.IsAnsibleVault(data) {
-			continue
-		}
-
-		header, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
-		if err != nil {
-			fmt.Printf("  - %s (encrypted, invalid header)\n", group)
-			continue
-		}
-
-		vaultInfo := "vault " + header.Version
-		if header.VaultID != "" {
-			vaultInfo += " id=" + header.VaultID
-		}
-
-		password, err := resolve(header.VaultID)
-		if err != nil {
-			fmt.Printf("  - %s (encrypted, %s, no password)\n", group, vaultInfo)
-			continue
-		}
-
-		plaintext, err := vault.Decrypt(data, password)
-		vault.ZeroBytes(password)
-		vault.ZeroBytes(plaintext)
-		if err != nil {
-			fmt.Printf("  - %s (encrypted, %s, decryption failed)\n", group, vaultInfo)
-		} else {
-			fmt.Printf("  - %s (encrypted, %s, decryption ok)\n", group, vaultInfo)
-		}
-	}
-
-	printCredentialFileStatus(cfg, resolve)
-}
-
-// printCredentialFileStatus reports vault-encrypted credential files
-// in credentials/<group>/ directories.
-func printCredentialFileStatus(cfg *config.Config, resolve func(string) ([]byte, error)) {
-	if cfg.CredentialsDir == "" {
-		return
-	}
-	groups, err := os.ReadDir(cfg.CredentialsDir)
-	if err != nil {
-		return
-	}
-
-	var found bool
-	for _, group := range groups {
-		if !group.IsDir() {
-			continue
-		}
-		groupDir := filepath.Join(cfg.CredentialsDir, group.Name())
-		files, err := os.ReadDir(groupDir)
-		if err != nil {
-			continue
-		}
-		for _, file := range files {
-			if file.IsDir() {
-				continue
-			}
-			path := filepath.Join(groupDir, file.Name())
-			f, err := os.Open(path) //nolint:gosec // credentials dir from config
-			if err != nil {
-				continue
-			}
-			header := make([]byte, 15)
-			n, _ := f.Read(header)
-			_ = f.Close()
-			if !vault.IsAnsibleVault(header[:n]) {
-				continue
-			}
-
-			if !found {
-				fmt.Printf("credential files:\n")
-				found = true
-			}
-
-			data, err := os.ReadFile(path) //nolint:gosec // credentials dir from config
-			if err != nil {
-				fmt.Printf("  - %s/%s (encrypted, read error)\n", group.Name(), file.Name())
-				continue
-			}
-
-			hdr, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
-			if err != nil {
-				fmt.Printf("  - %s/%s (encrypted, invalid header)\n", group.Name(), file.Name())
-				continue
-			}
-
-			vaultInfo := "vault " + hdr.Version
-			if hdr.VaultID != "" {
-				vaultInfo += " id=" + hdr.VaultID
-			}
-
-			password, err := resolve(hdr.VaultID)
-			if err != nil {
-				fmt.Printf("  - %s/%s (encrypted, %s, no password)\n", group.Name(), file.Name(), vaultInfo)
-				continue
-			}
-
-			plaintext, err := vault.Decrypt(data, password)
-			vault.ZeroBytes(password)
-			vault.ZeroBytes(plaintext)
-			if err != nil {
-				fmt.Printf("  - %s/%s (encrypted, %s, decryption failed)\n", group.Name(), file.Name(), vaultInfo)
-			} else {
-				fmt.Printf("  - %s/%s (encrypted, %s, decryption ok)\n", group.Name(), file.Name(), vaultInfo)
-			}
-		}
-	}
-}

--- a/cmd/wtmcp/main.go
+++ b/cmd/wtmcp/main.go
@@ -333,35 +333,33 @@ func runCheck() error {
 		result.Config.ReadOnly = true
 	}
 
-	w := os.Stdout
-
-	fmt.Fprintf(w, "wtmcp %s\n", Version)
-	fmt.Fprintf(w, "sandbox: %v\n", sandbox.Built())
-	fmt.Fprintf(w, "workdir: %s\n", result.Workdir)
+	fmt.Printf("wtmcp %s\n", Version)
+	fmt.Printf("sandbox: %v\n", sandbox.Built())
+	fmt.Printf("workdir: %s\n", result.Workdir)
 	if result.Config.ReadOnly {
-		fmt.Fprintf(w, "read-only: true (write tools will not be registered)\n")
+		fmt.Printf("read-only: true (write tools will not be registered)\n")
 	}
 	if len(result.Config.Plugins.Enabled) > 0 {
-		fmt.Fprintf(w, "plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
+		fmt.Printf("plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
 	} else {
-		fmt.Fprintf(w, "plugin mode: default\n")
+		fmt.Printf("plugin mode: default\n")
 	}
-	fmt.Fprintf(w, "user plugins: %v\n", result.Config.Plugins.UserPlugins)
+	fmt.Printf("user plugins: %v\n", result.Config.Plugins.UserPlugins)
 
-	diagnostic.PrintVaultStatus(w, result)
-	diagnostic.PrintEnvGroups(w, result)
+	diagnostic.PrintVaultStatus(os.Stdout, result)
+	diagnostic.PrintEnvGroups(os.Stdout, result)
 
-	fmt.Fprintf(w, "\nplugin search path:\n")
+	fmt.Printf("\nplugin search path:\n")
 	for i, dir := range result.Config.PluginDirs {
 		exists := "missing"
 		if info, statErr := os.Stat(dir); statErr == nil && info.IsDir() {
 			exists = "ok"
 		}
-		fmt.Fprintf(w, "  %d. %s [%s]\n", i+1, dir, exists)
+		fmt.Printf("  %d. %s [%s]\n", i+1, dir, exists)
 	}
 
 	manifests := result.Manager.Manifests()
-	fmt.Fprintf(w, "\ndiscovered plugins: %d\n", len(manifests))
+	fmt.Printf("\ndiscovered plugins: %d\n", len(manifests))
 	var totalPrimary, totalDeferred int
 	for _, m := range manifests {
 		var primaryCount, deferredCount int
@@ -374,18 +372,18 @@ func runCheck() error {
 		}
 		totalPrimary += primaryCount
 		totalDeferred += deferredCount
-		fmt.Fprintf(w, "  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
-		fmt.Fprintf(w, "    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
+		fmt.Printf("  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
+		fmt.Printf("    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
 			m.Handler, m.Execution, len(m.Tools), primaryCount, deferredCount)
 	}
 
-	fmt.Fprintf(w, "\ntool discovery: %s\n", result.Config.Tools.Discovery)
-	fmt.Fprintf(w, "primary tools: %d\n", totalPrimary)
-	fmt.Fprintf(w, "deferred tools: %d\n", totalDeferred)
+	fmt.Printf("\ntool discovery: %s\n", result.Config.Tools.Discovery)
+	fmt.Printf("primary tools: %d\n", totalPrimary)
+	fmt.Printf("deferred tools: %d\n", totalDeferred)
 
 	if len(manifests) == 0 {
-		fmt.Fprintln(w, "\nno plugins found. check that plugin directories contain")
-		fmt.Fprintln(w, "subdirectories with plugin.yaml files.")
+		fmt.Println("\nno plugins found. check that plugin directories contain")
+		fmt.Println("subdirectories with plugin.yaml files.")
 	}
 
 	return nil

--- a/cmd/wtmcpctl/check.go
+++ b/cmd/wtmcpctl/check.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/LeGambiArt/wtmcp/internal/config"
+	"github.com/LeGambiArt/wtmcp/internal/plugin"
+	"github.com/LeGambiArt/wtmcp/internal/secrets/vault"
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Print diagnostic info about config and plugins",
+	Args:  cobra.NoArgs,
+	RunE:  runCtlCheck,
+}
+
+func runCtlCheck(_ *cobra.Command, _ []string) error {
+	result, err := plugin.Discover(plugin.DiscoveryOptions{
+		WorkdirOverride: globalWorkdir,
+	})
+	if err != nil {
+		return err
+	}
+	defer result.Close()
+
+	fmt.Printf("wtmcpctl %s\n", Version)
+	fmt.Printf("workdir: %s\n", result.Workdir)
+	if len(result.Config.Plugins.Enabled) > 0 {
+		fmt.Printf("plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
+	} else {
+		fmt.Printf("plugin mode: default\n")
+	}
+	fmt.Printf("user plugins: %v\n", result.Config.Plugins.UserPlugins)
+
+	printCtlVaultStatus(result)
+
+	fmt.Printf("env groups: %d\n", len(result.EnvGroups))
+	for group := range result.EnvGroups {
+		fmt.Printf("  - %s\n", group)
+	}
+	if result.EnvDirError != "" {
+		fmt.Printf("env.d directory error: %s\n", result.EnvDirError)
+	}
+	if len(result.EnvErrors) > 0 {
+		fmt.Printf("env group errors: %d\n", len(result.EnvErrors))
+		for group, msg := range result.EnvErrors {
+			fmt.Printf("  - %s: %s\n", group, msg)
+		}
+	}
+
+	fmt.Printf("\nplugin search path:\n")
+	for i, dir := range result.Config.PluginDirs {
+		exists := "missing"
+		if info, statErr := os.Stat(dir); statErr == nil && info.IsDir() {
+			exists = "ok"
+		}
+		fmt.Printf("  %d. %s [%s]\n", i+1, dir, exists)
+	}
+
+	manifests := result.Manager.Manifests()
+	fmt.Printf("\ndiscovered plugins: %d\n", len(manifests))
+	var totalPrimary, totalDeferred int
+	for _, m := range manifests {
+		var primaryCount, deferredCount int
+		for _, t := range m.Tools {
+			if t.IsPrimary() {
+				primaryCount++
+			} else {
+				deferredCount++
+			}
+		}
+		totalPrimary += primaryCount
+		totalDeferred += deferredCount
+		fmt.Printf("  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
+		fmt.Printf("    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
+			m.Handler, m.Execution, len(m.Tools), primaryCount, deferredCount)
+	}
+
+	fmt.Printf("\ntool discovery: %s\n", result.Config.Tools.Discovery)
+	fmt.Printf("primary tools: %d\n", totalPrimary)
+	fmt.Printf("deferred tools: %d\n", totalDeferred)
+
+	if len(manifests) == 0 {
+		fmt.Println("\nno plugins found. check that plugin directories contain")
+		fmt.Println("subdirectories with plugin.yaml files.")
+	}
+
+	return nil
+}
+
+// printCtlVaultStatus reports vault password configuration and per-group
+// encryption status for the check command.
+func printCtlVaultStatus(result *plugin.DiscoveryResult) {
+	cfg := result.Config
+
+	passwordSource := "not configured"
+	switch {
+	case cfg.Secrets.VaultPasswordFile != "":
+		passwordSource = fmt.Sprintf("file (%s)", cfg.Secrets.VaultPasswordFile)
+	case len(cfg.Secrets.VaultIDs) > 0:
+		passwordSource = "vault IDs" //nolint:gosec // status label, not a credential
+	default:
+		if result.VaultResolver != nil {
+			if pw, err := result.VaultResolver(""); err == nil {
+				vault.ZeroBytes(pw)
+				passwordSource = "env var" //nolint:gosec // status label, not a credential
+			}
+		}
+	}
+	fmt.Printf("vault password: %s\n", passwordSource)
+
+	if len(cfg.Secrets.VaultIDs) > 0 {
+		fmt.Printf("vault IDs: %d configured\n", len(cfg.Secrets.VaultIDs))
+	}
+
+	if result.EnvDir == "" || result.EnvDirError != "" {
+		return
+	}
+
+	entries, err := os.ReadDir(result.EnvDir)
+	if err != nil {
+		return
+	}
+
+	resolve := result.VaultResolver
+	if resolve == nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".env") {
+			continue
+		}
+		group := strings.TrimSuffix(entry.Name(), ".env")
+		path := filepath.Join(result.EnvDir, entry.Name())
+
+		data, err := os.ReadFile(path) //nolint:gosec // check path from config
+		if err != nil {
+			continue
+		}
+
+		if !vault.IsAnsibleVault(data) {
+			continue
+		}
+
+		header, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
+		if err != nil {
+			fmt.Printf("  - %s (encrypted, invalid header)\n", group)
+			continue
+		}
+
+		vaultInfo := "vault " + header.Version
+		if header.VaultID != "" {
+			vaultInfo += " id=" + header.VaultID
+		}
+
+		password, err := resolve(header.VaultID)
+		if err != nil {
+			fmt.Printf("  - %s (encrypted, %s, no password)\n", group, vaultInfo)
+			continue
+		}
+
+		plaintext, err := vault.Decrypt(data, password)
+		vault.ZeroBytes(password)
+		vault.ZeroBytes(plaintext)
+		if err != nil {
+			fmt.Printf("  - %s (encrypted, %s, decryption failed)\n", group, vaultInfo)
+		} else {
+			fmt.Printf("  - %s (encrypted, %s, decryption ok)\n", group, vaultInfo)
+		}
+	}
+
+	printCtlCredentialFileStatus(cfg, resolve)
+}
+
+// printCtlCredentialFileStatus reports vault-encrypted credential files
+// in credentials/<group>/ directories.
+func printCtlCredentialFileStatus(cfg *config.Config, resolve func(string) ([]byte, error)) {
+	if cfg.CredentialsDir == "" {
+		return
+	}
+	groups, err := os.ReadDir(cfg.CredentialsDir)
+	if err != nil {
+		return
+	}
+
+	var found bool
+	for _, group := range groups {
+		if !group.IsDir() {
+			continue
+		}
+		groupDir := filepath.Join(cfg.CredentialsDir, group.Name())
+		files, err := os.ReadDir(groupDir)
+		if err != nil {
+			continue
+		}
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+			path := filepath.Join(groupDir, file.Name())
+			f, err := os.Open(path) //nolint:gosec // credentials dir from config
+			if err != nil {
+				continue
+			}
+			header := make([]byte, 15)
+			n, _ := f.Read(header)
+			_ = f.Close()
+			if !vault.IsAnsibleVault(header[:n]) {
+				continue
+			}
+
+			if !found {
+				fmt.Printf("credential files:\n")
+				found = true
+			}
+
+			data, err := os.ReadFile(path) //nolint:gosec // credentials dir from config
+			if err != nil {
+				fmt.Printf("  - %s/%s (encrypted, read error)\n", group.Name(), file.Name())
+				continue
+			}
+
+			hdr, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
+			if err != nil {
+				fmt.Printf("  - %s/%s (encrypted, invalid header)\n", group.Name(), file.Name())
+				continue
+			}
+
+			vaultInfo := "vault " + hdr.Version
+			if hdr.VaultID != "" {
+				vaultInfo += " id=" + hdr.VaultID
+			}
+
+			password, err := resolve(hdr.VaultID)
+			if err != nil {
+				fmt.Printf("  - %s/%s (encrypted, %s, no password)\n", group.Name(), file.Name(), vaultInfo)
+				continue
+			}
+
+			plaintext, err := vault.Decrypt(data, password)
+			vault.ZeroBytes(password)
+			vault.ZeroBytes(plaintext)
+			if err != nil {
+				fmt.Printf("  - %s/%s (encrypted, %s, decryption failed)\n", group.Name(), file.Name(), vaultInfo)
+			} else {
+				fmt.Printf("  - %s/%s (encrypted, %s, decryption ok)\n", group.Name(), file.Name(), vaultInfo)
+			}
+		}
+	}
+}

--- a/cmd/wtmcpctl/check.go
+++ b/cmd/wtmcpctl/check.go
@@ -26,31 +26,29 @@ func runCtlCheck(_ *cobra.Command, _ []string) error {
 	}
 	defer result.Close()
 
-	w := os.Stdout
-
-	fmt.Fprintf(w, "wtmcpctl %s\n", Version)
-	fmt.Fprintf(w, "workdir: %s\n", result.Workdir)
+	fmt.Printf("wtmcpctl %s\n", Version)
+	fmt.Printf("workdir: %s\n", result.Workdir)
 	if len(result.Config.Plugins.Enabled) > 0 {
-		fmt.Fprintf(w, "plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
+		fmt.Printf("plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
 	} else {
-		fmt.Fprintf(w, "plugin mode: default\n")
+		fmt.Printf("plugin mode: default\n")
 	}
-	fmt.Fprintf(w, "user plugins: %v\n", result.Config.Plugins.UserPlugins)
+	fmt.Printf("user plugins: %v\n", result.Config.Plugins.UserPlugins)
 
-	diagnostic.PrintVaultStatus(w, result)
-	diagnostic.PrintEnvGroups(w, result)
+	diagnostic.PrintVaultStatus(os.Stdout, result)
+	diagnostic.PrintEnvGroups(os.Stdout, result)
 
-	fmt.Fprintf(w, "\nplugin search path:\n")
+	fmt.Printf("\nplugin search path:\n")
 	for i, dir := range result.Config.PluginDirs {
 		exists := "missing"
 		if info, statErr := os.Stat(dir); statErr == nil && info.IsDir() {
 			exists = "ok"
 		}
-		fmt.Fprintf(w, "  %d. %s [%s]\n", i+1, dir, exists)
+		fmt.Printf("  %d. %s [%s]\n", i+1, dir, exists)
 	}
 
 	manifests := result.Manager.Manifests()
-	fmt.Fprintf(w, "\ndiscovered plugins: %d\n", len(manifests))
+	fmt.Printf("\ndiscovered plugins: %d\n", len(manifests))
 	var totalPrimary, totalDeferred int
 	for _, m := range manifests {
 		var primaryCount, deferredCount int
@@ -63,18 +61,18 @@ func runCtlCheck(_ *cobra.Command, _ []string) error {
 		}
 		totalPrimary += primaryCount
 		totalDeferred += deferredCount
-		fmt.Fprintf(w, "  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
-		fmt.Fprintf(w, "    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
+		fmt.Printf("  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
+		fmt.Printf("    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
 			m.Handler, m.Execution, len(m.Tools), primaryCount, deferredCount)
 	}
 
-	fmt.Fprintf(w, "\ntool discovery: %s\n", result.Config.Tools.Discovery)
-	fmt.Fprintf(w, "primary tools: %d\n", totalPrimary)
-	fmt.Fprintf(w, "deferred tools: %d\n", totalDeferred)
+	fmt.Printf("\ntool discovery: %s\n", result.Config.Tools.Discovery)
+	fmt.Printf("primary tools: %d\n", totalPrimary)
+	fmt.Printf("deferred tools: %d\n", totalDeferred)
 
 	if len(manifests) == 0 {
-		fmt.Fprintln(w, "\nno plugins found. check that plugin directories contain")
-		fmt.Fprintln(w, "subdirectories with plugin.yaml files.")
+		fmt.Println("\nno plugins found. check that plugin directories contain")
+		fmt.Println("subdirectories with plugin.yaml files.")
 	}
 
 	return nil

--- a/cmd/wtmcpctl/check.go
+++ b/cmd/wtmcpctl/check.go
@@ -3,14 +3,11 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/LeGambiArt/wtmcp/internal/config"
+	"github.com/LeGambiArt/wtmcp/internal/diagnostic"
 	"github.com/LeGambiArt/wtmcp/internal/plugin"
-	"github.com/LeGambiArt/wtmcp/internal/secrets/vault"
 )
 
 var checkCmd = &cobra.Command{
@@ -29,42 +26,31 @@ func runCtlCheck(_ *cobra.Command, _ []string) error {
 	}
 	defer result.Close()
 
-	fmt.Printf("wtmcpctl %s\n", Version)
-	fmt.Printf("workdir: %s\n", result.Workdir)
+	w := os.Stdout
+
+	fmt.Fprintf(w, "wtmcpctl %s\n", Version)
+	fmt.Fprintf(w, "workdir: %s\n", result.Workdir)
 	if len(result.Config.Plugins.Enabled) > 0 {
-		fmt.Printf("plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
+		fmt.Fprintf(w, "plugin mode: allowlist (%d plugins)\n", len(result.Config.Plugins.Enabled))
 	} else {
-		fmt.Printf("plugin mode: default\n")
+		fmt.Fprintf(w, "plugin mode: default\n")
 	}
-	fmt.Printf("user plugins: %v\n", result.Config.Plugins.UserPlugins)
+	fmt.Fprintf(w, "user plugins: %v\n", result.Config.Plugins.UserPlugins)
 
-	printCtlVaultStatus(result)
+	diagnostic.PrintVaultStatus(w, result)
+	diagnostic.PrintEnvGroups(w, result)
 
-	fmt.Printf("env groups: %d\n", len(result.EnvGroups))
-	for group := range result.EnvGroups {
-		fmt.Printf("  - %s\n", group)
-	}
-	if result.EnvDirError != "" {
-		fmt.Printf("env.d directory error: %s\n", result.EnvDirError)
-	}
-	if len(result.EnvErrors) > 0 {
-		fmt.Printf("env group errors: %d\n", len(result.EnvErrors))
-		for group, msg := range result.EnvErrors {
-			fmt.Printf("  - %s: %s\n", group, msg)
-		}
-	}
-
-	fmt.Printf("\nplugin search path:\n")
+	fmt.Fprintf(w, "\nplugin search path:\n")
 	for i, dir := range result.Config.PluginDirs {
 		exists := "missing"
 		if info, statErr := os.Stat(dir); statErr == nil && info.IsDir() {
 			exists = "ok"
 		}
-		fmt.Printf("  %d. %s [%s]\n", i+1, dir, exists)
+		fmt.Fprintf(w, "  %d. %s [%s]\n", i+1, dir, exists)
 	}
 
 	manifests := result.Manager.Manifests()
-	fmt.Printf("\ndiscovered plugins: %d\n", len(manifests))
+	fmt.Fprintf(w, "\ndiscovered plugins: %d\n", len(manifests))
 	var totalPrimary, totalDeferred int
 	for _, m := range manifests {
 		var primaryCount, deferredCount int
@@ -77,180 +63,19 @@ func runCtlCheck(_ *cobra.Command, _ []string) error {
 		}
 		totalPrimary += primaryCount
 		totalDeferred += deferredCount
-		fmt.Printf("  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
-		fmt.Printf("    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
+		fmt.Fprintf(w, "  - %s v%s (%s)\n", m.Name, m.Version, m.Dir)
+		fmt.Fprintf(w, "    handler: %s | execution: %s | tools: %d (primary: %d, deferred: %d)\n",
 			m.Handler, m.Execution, len(m.Tools), primaryCount, deferredCount)
 	}
 
-	fmt.Printf("\ntool discovery: %s\n", result.Config.Tools.Discovery)
-	fmt.Printf("primary tools: %d\n", totalPrimary)
-	fmt.Printf("deferred tools: %d\n", totalDeferred)
+	fmt.Fprintf(w, "\ntool discovery: %s\n", result.Config.Tools.Discovery)
+	fmt.Fprintf(w, "primary tools: %d\n", totalPrimary)
+	fmt.Fprintf(w, "deferred tools: %d\n", totalDeferred)
 
 	if len(manifests) == 0 {
-		fmt.Println("\nno plugins found. check that plugin directories contain")
-		fmt.Println("subdirectories with plugin.yaml files.")
+		fmt.Fprintln(w, "\nno plugins found. check that plugin directories contain")
+		fmt.Fprintln(w, "subdirectories with plugin.yaml files.")
 	}
 
 	return nil
-}
-
-// printCtlVaultStatus reports vault password configuration and per-group
-// encryption status for the check command.
-func printCtlVaultStatus(result *plugin.DiscoveryResult) {
-	cfg := result.Config
-
-	passwordSource := "not configured"
-	switch {
-	case cfg.Secrets.VaultPasswordFile != "":
-		passwordSource = fmt.Sprintf("file (%s)", cfg.Secrets.VaultPasswordFile)
-	case len(cfg.Secrets.VaultIDs) > 0:
-		passwordSource = "vault IDs" //nolint:gosec // status label, not a credential
-	default:
-		if result.VaultResolver != nil {
-			if pw, err := result.VaultResolver(""); err == nil {
-				vault.ZeroBytes(pw)
-				passwordSource = "env var" //nolint:gosec // status label, not a credential
-			}
-		}
-	}
-	fmt.Printf("vault password: %s\n", passwordSource)
-
-	if len(cfg.Secrets.VaultIDs) > 0 {
-		fmt.Printf("vault IDs: %d configured\n", len(cfg.Secrets.VaultIDs))
-	}
-
-	if result.EnvDir == "" || result.EnvDirError != "" {
-		return
-	}
-
-	entries, err := os.ReadDir(result.EnvDir)
-	if err != nil {
-		return
-	}
-
-	resolve := result.VaultResolver
-	if resolve == nil {
-		return
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".env") {
-			continue
-		}
-		group := strings.TrimSuffix(entry.Name(), ".env")
-		path := filepath.Join(result.EnvDir, entry.Name())
-
-		data, err := os.ReadFile(path) //nolint:gosec // check path from config
-		if err != nil {
-			continue
-		}
-
-		if !vault.IsAnsibleVault(data) {
-			continue
-		}
-
-		header, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
-		if err != nil {
-			fmt.Printf("  - %s (encrypted, invalid header)\n", group)
-			continue
-		}
-
-		vaultInfo := "vault " + header.Version
-		if header.VaultID != "" {
-			vaultInfo += " id=" + header.VaultID
-		}
-
-		password, err := resolve(header.VaultID)
-		if err != nil {
-			fmt.Printf("  - %s (encrypted, %s, no password)\n", group, vaultInfo)
-			continue
-		}
-
-		plaintext, err := vault.Decrypt(data, password)
-		vault.ZeroBytes(password)
-		vault.ZeroBytes(plaintext)
-		if err != nil {
-			fmt.Printf("  - %s (encrypted, %s, decryption failed)\n", group, vaultInfo)
-		} else {
-			fmt.Printf("  - %s (encrypted, %s, decryption ok)\n", group, vaultInfo)
-		}
-	}
-
-	printCtlCredentialFileStatus(cfg, resolve)
-}
-
-// printCtlCredentialFileStatus reports vault-encrypted credential files
-// in credentials/<group>/ directories.
-func printCtlCredentialFileStatus(cfg *config.Config, resolve func(string) ([]byte, error)) {
-	if cfg.CredentialsDir == "" {
-		return
-	}
-	groups, err := os.ReadDir(cfg.CredentialsDir)
-	if err != nil {
-		return
-	}
-
-	var found bool
-	for _, group := range groups {
-		if !group.IsDir() {
-			continue
-		}
-		groupDir := filepath.Join(cfg.CredentialsDir, group.Name())
-		files, err := os.ReadDir(groupDir)
-		if err != nil {
-			continue
-		}
-		for _, file := range files {
-			if file.IsDir() {
-				continue
-			}
-			path := filepath.Join(groupDir, file.Name())
-			f, err := os.Open(path) //nolint:gosec // credentials dir from config
-			if err != nil {
-				continue
-			}
-			header := make([]byte, 15)
-			n, _ := f.Read(header)
-			_ = f.Close()
-			if !vault.IsAnsibleVault(header[:n]) {
-				continue
-			}
-
-			if !found {
-				fmt.Printf("credential files:\n")
-				found = true
-			}
-
-			data, err := os.ReadFile(path) //nolint:gosec // credentials dir from config
-			if err != nil {
-				fmt.Printf("  - %s/%s (encrypted, read error)\n", group.Name(), file.Name())
-				continue
-			}
-
-			hdr, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
-			if err != nil {
-				fmt.Printf("  - %s/%s (encrypted, invalid header)\n", group.Name(), file.Name())
-				continue
-			}
-
-			vaultInfo := "vault " + hdr.Version
-			if hdr.VaultID != "" {
-				vaultInfo += " id=" + hdr.VaultID
-			}
-
-			password, err := resolve(hdr.VaultID)
-			if err != nil {
-				fmt.Printf("  - %s/%s (encrypted, %s, no password)\n", group.Name(), file.Name(), vaultInfo)
-				continue
-			}
-
-			plaintext, err := vault.Decrypt(data, password)
-			vault.ZeroBytes(password)
-			vault.ZeroBytes(plaintext)
-			if err != nil {
-				fmt.Printf("  - %s/%s (encrypted, %s, decryption failed)\n", group.Name(), file.Name(), vaultInfo)
-			} else {
-				fmt.Printf("  - %s/%s (encrypted, %s, decryption ok)\n", group.Name(), file.Name(), vaultInfo)
-			}
-		}
-	}
 }

--- a/cmd/wtmcpctl/main.go
+++ b/cmd/wtmcpctl/main.go
@@ -54,7 +54,7 @@ func init() {
 		return nil
 	}
 
-	rootCmd.AddCommand(versionCmd, agentCmd, oauthCmd, pluginsCmd, providerCmd, statsCmd, vaultCmd)
+	rootCmd.AddCommand(versionCmd, agentCmd, checkCmd, oauthCmd, pluginsCmd, providerCmd, statsCmd, vaultCmd)
 }
 
 func main() {

--- a/internal/diagnostic/vault.go
+++ b/internal/diagnostic/vault.go
@@ -1,3 +1,4 @@
+// Package diagnostic provides shared diagnostic output for wtmcp CLI tools.
 package diagnostic
 
 import (
@@ -37,10 +38,10 @@ func VaultPasswordSource(cfg *config.Config, resolver func(string) ([]byte, erro
 func PrintVaultStatus(w io.Writer, result *plugin.DiscoveryResult) {
 	cfg := result.Config
 
-	fmt.Fprintf(w, "vault password: %s\n", VaultPasswordSource(cfg, result.VaultResolver))
+	_, _ = fmt.Fprintf(w, "vault password: %s\n", VaultPasswordSource(cfg, result.VaultResolver))
 
 	if len(cfg.Secrets.VaultIDs) > 0 {
-		fmt.Fprintf(w, "vault IDs: %d configured\n", len(cfg.Secrets.VaultIDs))
+		_, _ = fmt.Fprintf(w, "vault IDs: %d configured\n", len(cfg.Secrets.VaultIDs))
 	}
 
 	if result.EnvDir == "" || result.EnvDirError != "" {
@@ -74,7 +75,7 @@ func PrintVaultStatus(w io.Writer, result *plugin.DiscoveryResult) {
 
 		header, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
 		if err != nil {
-			fmt.Fprintf(w, "  - %s (encrypted, invalid header)\n", group)
+			_, _ = fmt.Fprintf(w, "  - %s (encrypted, invalid header)\n", group)
 			continue
 		}
 
@@ -85,7 +86,7 @@ func PrintVaultStatus(w io.Writer, result *plugin.DiscoveryResult) {
 
 		password, err := resolve(header.VaultID)
 		if err != nil {
-			fmt.Fprintf(w, "  - %s (encrypted, %s, no password)\n", group, vaultInfo)
+			_, _ = fmt.Fprintf(w, "  - %s (encrypted, %s, no password)\n", group, vaultInfo)
 			continue
 		}
 
@@ -93,9 +94,9 @@ func PrintVaultStatus(w io.Writer, result *plugin.DiscoveryResult) {
 		vault.ZeroBytes(password)
 		vault.ZeroBytes(plaintext)
 		if err != nil {
-			fmt.Fprintf(w, "  - %s (encrypted, %s, decryption failed)\n", group, vaultInfo)
+			_, _ = fmt.Fprintf(w, "  - %s (encrypted, %s, decryption failed)\n", group, vaultInfo)
 		} else {
-			fmt.Fprintf(w, "  - %s (encrypted, %s, decryption ok)\n", group, vaultInfo)
+			_, _ = fmt.Fprintf(w, "  - %s (encrypted, %s, decryption ok)\n", group, vaultInfo)
 		}
 	}
 
@@ -136,7 +137,7 @@ func PrintCredentialFileStatus(w io.Writer, cfg *config.Config, resolve func(str
 			n, readErr := f.Read(header)
 			_ = f.Close()
 			if readErr != nil && n == 0 {
-				fmt.Fprintf(w, "  - %s/%s (read error: %v)\n", group.Name(), file.Name(), readErr)
+				_, _ = fmt.Fprintf(w, "  - %s/%s (read error: %v)\n", group.Name(), file.Name(), readErr)
 				continue
 			}
 			if !vault.IsAnsibleVault(header[:n]) {
@@ -144,19 +145,19 @@ func PrintCredentialFileStatus(w io.Writer, cfg *config.Config, resolve func(str
 			}
 
 			if !found {
-				fmt.Fprintf(w, "credential files:\n")
+				_, _ = fmt.Fprintf(w, "credential files:\n")
 				found = true
 			}
 
 			data, err := os.ReadFile(path) //nolint:gosec // credentials dir from config
 			if err != nil {
-				fmt.Fprintf(w, "  - %s/%s (encrypted, read error)\n", group.Name(), file.Name())
+				_, _ = fmt.Fprintf(w, "  - %s/%s (encrypted, read error)\n", group.Name(), file.Name())
 				continue
 			}
 
 			hdr, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
 			if err != nil {
-				fmt.Fprintf(w, "  - %s/%s (encrypted, invalid header)\n", group.Name(), file.Name())
+				_, _ = fmt.Fprintf(w, "  - %s/%s (encrypted, invalid header)\n", group.Name(), file.Name())
 				continue
 			}
 
@@ -167,7 +168,7 @@ func PrintCredentialFileStatus(w io.Writer, cfg *config.Config, resolve func(str
 
 			password, err := resolve(hdr.VaultID)
 			if err != nil {
-				fmt.Fprintf(w, "  - %s/%s (encrypted, %s, no password)\n", group.Name(), file.Name(), vaultInfo)
+				_, _ = fmt.Fprintf(w, "  - %s/%s (encrypted, %s, no password)\n", group.Name(), file.Name(), vaultInfo)
 				continue
 			}
 
@@ -175,9 +176,9 @@ func PrintCredentialFileStatus(w io.Writer, cfg *config.Config, resolve func(str
 			vault.ZeroBytes(password)
 			vault.ZeroBytes(plaintext)
 			if err != nil {
-				fmt.Fprintf(w, "  - %s/%s (encrypted, %s, decryption failed)\n", group.Name(), file.Name(), vaultInfo)
+				_, _ = fmt.Fprintf(w, "  - %s/%s (encrypted, %s, decryption failed)\n", group.Name(), file.Name(), vaultInfo)
 			} else {
-				fmt.Fprintf(w, "  - %s/%s (encrypted, %s, decryption ok)\n", group.Name(), file.Name(), vaultInfo)
+				_, _ = fmt.Fprintf(w, "  - %s/%s (encrypted, %s, decryption ok)\n", group.Name(), file.Name(), vaultInfo)
 			}
 		}
 	}
@@ -185,27 +186,27 @@ func PrintCredentialFileStatus(w io.Writer, cfg *config.Config, resolve func(str
 
 // PrintEnvGroups prints sorted env group names and any errors.
 func PrintEnvGroups(w io.Writer, result *plugin.DiscoveryResult) {
-	fmt.Fprintf(w, "env groups: %d\n", len(result.EnvGroups))
+	_, _ = fmt.Fprintf(w, "env groups: %d\n", len(result.EnvGroups))
 	groups := make([]string, 0, len(result.EnvGroups))
 	for g := range result.EnvGroups {
 		groups = append(groups, g)
 	}
 	slices.Sort(groups)
 	for _, g := range groups {
-		fmt.Fprintf(w, "  - %s\n", g)
+		_, _ = fmt.Fprintf(w, "  - %s\n", g)
 	}
 	if result.EnvDirError != "" {
-		fmt.Fprintf(w, "env.d directory error: %s\n", result.EnvDirError)
+		_, _ = fmt.Fprintf(w, "env.d directory error: %s\n", result.EnvDirError)
 	}
 	if len(result.EnvErrors) > 0 {
-		fmt.Fprintf(w, "env group errors: %d\n", len(result.EnvErrors))
+		_, _ = fmt.Fprintf(w, "env group errors: %d\n", len(result.EnvErrors))
 		errGroups := make([]string, 0, len(result.EnvErrors))
 		for g := range result.EnvErrors {
 			errGroups = append(errGroups, g)
 		}
 		slices.Sort(errGroups)
 		for _, g := range errGroups {
-			fmt.Fprintf(w, "  - %s: %s\n", g, result.EnvErrors[g])
+			_, _ = fmt.Fprintf(w, "  - %s: %s\n", g, result.EnvErrors[g])
 		}
 	}
 }

--- a/internal/diagnostic/vault.go
+++ b/internal/diagnostic/vault.go
@@ -1,0 +1,211 @@
+package diagnostic
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/LeGambiArt/wtmcp/internal/config"
+	"github.com/LeGambiArt/wtmcp/internal/plugin"
+	"github.com/LeGambiArt/wtmcp/internal/secrets/vault"
+)
+
+// VaultPasswordSource returns a human-readable label for how the vault
+// password is configured (file, vault IDs, env var, or not configured).
+func VaultPasswordSource(cfg *config.Config, resolver func(string) ([]byte, error)) string {
+	switch {
+	case cfg.Secrets.VaultPasswordFile != "":
+		return fmt.Sprintf("file (%s)", cfg.Secrets.VaultPasswordFile)
+	case len(cfg.Secrets.VaultIDs) > 0:
+		return "vault IDs" //nolint:gosec // status label, not a credential
+	default:
+		if resolver != nil {
+			if pw, err := resolver(""); err == nil {
+				vault.ZeroBytes(pw)
+				return "env var" //nolint:gosec // status label, not a credential
+			}
+		}
+	}
+	return "not configured"
+}
+
+// PrintVaultStatus reports vault password configuration and per-group
+// encryption status to w.
+func PrintVaultStatus(w io.Writer, result *plugin.DiscoveryResult) {
+	cfg := result.Config
+
+	fmt.Fprintf(w, "vault password: %s\n", VaultPasswordSource(cfg, result.VaultResolver))
+
+	if len(cfg.Secrets.VaultIDs) > 0 {
+		fmt.Fprintf(w, "vault IDs: %d configured\n", len(cfg.Secrets.VaultIDs))
+	}
+
+	if result.EnvDir == "" || result.EnvDirError != "" {
+		return
+	}
+
+	entries, err := os.ReadDir(result.EnvDir)
+	if err != nil {
+		return
+	}
+
+	resolve := result.VaultResolver
+	if resolve == nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".env") {
+			continue
+		}
+		group := strings.TrimSuffix(entry.Name(), ".env")
+		path := filepath.Join(result.EnvDir, entry.Name())
+
+		data, err := os.ReadFile(path) //nolint:gosec // diagnostic path from config
+		if err != nil {
+			continue
+		}
+
+		if !vault.IsAnsibleVault(data) {
+			continue
+		}
+
+		header, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
+		if err != nil {
+			fmt.Fprintf(w, "  - %s (encrypted, invalid header)\n", group)
+			continue
+		}
+
+		vaultInfo := "vault " + header.Version
+		if header.VaultID != "" {
+			vaultInfo += " id=" + header.VaultID
+		}
+
+		password, err := resolve(header.VaultID)
+		if err != nil {
+			fmt.Fprintf(w, "  - %s (encrypted, %s, no password)\n", group, vaultInfo)
+			continue
+		}
+
+		plaintext, err := vault.Decrypt(data, password)
+		vault.ZeroBytes(password)
+		vault.ZeroBytes(plaintext)
+		if err != nil {
+			fmt.Fprintf(w, "  - %s (encrypted, %s, decryption failed)\n", group, vaultInfo)
+		} else {
+			fmt.Fprintf(w, "  - %s (encrypted, %s, decryption ok)\n", group, vaultInfo)
+		}
+	}
+
+	PrintCredentialFileStatus(w, cfg, resolve)
+}
+
+// PrintCredentialFileStatus reports vault-encrypted credential files
+// in credentials/<group>/ directories.
+func PrintCredentialFileStatus(w io.Writer, cfg *config.Config, resolve func(string) ([]byte, error)) {
+	if cfg.CredentialsDir == "" {
+		return
+	}
+	groups, err := os.ReadDir(cfg.CredentialsDir)
+	if err != nil {
+		return
+	}
+
+	var found bool
+	for _, group := range groups {
+		if !group.IsDir() {
+			continue
+		}
+		groupDir := filepath.Join(cfg.CredentialsDir, group.Name())
+		files, err := os.ReadDir(groupDir)
+		if err != nil {
+			continue
+		}
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+			path := filepath.Join(groupDir, file.Name())
+			f, err := os.Open(path) //nolint:gosec // credentials dir from config
+			if err != nil {
+				continue
+			}
+			header := make([]byte, 15)
+			n, readErr := f.Read(header)
+			_ = f.Close()
+			if readErr != nil && n == 0 {
+				fmt.Fprintf(w, "  - %s/%s (read error: %v)\n", group.Name(), file.Name(), readErr)
+				continue
+			}
+			if !vault.IsAnsibleVault(header[:n]) {
+				continue
+			}
+
+			if !found {
+				fmt.Fprintf(w, "credential files:\n")
+				found = true
+			}
+
+			data, err := os.ReadFile(path) //nolint:gosec // credentials dir from config
+			if err != nil {
+				fmt.Fprintf(w, "  - %s/%s (encrypted, read error)\n", group.Name(), file.Name())
+				continue
+			}
+
+			hdr, err := vault.ParseHeader(strings.SplitN(string(data), "\n", 2)[0])
+			if err != nil {
+				fmt.Fprintf(w, "  - %s/%s (encrypted, invalid header)\n", group.Name(), file.Name())
+				continue
+			}
+
+			vaultInfo := "vault " + hdr.Version
+			if hdr.VaultID != "" {
+				vaultInfo += " id=" + hdr.VaultID
+			}
+
+			password, err := resolve(hdr.VaultID)
+			if err != nil {
+				fmt.Fprintf(w, "  - %s/%s (encrypted, %s, no password)\n", group.Name(), file.Name(), vaultInfo)
+				continue
+			}
+
+			plaintext, err := vault.Decrypt(data, password)
+			vault.ZeroBytes(password)
+			vault.ZeroBytes(plaintext)
+			if err != nil {
+				fmt.Fprintf(w, "  - %s/%s (encrypted, %s, decryption failed)\n", group.Name(), file.Name(), vaultInfo)
+			} else {
+				fmt.Fprintf(w, "  - %s/%s (encrypted, %s, decryption ok)\n", group.Name(), file.Name(), vaultInfo)
+			}
+		}
+	}
+}
+
+// PrintEnvGroups prints sorted env group names and any errors.
+func PrintEnvGroups(w io.Writer, result *plugin.DiscoveryResult) {
+	fmt.Fprintf(w, "env groups: %d\n", len(result.EnvGroups))
+	groups := make([]string, 0, len(result.EnvGroups))
+	for g := range result.EnvGroups {
+		groups = append(groups, g)
+	}
+	slices.Sort(groups)
+	for _, g := range groups {
+		fmt.Fprintf(w, "  - %s\n", g)
+	}
+	if result.EnvDirError != "" {
+		fmt.Fprintf(w, "env.d directory error: %s\n", result.EnvDirError)
+	}
+	if len(result.EnvErrors) > 0 {
+		fmt.Fprintf(w, "env group errors: %d\n", len(result.EnvErrors))
+		errGroups := make([]string, 0, len(result.EnvErrors))
+		for g := range result.EnvErrors {
+			errGroups = append(errGroups, g)
+		}
+		slices.Sort(errGroups)
+		for _, g := range errGroups {
+			fmt.Fprintf(w, "  - %s: %s\n", g, result.EnvErrors[g])
+		}
+	}
+}

--- a/internal/diagnostic/vault_test.go
+++ b/internal/diagnostic/vault_test.go
@@ -1,0 +1,149 @@
+package diagnostic
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/LeGambiArt/wtmcp/internal/config"
+	"github.com/LeGambiArt/wtmcp/internal/plugin"
+)
+
+func TestVaultPasswordSource_File(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Secrets.VaultPasswordFile = "/tmp/vault-pass"
+
+	got := VaultPasswordSource(cfg, nil)
+	want := "file (/tmp/vault-pass)"
+	if got != want {
+		t.Errorf("VaultPasswordSource = %q, want %q", got, want)
+	}
+}
+
+func TestVaultPasswordSource_VaultIDs(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Secrets.VaultIDs = map[string]string{"prod": "/tmp/prod-pass"}
+
+	got := VaultPasswordSource(cfg, nil)
+	if got != "vault IDs" {
+		t.Errorf("VaultPasswordSource = %q, want %q", got, "vault IDs")
+	}
+}
+
+func TestVaultPasswordSource_EnvVar(t *testing.T) {
+	cfg := &config.Config{}
+	resolver := func(_ string) ([]byte, error) {
+		return []byte("secret"), nil
+	}
+
+	got := VaultPasswordSource(cfg, resolver)
+	if got != "env var" {
+		t.Errorf("VaultPasswordSource = %q, want %q", got, "env var")
+	}
+}
+
+func TestVaultPasswordSource_NotConfigured(t *testing.T) {
+	cfg := &config.Config{}
+
+	got := VaultPasswordSource(cfg, nil)
+	if got != "not configured" {
+		t.Errorf("VaultPasswordSource = %q, want %q", got, "not configured")
+	}
+}
+
+func TestVaultPasswordSource_FileTakesPrecedence(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Secrets.VaultPasswordFile = "/tmp/vault-pass"
+	cfg.Secrets.VaultIDs = map[string]string{"prod": "/tmp/prod-pass"}
+
+	got := VaultPasswordSource(cfg, func(_ string) ([]byte, error) {
+		return []byte("secret"), nil
+	})
+	if got != "file (/tmp/vault-pass)" {
+		t.Errorf("file should take precedence, got %q", got)
+	}
+}
+
+func TestPrintEnvGroups_Sorted(t *testing.T) {
+	result := &plugin.DiscoveryResult{
+		EnvGroups: map[string]map[string]string{
+			"zeta":  {"K": "V"},
+			"alpha": {"K": "V"},
+			"mid":   {"K": "V"},
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintEnvGroups(&buf, result)
+
+	got := buf.String()
+	want := "env groups: 3\n  - alpha\n  - mid\n  - zeta\n"
+	if got != want {
+		t.Errorf("PrintEnvGroups output:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestPrintEnvGroups_WithErrors(t *testing.T) {
+	result := &plugin.DiscoveryResult{
+		EnvGroups: map[string]map[string]string{},
+		EnvErrors: map[string]string{
+			"beta":  "permission denied",
+			"alpha": "file not found",
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintEnvGroups(&buf, result)
+
+	got := buf.String()
+	if !bytes.Contains([]byte(got), []byte("alpha: file not found")) {
+		t.Error("expected alpha error in output")
+	}
+	if !bytes.Contains([]byte(got), []byte("beta: permission denied")) {
+		t.Error("expected beta error in output")
+	}
+}
+
+func TestPrintVaultStatus_NoVault(t *testing.T) {
+	result := &plugin.DiscoveryResult{
+		Config: &config.Config{},
+	}
+
+	var buf bytes.Buffer
+	PrintVaultStatus(&buf, result)
+
+	got := buf.String()
+	if got != "vault password: not configured\n" {
+		t.Errorf("PrintVaultStatus = %q, want %q", got, "vault password: not configured\n")
+	}
+}
+
+func TestPrintCredentialFileStatus_ReadError(t *testing.T) {
+	dir := t.TempDir()
+	groupDir := filepath.Join(dir, "testgroup")
+	if err := os.Mkdir(groupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	credFile := filepath.Join(groupDir, "creds.json")
+	if err := os.WriteFile(credFile, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(credFile, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(credFile, 0o600) })
+
+	cfg := &config.Config{CredentialsDir: dir}
+	resolver := func(_ string) ([]byte, error) {
+		return []byte("pw"), nil
+	}
+
+	var buf bytes.Buffer
+	PrintCredentialFileStatus(&buf, cfg, resolver)
+
+	got := buf.String()
+	if got != "" && !bytes.Contains([]byte(got), []byte("read error")) {
+		t.Errorf("expected empty output or read error, got: %q", got)
+	}
+}

--- a/internal/diagnostic/vault_test.go
+++ b/internal/diagnostic/vault_test.go
@@ -132,7 +132,7 @@ func TestPrintCredentialFileStatus_ReadError(t *testing.T) {
 	if err := os.Chmod(credFile, 0o000); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Chmod(credFile, 0o600) })
+	t.Cleanup(func() { _ = os.Chmod(credFile, 0o600) })
 
 	cfg := &config.Config{CredentialsDir: dir}
 	resolver := func(_ string) ([]byte, error) {


### PR DESCRIPTION
## Summary

Closes #55, closes #56.

Add `wtmcpctl check` command for pre-flight configuration validation.
Extract vault diagnostic logic into shared `internal/diagnostic` package,
fixing a `VaultPasswordCloser` leak in the server-side `runCheck`.

## Changes

- `cmd/wtmcpctl/check.go` — new `check` command using `plugin.Discover()`
- `internal/diagnostic/vault.go` — shared vault/credential diagnostic output (was duplicated in `cmd/wtmcp/main.go` and `cmd/wtmcpctl/check.go`)
- `internal/diagnostic/vault_test.go` — tests for password source detection, sorted output, read error handling
- `cmd/wtmcp/main.go` — replaced inline vault diagnostics with `diagnostic.Print*`, added `defer result.Close()`
- `README-wtmcpctl.md` — documented the `check` command

## Review feedback addressed

- Extracted ~160 lines of duplicated vault diagnostic code into `internal/diagnostic`
- Fixed `VaultPasswordCloser` leak in server-side `runCheck` (`defer result.Close()`)
- Sorted map iteration for deterministic output (`slices.Sort`)
- Report `f.Read` errors instead of silently skipping
- Added 9 tests in `diagnostic/vault_test.go`