### PR TITLE
fix: macOS build, test, and process lifetime fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,17 @@ jobs:
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   go:
-    name: Go
-    runs-on: ubuntu-latest
+    name: Go (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install system dependencies
+        if: runner.os == 'Linux'
         run: sudo apt-get install -y libkrb5-dev
 
       - name: Set up Go
@@ -53,16 +57,19 @@ jobs:
         run: go test -race ./...
 
       - name: Vulnerability check
+        if: runner.os == 'Linux'
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           govulncheck ./...
 
       - name: Generate SBOM
+        if: runner.os == 'Linux'
         run: |
           go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.8.0
           cyclonedx-gomod mod -json -output wtmcp.sbom.json
 
       - name: Upload SBOM
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.4
+    rev: v2.12.2
     hooks:
       - id: golangci-lint-full
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LeGambiArt/wtmcp
 
-go 1.25.11
+go 1.26.4
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/internal/auth/kerberos/kerberos_darwin.go
+++ b/internal/auth/kerberos/kerberos_darwin.go
@@ -126,6 +126,8 @@ func Available() bool {
 // Most servers accept pure Kerberos tokens via HTTP Negotiate authentication.
 //
 // The spn parameter should be in the format "HTTP@hostname" (not "HTTP/hostname").
+//
+//nolint:gocritic // dupSubExpr false positives from CGo GSS-API macros
 func GetSPNEGOToken(spn string) (string, error) {
 	initMutex.Lock()
 	avail := available

--- a/internal/fileio/fileio_test.go
+++ b/internal/fileio/fileio_test.go
@@ -13,8 +13,14 @@ import (
 
 func testConfig(t *testing.T) Config {
 	t.Helper()
-	outputDir := t.TempDir()
-	tmpDir := t.TempDir()
+	outputDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	return Config{
 		OutputDir: outputDir,
 		TmpDir:    tmpDir,
@@ -185,7 +191,7 @@ func TestWriteFile_SourcePath(t *testing.T) {
 			setup: func(cfg Config) string {
 				return filepath.Join(cfg.TmpDir, "nonexistent.tmp")
 			},
-			wantErr: true, errMsg: "open",
+			wantErr: true, errMsg: "no such file",
 		},
 		{
 			name: "directory not file",

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -693,12 +693,16 @@ func TestToolDefLocalWrite(t *testing.T) {
 
 func TestManifestValidateConcurrencyMixedAccess(t *testing.T) {
 	base := func(concurrency int, access1, access2 string) *Manifest {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "handler"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // test needs executable
+			t.Fatal(err)
+		}
 		return &Manifest{
 			Name:        "test",
 			Handler:     "handler",
 			Execution:   "persistent",
 			Concurrency: concurrency,
-			Dir:         t.TempDir(),
+			Dir:         dir,
 			Tools: []ToolDef{
 				{Name: "tool_a", Description: "d", Access: access1},
 				{Name: "tool_b", Description: "d", Access: access2},
@@ -727,12 +731,16 @@ func TestManifestValidateConcurrencyMixedAccess(t *testing.T) {
 
 func TestManifestValidateConcurrencyMixedLocalWrite(t *testing.T) {
 	base := func(lw1, lw2 bool) *Manifest {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "handler"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // test needs executable
+			t.Fatal(err)
+		}
 		return &Manifest{
 			Name:        "test",
 			Handler:     "handler",
 			Execution:   "persistent",
 			Concurrency: 2,
-			Dir:         t.TempDir(),
+			Dir:         dir,
 			Tools: []ToolDef{
 				{Name: "tool_a", Description: "d", Access: "read", LocalWrite: lw1},
 				{Name: "tool_b", Description: "d", Access: "read", LocalWrite: lw2},
@@ -757,11 +765,15 @@ func TestManifestValidateConcurrencyMixedLocalWrite(t *testing.T) {
 
 func TestManifestValidateLocalWrite(t *testing.T) {
 	base := func(access string, localWrite bool) *Manifest {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "handler"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // test needs executable
+			t.Fatal(err)
+		}
 		return &Manifest{
 			Name:      "test",
 			Handler:   "handler",
 			Execution: "oneshot",
-			Dir:       t.TempDir(),
+			Dir:       dir,
 			Tools: []ToolDef{{
 				Name:        "t",
 				Description: "d",

--- a/internal/plugin/process.go
+++ b/internal/plugin/process.go
@@ -214,6 +214,9 @@ func (p *Process) doInit(ctx context.Context) error {
 }
 
 func (p *Process) queryResources(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, p.initTimeout)
+	defer cancel()
+
 	id := p.Transport.GenerateID("res")
 	resp, err := p.Transport.SendAndWait(ctx, id, protocol.Message{
 		Type: protocol.TypeListResources,

--- a/internal/plugin/process.go
+++ b/internal/plugin/process.go
@@ -75,7 +75,7 @@ func NewProcess(manifest *Manifest, handler ServiceHandler, cfg ProcessConfig, g
 
 // SetSandbox configures the sandbox manager for this process.
 // When set and enabled, Start() launches via arapuca instead of
-// exec.CommandContext.
+// exec.Command.
 func (p *Process) SetSandbox(sb *sandbox.Manager) {
 	p.sbMgr = sb
 }
@@ -92,14 +92,14 @@ func (p *Process) Start(ctx context.Context) error {
 	var stdout, stderr io.ReadCloser
 
 	if p.sbMgr != nil && p.sbMgr.Enabled() {
-		if err := p.startSandboxed(ctx, &stdin, &stdout, &stderr); err != nil {
+		if err := p.startSandboxed(&stdin, &stdout, &stderr); err != nil {
 			return err
 		}
 	} else {
 		if p.sbMgr != nil {
 			log.Printf("[%s] WARNING: sandbox disabled — process is not isolated", p.manifest.Name)
 		}
-		if err := p.startUnsandboxed(ctx, &stdin, &stdout, &stderr); err != nil {
+		if err := p.startUnsandboxed(&stdin, &stdout, &stderr); err != nil {
 			return err
 		}
 	}
@@ -125,8 +125,8 @@ func (p *Process) Start(ctx context.Context) error {
 	return nil
 }
 
-func (p *Process) startSandboxed(ctx context.Context, stdin *io.WriteCloser, stdout, stderr *io.ReadCloser) error {
-	launchCtx, cancel := context.WithCancel(ctx)
+func (p *Process) startSandboxed(stdin *io.WriteCloser, stdout, stderr *io.ReadCloser) error {
+	launchCtx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
 
 	env := buildPluginEnvMap(p.manifest, p.groupVars)
@@ -151,12 +151,12 @@ func (p *Process) startSandboxed(ctx context.Context, stdin *io.WriteCloser, std
 	return nil
 }
 
-func (p *Process) startUnsandboxed(ctx context.Context, stdin *io.WriteCloser, stdout, stderr *io.ReadCloser) error {
+func (p *Process) startUnsandboxed(stdin *io.WriteCloser, stdout, stderr *io.ReadCloser) error {
 	if err := validateHandlerAtLaunch(p.manifest); err != nil {
 		p.state = StateFailed
 		return err
 	}
-	p.cmd = exec.CommandContext(ctx, p.manifest.HandlerPath()) //nolint:gosec // handler path is validated by Manifest.Validate()
+	p.cmd = exec.Command(p.manifest.HandlerPath()) //nolint:gosec // handler path is validated by Manifest.Validate()
 	p.cmd.Dir = p.manifest.Dir
 	p.cmd.Env = buildPluginEnv(p.manifest, p.groupVars)
 
@@ -258,6 +258,9 @@ func (p *Process) Stop(ctx context.Context) error {
 
 func (p *Process) wait() error {
 	if p.sbProc != nil {
+		if p.cancel != nil {
+			p.cancel()
+		}
 		_, err := p.sbProc.Wait()
 		p.logResourceStats()
 		p.sbProc.Cleanup()

--- a/internal/plugin/process_test.go
+++ b/internal/plugin/process_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/LeGambiArt/wtmcp/internal/protocol"
 )
 
 func TestBuildPluginEnv(t *testing.T) {
@@ -159,6 +161,80 @@ done
 	}
 
 	if err := proc.Stop(ctx); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+}
+
+func TestProcessSurvivesContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+
+	// Handler that responds to init, tool_call, and shutdown
+	script := `#!/bin/bash
+while IFS= read -r line; do
+  type=$(echo "$line" | jq -r '.type')
+  id=$(echo "$line" | jq -r '.id')
+  case "$type" in
+    init)
+      echo "{\"id\":\"$id\",\"type\":\"init_ok\"}"
+      ;;
+    tool_call)
+      echo "{\"id\":\"$id\",\"type\":\"tool_result\",\"result\":{\"alive\":true}}"
+      ;;
+    shutdown)
+      echo "{\"id\":\"$id\",\"type\":\"shutdown_ok\"}"
+      exit 0
+      ;;
+  esac
+done
+`
+	handlerPath := filepath.Join(dir, "handler.sh")
+	if err := os.WriteFile(handlerPath, []byte(script), 0o755); err != nil { //nolint:gosec // test needs executable
+		t.Fatal(err)
+	}
+
+	m := &Manifest{
+		Name:        "test-ctx-cancel",
+		Execution:   "persistent",
+		Handler:     "./handler.sh",
+		Concurrency: 1,
+		Dir:         dir,
+	}
+
+	proc := NewProcess(m, &mockServiceHandler{}, ProcessConfig{
+		InitTimeout:       5 * time.Second,
+		ShutdownTimeout:   5 * time.Second,
+		ShutdownKillAfter: 2 * time.Second,
+		MaxMessageSize:    1024 * 1024,
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := proc.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Cancel the context (simulates MCP request context being cancelled
+	// after plugin_reload returns).
+	cancel()
+	// Give the runtime time to deliver the cancellation signal; if the
+	// old exec.CommandContext behaviour were still in place, the process
+	// would be killed within this window.
+	time.Sleep(100 * time.Millisecond)
+
+	// Process must still be alive — verify by sending a tool call.
+	id := proc.Transport.GenerateID("test")
+	resp, err := proc.Transport.SendAndWait(context.Background(), id, protocol.Message{
+		Type: protocol.TypeToolCall,
+		Tool: "ping",
+	})
+	if err != nil {
+		t.Fatalf("tool call after context cancel failed: %v", err)
+	}
+	if resp.Type != protocol.TypeToolResult {
+		t.Errorf("response type = %q, want tool_result", resp.Type)
+	}
+
+	// Explicit stop must still work.
+	if err := proc.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop failed: %v", err)
 	}
 }

--- a/internal/proxy/saml_test.go
+++ b/internal/proxy/saml_test.go
@@ -325,7 +325,7 @@ func TestHandleSAMLSSO(t *testing.T) {
 			w.WriteHeader(400)
 			return
 		}
-		http.SetCookie(w, &http.Cookie{Name: "JSESSIONID", Value: "test-session", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "JSESSIONID", Value: "test-session", Path: "/", HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode})
 		w.WriteHeader(200)
 	})
 
@@ -508,7 +508,7 @@ func TestInitSAMLSessionFormFirst(t *testing.T) {
 		if r.Form.Get("SAMLResponse") == "" {
 			t.Error("digest request missing SAMLResponse")
 		}
-		http.SetCookie(w, &http.Cookie{Name: "session", Value: "authenticated"})
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "authenticated", HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode})
 		w.WriteHeader(200)
 	})
 

--- a/internal/sandbox/sandbox_stub.go
+++ b/internal/sandbox/sandbox_stub.go
@@ -1,7 +1,7 @@
 //go:build !sandbox
 
 // Package sandbox provides a stub implementation when built without
-// the sandbox tag. All plugins run unsandboxed via exec.CommandContext.
+// the sandbox tag. All plugins run unsandboxed via exec.Command.
 package sandbox
 
 import (

--- a/internal/secrets/securefile/securefile_darwin.go
+++ b/internal/secrets/securefile/securefile_darwin.go
@@ -36,13 +36,13 @@ func createSecureFile(name string, cloexec bool) (*SecureFile, error) {
 
 	path := f.Name()
 	if err := os.Remove(path); err != nil {
-		f.Close()
+		f.Close() //nolint:errcheck,gosec // best-effort cleanup on error
 		return nil, fmt.Errorf("unlink temp file: %w", err)
 	}
 
 	fdNum := f.Fd()
 	if err := setFdCloexec(fdNum, cloexec); err != nil {
-		f.Close()
+		f.Close() //nolint:errcheck,gosec // best-effort cleanup on error
 		return nil, fmt.Errorf("set fd flags: %w", err)
 	}
 

--- a/plugins/bugzilla/helpers_test.go
+++ b/plugins/bugzilla/helpers_test.go
@@ -357,8 +357,12 @@ func TestConfineRead(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !strings.HasPrefix(got, dir) {
-			t.Errorf("result %q not under dir %q", got, dir)
+		resolvedDir, err := filepath.EvalSymlinks(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(got, resolvedDir) {
+			t.Errorf("result %q not under dir %q", got, resolvedDir)
 		}
 	})
 

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -4445,6 +4445,7 @@ func TestParseMarkdownTable(t *testing.T) {
 
 			if got == nil {
 				t.Fatal("expected non-nil result")
+				return
 			}
 
 			if got.numColumns != tt.want.numColumns {
@@ -4589,6 +4590,7 @@ func TestTableParsingWithFormatting(t *testing.T) {
 			table := parseMarkdownTable(tt.lines)
 			if table == nil {
 				t.Fatal("expected non-nil table")
+				return
 			}
 
 			if tt.checkCell.row >= len(table.rows) {
@@ -4764,6 +4766,7 @@ func TestTableSizeLimits(t *testing.T) {
 		table := parseMarkdownTable(lines)
 		if table == nil {
 			t.Fatal("parser should parse large tables (limits enforced at tool level)")
+			return
 		}
 		if table.numColumns != maxTableColumns+5 {
 			t.Errorf("expected %d columns, got %d", maxTableColumns+5, table.numColumns)
@@ -4836,6 +4839,7 @@ func TestInlineCodeInTableCells(t *testing.T) {
 		table := parseMarkdownTable(lines)
 		if table == nil {
 			t.Fatal("expected table")
+			return
 		}
 		cell := table.rows[1].cells[0]
 		foundInlineCode := false
@@ -4860,6 +4864,7 @@ func TestPipeEscaping(t *testing.T) {
 		table := parseMarkdownTable(lines)
 		if table == nil {
 			t.Fatal("expected table")
+			return
 		}
 		if table.numColumns != 2 {
 			t.Errorf("expected 2 columns, got %d", table.numColumns)
@@ -4879,6 +4884,7 @@ func TestPipeEscaping(t *testing.T) {
 		table := parseMarkdownTable(lines)
 		if table == nil {
 			t.Fatal("expected table")
+			return
 		}
 		if table.numColumns != 2 {
 			t.Errorf("expected 2 columns, got %d", table.numColumns)
@@ -4898,6 +4904,7 @@ func TestPipeEscaping(t *testing.T) {
 		table := parseMarkdownTable(lines)
 		if table == nil {
 			t.Fatal("expected table")
+			return
 		}
 		cell := table.rows[1].cells[0]
 		if len(cell.segments) == 0 || cell.segments[0].text != `C:\|` {
@@ -4914,6 +4921,7 @@ func TestPipeEscaping(t *testing.T) {
 		table := parseMarkdownTable(lines)
 		if table == nil {
 			t.Fatal("expected table")
+			return
 		}
 		cell := table.rows[1].cells[0]
 		if len(cell.segments) == 0 || cell.segments[0].text != `a | b | c` {
@@ -4930,6 +4938,7 @@ func TestPipeEscaping(t *testing.T) {
 		table := parseMarkdownTable(lines)
 		if table == nil {
 			t.Fatal("expected table")
+			return
 		}
 		cell := table.rows[1].cells[0]
 		foundBold := false
@@ -5069,6 +5078,7 @@ func TestCollectTableCellRequests(t *testing.T) {
 		reqs := flattenCellRequests(collectTableCellRequests(apiRows, parsedRows))
 		if len(reqs) == 0 {
 			t.Fatal("expected requests for single-cell table")
+			return
 		}
 		if reqs[0].InsertText == nil || reqs[0].InsertText.Text != "only" {
 			t.Error("expected InsertText with 'only'")
@@ -5272,6 +5282,7 @@ func TestConvertTableToRequests(t *testing.T) {
 	// First request should be InsertTable
 	if requests[0].InsertTable == nil {
 		t.Fatal("first request should be InsertTable")
+		return
 	}
 
 	insertTable := requests[0].InsertTable
@@ -5443,11 +5454,13 @@ func TestTableEdgeCases(t *testing.T) {
 		segments := parseMarkdown(markdown)
 		if len(segments) == 0 || !segments[0].isTable {
 			t.Fatal("expected table segment")
+			return
 		}
 
 		table := segments[0].table
 		if len(table.rows) < 2 {
 			t.Fatal("expected at least 2 rows")
+			return
 		}
 
 		// Check empty cell
@@ -5554,11 +5567,13 @@ Paragraph`
 		segments := parseMarkdown(markdown)
 		if len(segments) == 0 || !segments[0].isTable {
 			t.Fatal("expected table segment")
+			return
 		}
 
 		table := segments[0].table
 		if len(table.rows) < 2 {
 			t.Fatal("expected at least 2 rows")
+			return
 		}
 
 		// Check for date field in data row


### PR DESCRIPTION
- Fix golangci-lint warnings and build issues on darwin (kerberos, securefile, sandbox stubs)
- Resolve symlink-related test failures on macOS (fileio, bugzilla, manifest, google-docs)
- Add macOS to the CI test matrix
- Decouple plugin process lifetime from MCP request context and add resource query timeout
- Upgrade Go to 1.26.4 to address security vulnerabilities