### PR TITLE
docs: fix default workdir path in README-wtmcpctl.md (#52)

### DIFF
--- a/README-wtmcpctl.md
+++ b/README-wtmcpctl.md
@@ -16,7 +16,7 @@ This creates `wtmcpctl` in the repository root.
 
 | Flag | Description |
 |---|---|
-| `--workdir <path>` | Override the wtmcp working directory (default: `~/.local/share/wtmcp`) |
+| `--workdir <path>` | Override the wtmcp working directory (default: `~/.config/wtmcp`) |
 | `--verbose`, `-v` | Show verbose output (discovery logs, etc.) |
 | `--version` | Show version information |
 


### PR DESCRIPTION
## Summary

Fixes an incorrect default path documented in the Global Flags table of `README-wtmcpctl.md`.

The `--workdir` flag default was documented as `~/.local/share/wtmcp`, but the actual default defined in `internal/config/env.go` is `~/.config/wtmcp`.

## Changes

- **`README-wtmcpctl.md` (line 19):** Updated the `--workdir` default path from `~/.local/share/wtmcp` to `~/.config/wtmcp` to match the code.

## Test Plan

This is a documentation-only change. No code was modified.

- Verify `README-wtmcpctl.md` shows `~/.config/wtmcp` as the default for `--workdir`.
- Verify `internal/config/env.go` (line 29) still defines `~/.config/wtmcp` as the default.
- Confirm no remaining references to `~/.local/share/wtmcp` exist in the file.

## Acceptance Criteria

- [x] `README-wtmcpctl.md` now documents `~/.config/wtmcp` as the default workdir path
- [x] No remaining references to `~/.local/share/wtmcp` in `README-wtmcpctl.md`
- [x] Only a documentation file was modified (no code changes)
