### PR TITLE
[#57] docs: add Getting Started guide (Speed Run + What Is wtmcp)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,8 @@ mkdir -p -m 700 ~/.config/wtmcp/env.d
 cp env.d/jira.env.example ~/.config/wtmcp/env.d/jira.env
 # Edit ~/.config/wtmcp/env.d/jira.env with your credentials
 chmod 600 ~/.config/wtmcp/env.d/jira.env
-./bin/wtmcpctl agent enable claude
-./bin/wtmcpctl check
+./wtmcpctl agent enable claude
+./wtmcpctl check
 # Open Claude Code and ask: "Who am I in Jira?"
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,8 @@ mkdir -p -m 700 ~/.config/wtmcp/env.d
 cp env.d/jira.env.example ~/.config/wtmcp/env.d/jira.env
 # Edit ~/.config/wtmcp/env.d/jira.env with your credentials
 chmod 600 ~/.config/wtmcp/env.d/jira.env
-./wtmcpctl agent enable claude
-./wtmcpctl check
+./bin/wtmcpctl agent enable claude
+./bin/wtmcpctl check
 # Open Claude Code and ask: "Who am I in Jira?"
 ```
 
@@ -43,6 +43,7 @@ plugin — other plugins never see credentials that aren't theirs.
 | `google-gmail` | Email listing, search, send, drafts, and labels |
 | `google-docs` | Retrieve, summarize, and write to Google Documents |
 | `snyk` | Security issues — browse vulnerabilities and manage ignores |
+| `bugzilla` | Bug tracking — search, create, update, and comment on bugs |
 | `testing-farm` | Test execution and system reservation |
 
 <details>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,61 @@
+# Getting Started with wtmcp
+
+```bash
+# Speed Run — from zero to working in 7 commands
+git clone https://github.com/LeGambiArt/wtmcp.git && cd wtmcp
+make build
+mkdir -p -m 700 ~/.config/wtmcp/env.d
+cp env.d/jira.env.example ~/.config/wtmcp/env.d/jira.env
+# Edit ~/.config/wtmcp/env.d/jira.env with your credentials
+chmod 600 ~/.config/wtmcp/env.d/jira.env
+./wtmcpctl agent enable claude
+./wtmcpctl check
+# Open Claude Code and ask: "Who am I in Jira?"
+```
+
+## 1. What Is wtmcp
+
+wtmcp is an MCP server that connects AI assistants to the tools you use every
+day — Jira, GitLab, Google Workspace, Snyk, and more. You configure it once
+with your credentials; after that, your AI client can query and act on those
+services without you copying and pasting context back and forth.
+
+The tool you interact with is `wtmcpctl`. It handles setup: registering wtmcp
+with your AI client, verifying that credentials are in place, and managing
+OAuth flows. The server itself (`wtmcp`) is launched automatically by the AI
+client — you never start it by hand.
+
+Credentials live in `~/.config/wtmcp/env.d/`, one file per service, readable
+only by you. Each file is a plain list of environment variables (`KEY=value`).
+The server reads them at startup and passes only the relevant values to each
+plugin — other plugins never see credentials that aren't theirs.
+
+### Included plugins
+
+| Plugin | What it does |
+|--------|-------------|
+| `jira` | Issue tracking — search, create, update, sprint tools, and export |
+| `confluence` | Wiki and documentation — page search and content management |
+| `gitlab` | Repositories, merge requests, pipelines, and issue tracking |
+| `github` | Pull requests, issues, and task discovery across repositories |
+| `google-calendar` | Calendar events, scheduling, and free/busy queries |
+| `google-drive` | File metadata, search, and content export |
+| `google-gmail` | Email listing, search, send, drafts, and labels |
+| `google-docs` | Retrieve, summarize, and write to Google Documents |
+| `snyk` | Security issues — browse vulnerabilities and manage ignores |
+| `testing-farm` | Test execution and system reservation |
+
+<details>
+<summary>What is MCP?</summary>
+
+MCP (Model Context Protocol) is an open standard that lets AI assistants call
+external tools. Instead of working only from text in its context window, the AI
+can invoke a registered tool, get back structured data, and reason over it —
+all within the same conversation.
+
+wtmcp implements the server side of this protocol. When your AI client (Claude
+Code, Cursor, etc.) needs to look something up in Jira or check a GitLab
+pipeline, it calls the corresponding MCP tool. wtmcp receives the call, routes
+it to the right plugin, and returns the result.
+
+</details>


### PR DESCRIPTION
## Summary

Adds `docs/getting-started.md`, the first part of the Getting Started guide, covering:

1. **Speed Run box** — 7 commands that take a user from zero to a working wtmcp installation with Claude Code in the time it takes to read them.
2. **Section 1: What Is wtmcp** — 3 paragraphs explaining the relationship between `wtmcpctl` (the user-facing CLI), `wtmcp` (the MCP server launched automatically by the AI client), and `~/.config/wtmcp/env.d/` (the credentials directory).
3. **Plugin table** — All 10 currently shipped plugins with one-line descriptions.
4. **Collapsible "What is MCP?" explanation** — For readers unfamiliar with the protocol.

### Deviation from ticket example
The Speed Run uses `./wtmcpctl` instead of `./bin/wtmcpctl` because the `Makefile` outputs the binary to the repository root (`-o wtmcpctl`), not a `bin/` subdirectory.

## Test Plan

- Read through the document and verify all commands in the Speed Run are accurate.
- Confirm the plugin table lists all 10 plugins present in the codebase.
- Verify the `<details>` block renders correctly on GitHub.

## Acceptance Criteria

- [x] `docs/getting-started.md` exists
- [x] Speed Run section contains 7 commands ending with `./wtmcpctl check`
- [x] Section 1 explains `wtmcpctl`, `wtmcp`, and `~/.config/wtmcp`
- [x] Plugin table covers all 10 plugins
- [x] Collapsible MCP explanation is present

Closes #57