### PR TITLE
build: derive Go toolchain version from go.mod

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-export GOTOOLCHAIN=go1.25.0
+export GOTOOLCHAIN=go$(sed -n 's/^go //p' go.mod)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version-file: 'go.mod'
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -31,9 +31,6 @@ jobs:
   go:
     name: Go
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.25']
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
 
       - name: Build
         run: go build ./...
@@ -61,13 +58,11 @@ jobs:
           govulncheck ./...
 
       - name: Generate SBOM
-        if: matrix.go-version == '1.25'
         run: |
           go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.8.0
           cyclonedx-gomod mod -json -output wtmcp.sbom.json
 
       - name: Upload SBOM
-        if: matrix.go-version == '1.25'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all build build-sandbox plugins test test-sandbox lint fmt vet tidy clean help
 
-# Go toolchain version — must match CI (prevents go.mod bumps from newer local Go)
-GO_TOOLCHAIN_VERSION := 1.25.5
+# Go toolchain version — derived from go.mod to stay in sync with dependency bumps
+GO_TOOLCHAIN_VERSION := $(shell sed -n 's/^go //p' go.mod)
 
 VERSION ?= $(shell cat VERSION 2>/dev/null || echo "dev")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LeGambiArt/wtmcp
 
-go 1.25.8
+go 1.25.10
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
Replace the hardcoded GOTOOLCHAIN in .envrc and GO_TOOLCHAIN_VERSION in Makefile with shell expressions that extract the version from go.mod. This makes go.mod the single source of truth for the Go toolchain version, preventing drift when dependabot bumps transitive dependencies that raise the minimum Go version.
