### PR TITLE
[#54] docs: add google-docs to Google Plugins table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ authentication:
 |--------|-------------|
 | google-drive | File metadata, search, and export |
 | google-calendar | Calendar events and management |
+| google-docs | Document retrieval, summarization, and editing |
 | google-gmail | Email reading and sending |
 
 All Google plugins require OAuth2 authentication. See [README-wtmcpctl.md](README-wtmcpctl.md)


### PR DESCRIPTION
## Summary

Adds a new row for `google-docs` to the Google Plugins table in `README.md`, as specified in ticket #54.

### Change

| Plugin | Description |
|--------|-------------|
| google-drive | File metadata, search, and export |
| google-calendar | Calendar events and management |
| **google-docs** | **Document retrieval, summarization, and editing** |
| google-gmail | Email reading and sending |

- **File modified:** `README.md` — 1 line inserted
- **Ticket:** #54

## Test Plan

1. Review `README.md` and confirm the Google Plugins table now includes a `google-docs` row.
2. Verify the row is positioned correctly between `google-calendar` and `google-gmail`.
3. Confirm no other files were modified.

## Acceptance Criteria

- [x] `google-docs` row is present in the Google Plugins table in `README.md`
- [x] Description for `google-docs` is accurate and consistent with other entries
- [x] No other files were modified
- [x] Documentation only — no functional changes