### PR TITLE
feat(wtmcpctl): add user-plugins command to manage user plugin support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
 
       - id: govulncheck
         name: govulncheck
-        entry: bash -c 'cd "$(git rev-parse --show-toplevel)" && command -v govulncheck >/dev/null 2>&1 || go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...'
+        entry: bash -c 'export PATH="$(go env GOPATH)/bin:$PATH" && cd "$(git rev-parse --show-toplevel)" && command -v govulncheck >/dev/null 2>&1 || go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...'
         language: system
         types: [go]
         pass_filenames: false

--- a/cmd/wtmcpctl/common.go
+++ b/cmd/wtmcpctl/common.go
@@ -141,6 +141,58 @@ func discoverPlugins() (map[string]*plugin.Manifest, error) {
 	return result.Manager.Manifests(), nil
 }
 
+// updateConfigBool sets or removes a boolean value at doc[section][key]
+// in the YAML config file. If val is nil, the key is deleted; if the
+// section becomes empty, it is also deleted.
+func updateConfigBool(configPath, section, key string, val *bool) error {
+	data, err := os.ReadFile(configPath) //nolint:gosec // config file path from user
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	var doc map[string]any
+	if len(data) > 0 {
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parse config: %w", err)
+		}
+	}
+	if doc == nil {
+		doc = make(map[string]any)
+	}
+
+	sectionRaw, ok := doc[section]
+	var sectionMap map[string]any
+	if ok {
+		sectionMap, _ = sectionRaw.(map[string]any)
+	}
+	if sectionMap == nil {
+		sectionMap = make(map[string]any)
+	}
+
+	if val != nil {
+		sectionMap[key] = *val
+	} else {
+		delete(sectionMap, key)
+	}
+
+	if len(sectionMap) > 0 {
+		doc[section] = sectionMap
+	} else {
+		delete(doc, section)
+	}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+
+	return atomicWriteFile(configPath, out, 0o600)
+}
+
 // getCredentialsDir returns the credentials directory for the current workdir.
 // Respects GOOGLE_CREDENTIALS_DIR env var (from process environment, not scoped
 // env.d), otherwise uses workdir/credentials/google.

--- a/cmd/wtmcpctl/plugins.go
+++ b/cmd/wtmcpctl/plugins.go
@@ -74,13 +74,50 @@ except those in plugins.disabled).`,
 	RunE:              runPluginsOnly,
 }
 
+var userPluginsCmd = &cobra.Command{
+	Use:   "user-plugins",
+	Short: "Manage user plugin support",
+	Long: `Enable or disable loading of user plugins from {workdir}/plugins/.
+
+User plugins are disabled by default for security. When enabled, plugins
+in your workdir/plugins/ directory will be loaded alongside system plugins.
+
+User plugins cannot:
+- Override system plugins
+- Declare authentication providers
+- Claim credential groups owned by system plugins
+- Use symlinks or hardlinks in handler paths`,
+}
+
+var userPluginsEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable user plugin support",
+	Args:  cobra.NoArgs,
+	RunE:  runUserPluginsEnable,
+}
+
+var userPluginsDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable user plugin support",
+	Args:  cobra.NoArgs,
+	RunE:  runUserPluginsDisable,
+}
+
+var userPluginsStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show user plugin support status",
+	Args:  cobra.NoArgs,
+	RunE:  runUserPluginsStatus,
+}
+
 func init() {
 	pluginsListCmd.Flags().BoolP("plain", "p", false,
 		"Plain text output (no colors or borders)")
 	pluginsOnlyCmd.Flags().Bool("clear", false,
 		"Remove the allowlist, returning to default behavior")
 
-	pluginsCmd.AddCommand(pluginsListCmd, pluginsEnableCmd, pluginsDisableCmd, pluginsOnlyCmd)
+	userPluginsCmd.AddCommand(userPluginsEnableCmd, userPluginsDisableCmd, userPluginsStatusCmd)
+	pluginsCmd.AddCommand(pluginsListCmd, pluginsEnableCmd, pluginsDisableCmd, pluginsOnlyCmd, userPluginsCmd)
 }
 
 // getPluginsDiscoveryResult discovers ALL plugins, ignoring the
@@ -644,4 +681,82 @@ func completeAllPlugins(
 	}
 	sort.Strings(names)
 	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+func runUserPluginsEnable(_ *cobra.Command, _ []string) error {
+	result, err := getDiscoveryResult()
+	if err != nil {
+		return err
+	}
+
+	val := true
+	if err := updateConfigBool(result.ConfigPath, "plugins", "user_plugins", &val); err != nil {
+		return err
+	}
+
+	fmt.Printf("User plugin support enabled in %s\n", result.ConfigPath)
+	fmt.Printf("User plugins will be loaded from: %s/plugins/\n", result.Workdir)
+	fmt.Println("\nSecurity restrictions for user plugins:")
+	fmt.Println("  - Cannot override system plugins")
+	fmt.Println("  - Cannot declare authentication providers")
+	fmt.Println("  - Cannot claim credential groups owned by system plugins")
+	fmt.Println("  - Cannot use symlinks or hardlinks in handler paths")
+	fmt.Println("\nRestart wtmcp for changes to take effect.")
+	return nil
+}
+
+func runUserPluginsDisable(_ *cobra.Command, _ []string) error {
+	result, err := getDiscoveryResult()
+	if err != nil {
+		return err
+	}
+
+	val := false
+	if err := updateConfigBool(result.ConfigPath, "plugins", "user_plugins", &val); err != nil {
+		return err
+	}
+
+	fmt.Printf("User plugin support disabled in %s\n", result.ConfigPath)
+	fmt.Println("Restart wtmcp for changes to take effect.")
+	return nil
+}
+
+func runUserPluginsStatus(_ *cobra.Command, _ []string) error {
+	result, err := getPluginsDiscoveryResult()
+	if err != nil {
+		return err
+	}
+
+	status := "disabled"
+	statusStyle := disabledStyle
+	if result.Config.Plugins.UserPlugins {
+		status = "enabled"
+		statusStyle = enabledStyle
+	}
+
+	fmt.Printf("User plugin support: %s\n", statusStyle.Render(status))
+	fmt.Printf("Config file: %s\n", result.ConfigPath)
+	fmt.Printf("User plugin directory: %s/plugins/\n", result.Workdir)
+
+	if result.Config.Plugins.UserPlugins {
+		var userPlugins []*plugin.Manifest
+		for _, m := range result.Manager.Manifests() {
+			if m.IsUserPlugin {
+				userPlugins = append(userPlugins, m)
+			}
+		}
+		sort.Slice(userPlugins, func(i, j int) bool {
+			return userPlugins[i].Name < userPlugins[j].Name
+		})
+		if len(userPlugins) > 0 {
+			fmt.Printf("\nUser plugins found: %d\n", len(userPlugins))
+			for _, m := range userPlugins {
+				fmt.Printf("  - %s (v%s)\n", m.Name, m.Version)
+			}
+		} else {
+			fmt.Println("\nNo user plugins found in user plugin directory.")
+		}
+	}
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LeGambiArt/wtmcp
 
-go 1.25.10
+go 1.25.11
 
 require gopkg.in/yaml.v3 v3.0.1
 
@@ -75,7 +75,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect
 	google.golang.org/grpc v1.81.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHS
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 h1:SbTAbRFnd5kjQXbczszQ0hdk3ctwYf3qBNH9jIsGclE=
 golang.org/x/exp v0.0.0-20250813145105-42675adae3e6/go.mod h1:4QTo5u+SEIbbKW1RacMZq1YEfOBqeXa19JeshGi+zc4=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=


### PR DESCRIPTION
Add wtmcpctl plugin user-plugins subcommand with enable, disable, and status actions to manage the plugins.user_plugins configuration option.

This provides a convenient CLI interface for toggling user plugin support instead of manually editing config.yaml.

Commands:
- wtmcpctl plugin user-plugins enable: set user_plugins to true
- wtmcpctl plugin user-plugins disable: set user_plugins to false
- wtmcpctl plugin user-plugins status: show current state and list user plugins

Implementation:
- Added updateConfigBool() helper in common.go for atomic boolean config updates
- Added user-plugins command hierarchy in plugins.go with three subcommands
- Status command shows enabled/disabled state and lists discovered user plugins

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>