### PR TITLE
fix: include full commit message in gitlab_get_commits

### DIFF
--- a/plugins/gitlab/tools.go
+++ b/plugins/gitlab/tools.go
@@ -82,6 +82,7 @@ func toolGetCommits(params, _ json.RawMessage) (any, error) {
 			"id":            c.ID,
 			"short_id":      c.ShortID,
 			"title":         c.Title,
+			"message":       c.Message,
 			"author_name":   c.AuthorName,
 			"author_email":  c.AuthorEmail,
 			"authored_date": timeStr(c.AuthoredDate),

--- a/plugins/gitlab/tools_test.go
+++ b/plugins/gitlab/tools_test.go
@@ -244,7 +244,7 @@ func jsonResponse(w http.ResponseWriter, data string) {
 func TestToolGetCommits(t *testing.T) {
 	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/repository/commits") {
-			jsonResponse(w, `[{"id":"abc123","short_id":"abc","title":"Initial commit","author_name":"Alice","author_email":"alice@example.com","web_url":"https://gitlab.example.com/commit/abc123"}]`)
+			jsonResponse(w, `[{"id":"abc123","short_id":"abc","title":"Initial commit","message":"Initial commit\n\nSigned-off-by: Alice <alice@example.com>","author_name":"Alice","author_email":"alice@example.com","web_url":"https://gitlab.example.com/commit/abc123"}]`)
 			return
 		}
 		http.NotFound(w, r)
@@ -269,6 +269,9 @@ func TestToolGetCommits(t *testing.T) {
 	}
 	if commits[0]["author_name"] != "Alice" {
 		t.Errorf("author_name = %v", commits[0]["author_name"])
+	}
+	if commits[0]["message"] != "Initial commit\n\nSigned-off-by: Alice <alice@example.com>" {
+		t.Errorf("message = %v", commits[0]["message"])
 	}
 }
 


### PR DESCRIPTION
The tool only returned the commit title (first line), making it impossible to access information in the commit body such as ticket references, changelog entries, or sign-off lines. The go-gitlab API already provides the full message — pass it through to match the behavior of github_get_pr_commits.