### PR TITLE
feat(jira): add set_issue_type and get_issue_types tools

### DIFF
--- a/plugins/jira/helpers.py
+++ b/plugins/jira/helpers.py
@@ -8,6 +8,7 @@ import math
 import re
 
 _ISSUE_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]+-\d+$")
+_PROJECT_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]+$")
 
 _USER_ALIASES = frozenset({"me", "myself", "currentuser"})
 
@@ -96,6 +97,17 @@ def validate_issue_key(key):
     cleaned = key.strip().upper()
     if not _ISSUE_KEY_RE.match(cleaned):
         raise ValueError(f"Invalid issue key: '{key}' (expected format: PROJECT-123)")
+    return cleaned
+
+
+def validate_project_key(key):
+    """Validate and return a cleaned project key.
+
+    Raises ValueError if key doesn't match Jira's project key format.
+    """
+    cleaned = key.strip().upper()
+    if not _PROJECT_KEY_RE.match(cleaned):
+        raise ValueError(f"Invalid project key: '{key}' (expected format: PROJ)")
     return cleaned
 
 

--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -134,6 +134,17 @@ tools:
       link type names.
     params: {}
 
+  - name: jira_get_issue_types
+    access: read
+    description: >
+      Get available issue types for a project. Use before
+      jira_set_issue_type to find valid issue type names.
+      Optionally filter by project key. Cached for 1 hour.
+    params:
+      project_key:
+        type: string
+        description: "Project key to list types for (e.g. PROJ). If omitted, lists all instance types."
+
   - name: jira_flush_cache
     access: read
     description: >
@@ -565,6 +576,25 @@ tools:
         type: string
         required: true
         description: "Comma-separated issue keys to unlink from their parent"
+      dry_run:
+        type: boolean
+        default: true
+
+  - name: jira_set_issue_type
+    access: write
+    description: >
+      Change the issue type of a Jira issue (e.g. Story to Bug,
+      Task to Epic). Use jira_get_issue_types first to find valid
+      type names for the project. Defaults to dry_run=true.
+    params:
+      issue_key:
+        type: string
+        required: true
+        description: "Issue key (e.g. PROJ-123)"
+      issue_type:
+        type: string
+        required: true
+        description: "Target issue type name (e.g. Bug, Story, Task, Epic)"
       dry_run:
         type: boolean
         default: true

--- a/plugins/jira/tests/test_tools_read.py
+++ b/plugins/jira/tests/test_tools_read.py
@@ -577,6 +577,61 @@ class TestGetLinkTypes:
             assert result["error"] == "HTTP 403"
 
 
+# --- jira_get_issue_types ---
+
+
+class TestGetIssueTypes:
+    def test_project_specific(self):
+        project_body = {
+            "key": "PROJ",
+            "issueTypes": [
+                {"id": "1", "name": "Bug", "subtask": False},
+                {"id": "2", "name": "Story", "subtask": False},
+                {"id": "3", "name": "Sub-task", "subtask": True},
+            ],
+        }
+        with _mock_cache_get(None), _mock_http(200, project_body) as mock_http, _mock_cache_set() as mock_set:
+            result = tools_read.get_issue_types({"project_key": "PROJ"})
+            assert result["project_key"] == "PROJ"
+            assert len(result["issue_types"]) == 3
+            assert result["issue_types"][0] == {"id": "1", "name": "Bug", "subtask": False}
+            assert result["issue_types"][2]["subtask"] is True
+            mock_http.assert_called_once_with("GET", "/rest/api/2/project/PROJ")
+            mock_set.assert_called_once()
+            assert mock_set.call_args[1]["ttl"] == 3600
+
+    def test_all_instance_types(self):
+        all_types = [
+            {"id": "10", "name": "Epic", "subtask": False},
+            {"id": "11", "name": "Task", "subtask": False},
+        ]
+        with _mock_cache_get(None), _mock_http(200, all_types) as mock_http, _mock_cache_set():
+            result = tools_read.get_issue_types({})
+            assert "project_key" not in result
+            assert len(result["issue_types"]) == 2
+            mock_http.assert_called_once_with("GET", "/rest/api/2/issuetype")
+
+    def test_cache_hit(self):
+        cached = {"issue_types": [{"id": "1", "name": "Bug", "subtask": False}], "project_key": "PROJ"}
+        with _mock_cache_get(cached):
+            result = tools_read.get_issue_types({"project_key": "PROJ"})
+            assert result == cached
+
+    def test_cache_key_varies_by_project(self):
+        keys = set()
+        body = {"key": "X", "issueTypes": [{"id": "1", "name": "Bug"}]}
+        for proj in ["PROJ", "OTHER"]:
+            with _mock_cache_get(None), _mock_http(200, body), _mock_cache_set() as mock_set:
+                tools_read.get_issue_types({"project_key": proj})
+                keys.add(mock_set.call_args[0][0])
+        assert len(keys) == 2
+
+    def test_http_error(self):
+        with _mock_cache_get(None), _mock_http(404, {"error": "Project not found"}):
+            result = tools_read.get_issue_types({"project_key": "NOPE"})
+            assert result["error"] == "HTTP 404"
+
+
 # --- jira_flush_cache ---
 
 

--- a/plugins/jira/tests/test_tools_read.py
+++ b/plugins/jira/tests/test_tools_read.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import handler
+import pytest
 import tools_read
 
 
@@ -402,8 +403,6 @@ class TestGetIssues:
         assert result == {"issues": [], "count": 0}
 
     def test_invalid_key_raises(self):
-        import pytest
-
         with pytest.raises(ValueError, match="Invalid issue key"):
             tools_read.get_issues({"issue_keys": "bad-key"})
 
@@ -505,8 +504,6 @@ class TestGetTransitions:
             assert result["transitions"][0]["name"] == "Start Progress"
 
     def test_invalid_key(self):
-        import pytest
-
         with pytest.raises(ValueError, match="Invalid issue key"):
             tools_read.get_transitions({"issue_key": "bad"})
 
@@ -598,6 +595,7 @@ class TestGetIssueTypes:
             assert result["issue_types"][2]["subtask"] is True
             mock_http.assert_called_once_with("GET", "/rest/api/2/project/PROJ")
             mock_set.assert_called_once()
+            assert mock_set.call_args[0][0] == "issue_types:project:PROJ"
             assert mock_set.call_args[1]["ttl"] == 3600
 
     def test_all_instance_types(self):
@@ -605,11 +603,12 @@ class TestGetIssueTypes:
             {"id": "10", "name": "Epic", "subtask": False},
             {"id": "11", "name": "Task", "subtask": False},
         ]
-        with _mock_cache_get(None), _mock_http(200, all_types) as mock_http, _mock_cache_set():
+        with _mock_cache_get(None), _mock_http(200, all_types) as mock_http, _mock_cache_set() as mock_set:
             result = tools_read.get_issue_types({})
             assert "project_key" not in result
             assert len(result["issue_types"]) == 2
             mock_http.assert_called_once_with("GET", "/rest/api/2/issuetype")
+            assert mock_set.call_args[0][0] == "issue_types:global"
 
     def test_cache_hit(self):
         cached = {"issue_types": [{"id": "1", "name": "Bug", "subtask": False}], "project_key": "PROJ"}
@@ -630,6 +629,17 @@ class TestGetIssueTypes:
         with _mock_cache_get(None), _mock_http(404, {"error": "Project not found"}):
             result = tools_read.get_issue_types({"project_key": "NOPE"})
             assert result["error"] == "HTTP 404"
+
+    def test_invalid_project_key_raises(self):
+        with pytest.raises(ValueError, match="Invalid project key"):
+            tools_read.get_issue_types({"project_key": "../evil"})
+
+    def test_lowercase_key_normalized(self):
+        body = {"key": "PROJ", "issueTypes": [{"id": "1", "name": "Bug"}]}
+        with _mock_cache_get(None), _mock_http(200, body) as mock_http, _mock_cache_set():
+            result = tools_read.get_issue_types({"project_key": "proj"})
+            assert result["project_key"] == "PROJ"
+            mock_http.assert_called_once_with("GET", "/rest/api/2/project/PROJ")
 
 
 # --- jira_flush_cache ---

--- a/plugins/jira/tests/test_tools_write.py
+++ b/plugins/jira/tests/test_tools_write.py
@@ -811,6 +811,47 @@ class TestClearParent:
             assert "/rest/agile/1.0/epic/none/issue" in agile_call[0][1]
 
 
+# --- jira_set_issue_type ---
+
+
+class TestSetIssueType:
+    def test_dry_run(self):
+        result = tools_write.set_issue_type({"issue_key": "PROJ-1", "issue_type": "Bug", "dry_run": True})
+        assert result["dry_run"] is True
+        assert result["action"] == "jira_set_issue_type"
+        assert result["issue_key"] == "PROJ-1"
+        assert result["issue_type"] == "Bug"
+
+    def test_success(self):
+        with _mock_http(204, {}):
+            result = tools_write.set_issue_type({"issue_key": "PROJ-1", "issue_type": "Story", "dry_run": False})
+            assert result["success"] is True
+            assert result["issue_type"] == "Story"
+
+    def test_sends_correct_payload(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_issue_type({"issue_key": "PROJ-1", "issue_type": "Epic", "dry_run": False})
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body == {"fields": {"issuetype": {"name": "Epic"}}}
+
+    def test_http_error(self):
+        with _mock_http(400, {"errorMessages": ["Cannot change type"]}):
+            result = tools_write.set_issue_type({"issue_key": "PROJ-1", "issue_type": "Epic", "dry_run": False})
+            assert "error" in result
+
+    def test_invalid_key_raises(self):
+        with pytest.raises(ValueError, match="Invalid issue key"):
+            tools_write.set_issue_type({"issue_key": "bad", "issue_type": "Bug"})
+
+    def test_empty_issue_type_raises(self):
+        with pytest.raises(ValueError, match="issue_type is required"):
+            tools_write.set_issue_type({"issue_key": "PROJ-1", "issue_type": ""})
+
+    def test_whitespace_issue_type_raises(self):
+        with pytest.raises(ValueError, match="issue_type is required"):
+            tools_write.set_issue_type({"issue_key": "PROJ-1", "issue_type": "   "})
+
+
 # --- Cache invalidation ---
 
 

--- a/plugins/jira/tools_read.py
+++ b/plugins/jira/tools_read.py
@@ -297,8 +297,7 @@ def get_issue_types(params):
 
     result = {
         "issue_types": [
-            {"id": t.get("id"), "name": t.get("name"), "subtask": t.get("subtask", False)}
-            for t in raw_types
+            {"id": t.get("id"), "name": t.get("name"), "subtask": t.get("subtask", False)} for t in raw_types
         ],
     }
     if project_key:

--- a/plugins/jira/tools_read.py
+++ b/plugins/jira/tools_read.py
@@ -10,6 +10,7 @@ from helpers import (
     http_error,
     is_user_alias,
     validate_issue_key,
+    validate_project_key,
 )
 
 
@@ -277,9 +278,10 @@ def get_link_types(_params):
 
 def get_issue_types(params):
     """Get available issue types for a project, cached for 1 hour."""
-    project_key = params.get("project_key", "")
+    raw_key = params.get("project_key", "")
+    project_key = validate_project_key(raw_key) if raw_key else ""
 
-    cache_key = f"issue_types:{project_key}" if project_key else "issue_types:all"
+    cache_key = f"issue_types:project:{project_key}" if project_key else "issue_types:global"
     cached = handler.cache_get(cache_key)
     if cached:
         return cached

--- a/plugins/jira/tools_read.py
+++ b/plugins/jira/tools_read.py
@@ -275,6 +275,38 @@ def get_link_types(_params):
     return body
 
 
+def get_issue_types(params):
+    """Get available issue types for a project, cached for 1 hour."""
+    project_key = params.get("project_key", "")
+
+    cache_key = f"issue_types:{project_key}" if project_key else "issue_types:all"
+    cached = handler.cache_get(cache_key)
+    if cached:
+        return cached
+
+    if project_key:
+        status, body, _ = handler.http("GET", f"/rest/api/2/project/{project_key}")
+        if status < 200 or status >= 300:
+            return http_error(status, body)
+        raw_types = body.get("issueTypes", []) if isinstance(body, dict) else []
+    else:
+        status, body, _ = handler.http("GET", "/rest/api/2/issuetype")
+        if status < 200 or status >= 300:
+            return http_error(status, body)
+        raw_types = body if isinstance(body, list) else []
+
+    result = {
+        "issue_types": [
+            {"id": t.get("id"), "name": t.get("name"), "subtask": t.get("subtask", False)}
+            for t in raw_types
+        ],
+    }
+    if project_key:
+        result["project_key"] = project_key
+    handler.cache_set(cache_key, result, ttl=3600)
+    return result
+
+
 def flush_cache(_params):
     """Flush all Jira plugin cache entries."""
     handler.cache_flush()
@@ -289,5 +321,6 @@ TOOLS = {
     "jira_get_transitions": get_transitions,
     "jira_get_resolutions": get_resolutions,
     "jira_get_link_types": get_link_types,
+    "jira_get_issue_types": get_issue_types,
     "jira_flush_cache": flush_cache,
 }

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -567,6 +567,31 @@ def clear_parent(params):
     return {"success": True, "issue_keys": issue_keys}
 
 
+def set_issue_type(params):
+    """Change the issue type of a Jira issue."""
+    issue_key = validate_issue_key(params.get("issue_key", ""))
+    issue_type = params.get("issue_type", "")
+    dry_run = params.get("dry_run", True)
+
+    if not issue_type.strip():
+        raise ValueError("issue_type is required")
+
+    if dry_run:
+        return {
+            "dry_run": True,
+            "action": "jira_set_issue_type",
+            "issue_key": issue_key,
+            "issue_type": issue_type,
+        }
+
+    fields = {"issuetype": {"name": issue_type}}
+    status, body, _ = handler.http("PUT", f"/rest/api/2/issue/{issue_key}", body={"fields": fields})
+    if status < 200 or status >= 300:
+        return http_error(status, body)
+    handler.invalidate_cache(issue_key)
+    return {"success": True, "issue_key": issue_key, "issue_type": issue_type}
+
+
 TOOLS = {
     "jira_create_issue": create_issue,
     "jira_add_comment": add_comment,
@@ -588,4 +613,5 @@ TOOLS = {
     "jira_add_issues_to_backlog": add_issues_to_backlog,
     "jira_set_parent": set_parent,
     "jira_clear_parent": clear_parent,
+    "jira_set_issue_type": set_issue_type,
 }


### PR DESCRIPTION
## Summary
- Add `jira_set_issue_type` write tool to change an issue's type (e.g. Story → Bug, Task → Epic) via `PUT /rest/api/2/issue/{key}` with `dry_run=true` default
- Add `jira_get_issue_types` read tool to list available issue types for a project (or all instance types), cached for 1 hour — intended as a discovery step before `set_issue_type`
- 12 new tests (5 read, 7 write) covering dry_run, success, HTTP errors, cache behavior, and input validation

## Test plan
- [x] `pytest plugins/jira/tests/ -v` — 468 passed
- [x] `ruff check` — clean
- [ ] Manual: call `jira_get_issue_types` with a project key, verify returned types
- [ ] Manual: call `jira_set_issue_type` with `dry_run=true`, verify preview
- [ ] Manual: call `jira_set_issue_type` with `dry_run=false`, verify type changes in Jira

🤖 Generated with [Claude Code](https://claude.com/claude-code)