### PR TITLE
[#58] docs: add Prerequisites section to Getting Started guide

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,42 @@
+# Building wtmcp from source
+
+## Requirements
+
+- **Go** — see `go.mod` for the required version
+- **Git**
+- **Python 3.9+** — for Python-based plugins (Jira, Confluence, GitHub,
+  GitLab, Jenkins, Snyk, Testing Farm)
+
+Go auto-downloads the correct toolchain when `GOTOOLCHAIN=auto` is set.
+Check with `go env GOTOOLCHAIN`; enable with `go env -w GOTOOLCHAIN=auto`.
+
+## Build
+
+```bash
+git clone https://github.com/LeGambiArt/wtmcp.git
+cd wtmcp
+make build
+```
+
+Binaries are built in the repository root: `wtmcp` (MCP server) and
+`wtmcpctl` (management CLI). Go plugins are compiled in their plugin
+directories.
+
+## Sandbox support
+
+The default build includes OS-level plugin sandboxing via
+[arapuca](https://github.com/sergio-correia/arapuca). The Makefile
+auto-detects system libarapuca via pkg-config; if not found, it builds
+from the `third_party/arapuca` submodule (requires a Rust toolchain).
+
+To build without sandbox support:
+
+```bash
+make build-nosandbox
+```
+
+## Verify
+
+```bash
+./wtmcpctl check
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,27 +63,41 @@ it to the right plugin, and returns the result.
 
 ## 2. Prerequisites
 
-The table below lists everything you need before running `make build`. Verify
-each tool is available by running the command in the last column.
+You need an AI client that supports MCP: **Claude Code**, **Gemini CLI**,
+or **Cursor**.
 
-| Tool | Minimum version | Required for | Verify |
-|------|-----------------|-------------|--------|
-| [Go](https://go.dev/dl/) | 1.26+ | Building wtmcp and all Go plugins | `go version` |
-| [Git](https://git-scm.com/) | any | Cloning the repository | `git --version` |
-| [Python 3](https://www.python.org/downloads/) | 3.9+ | Jira, Confluence, GitHub, Jenkins, Snyk, and Testing Farm plugins | `python3 --version` |
-| AI client | — | Issuing natural-language commands | — |
+Python 3.9+ is required for the Jira, Confluence, GitHub, GitLab, Jenkins,
+Snyk, and Testing Farm plugins. Go plugins (Bugzilla and the Google
+Workspace suite) work without Python.
 
-**Supported AI clients:** Claude Code, Gemini CLI, or Cursor.
+**Operating system:** Linux and macOS are supported. Windows users should
+use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 
-Go plugins (Bugzilla, GitLab, and the full Google Workspace suite) do not
-require Python.
+## 3. Install wtmcp
 
-**Operating system:** Linux and macOS are supported. Windows users should run
-wtmcp inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
-(Windows Subsystem for Linux).
+### COPR (Fedora / RHEL)
 
-> **Go toolchain auto-download.** If the exact Go toolchain version is not
-> already installed on your system, Go will download it automatically when
-> `GOTOOLCHAIN=auto` is set. Check your current setting with
-> `go env GOTOOLCHAIN` and enable auto-download with
-> `go env -w GOTOOLCHAIN=auto`.
+```bash
+sudo dnf copr enable scorreia/wtmcp
+sudo dnf install wtmcp
+```
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap legambiart/wtmcp
+brew install --HEAD wtmcp
+```
+
+> **Note:** `--HEAD` is required until the 0.1.9 release, after which
+> `brew install wtmcp` will work.
+
+### Build from source
+
+```bash
+git clone https://github.com/LeGambiArt/wtmcp.git && cd wtmcp
+make build
+```
+
+This requires Go and Git. See `go.mod` for the required Go version.
+Binaries are built in the repository root (`wtmcp` and `wtmcpctl`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,3 +60,30 @@ pipeline, it calls the corresponding MCP tool. wtmcp receives the call, routes
 it to the right plugin, and returns the result.
 
 </details>
+
+## 2. Prerequisites
+
+The table below lists everything you need before running `make build`. Verify
+each tool is available by running the command in the last column.
+
+| Tool | Minimum version | Required for | Verify |
+|------|-----------------|-------------|--------|
+| [Go](https://go.dev/dl/) | 1.26+ | Building wtmcp and all Go plugins | `go version` |
+| [Git](https://git-scm.com/) | any | Cloning the repository | `git --version` |
+| [Python 3](https://www.python.org/downloads/) | 3.9+ | Jira, Confluence, GitHub, Jenkins, Snyk, and Testing Farm plugins | `python3 --version` |
+| AI client | — | Issuing natural-language commands | — |
+
+**Supported AI clients:** Claude Code, Gemini CLI, or Cursor.
+
+Go plugins (Bugzilla, GitLab, and the full Google Workspace suite) do not
+require Python.
+
+**Operating system:** Linux and macOS are supported. Windows users should run
+wtmcp inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
+(Windows Subsystem for Linux).
+
+> **Go toolchain auto-download.** If the exact Go toolchain version is not
+> already installed on your system, Go will download it automatically when
+> `GOTOOLCHAIN=auto` is set. Check your current setting with
+> `go env GOTOOLCHAIN` and enable auto-download with
+> `go env -w GOTOOLCHAIN=auto`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,11 +86,8 @@ sudo dnf install wtmcp
 
 ```bash
 brew tap legambiart/wtmcp
-brew install --HEAD wtmcp
+brew install wtmcp
 ```
-
-> **Note:** `--HEAD` is required until the 0.1.9 release, after which
-> `brew install wtmcp` will work.
 
 ### Build from source
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,10 +94,4 @@ brew install --HEAD wtmcp
 
 ### Build from source
 
-```bash
-git clone https://github.com/LeGambiArt/wtmcp.git && cd wtmcp
-make build
-```
-
-This requires Go and Git. See `go.mod` for the required Go version.
-Binaries are built in the repository root (`wtmcp` and `wtmcpctl`).
+See [BUILDING.md](../BUILDING.md) for instructions on building from source.


### PR DESCRIPTION
## Summary

Adds **Section 2 — Prerequisites** to `docs/getting-started.md`, giving users a clear checklist of everything they need before running `make build`.

### Changes

- **Prerequisite table** listing Go 1.26+, Git, Python 3.9+, and an AI client — with minimum versions, scope notes, and `verify` commands.
- **Supported AI clients** callout (Claude Code, Gemini CLI, Cursor).
- **Python scope note** clarifying which plugins require Python (Jira, Confluence, GitHub, Jenkins, Snyk, Testing Farm) and which are pure Go (Bugzilla, GitLab, Google Workspace).
- **OS support note** — Linux/macOS natively; Windows via WSL.
- **Go toolchain auto-download tip** explaining `GOTOOLCHAIN=auto` for users who don't have the exact toolchain version pre-installed.

### Deviations from ticket description

| Item | Ticket said | Implemented | Reason |
|------|------------|-------------|--------|
| Go version | 1.25+ | 1.26+ | `go.mod` specifies `go 1.26.4` |
| GitLab Python dependency | Listed as Python | Listed as Go | Actual handler is Go-based |
| Jenkins | Not mentioned | Added to Python list | Handler is Python-based |

## Test Plan

1. Render `docs/getting-started.md` in a Markdown previewer or GitHub's web UI and confirm the table and callout blocks render correctly.
2. Run each verify command on a clean machine and confirm it produces output (or a useful error if the tool is missing).
3. Confirm no source code, tests, or configuration files were modified (`git diff HEAD~1 --stat`).

## Acceptance Criteria

- [x] Prerequisite table includes Go, Git, Python 3, and AI client rows
- [x] Each row includes a minimum version and a verify command
- [x] Python is scoped to specific plugins only (not listed as globally required)
- [x] Linux/macOS supported; Windows via WSL noted
- [x] Go toolchain auto-download tip present (`GOTOOLCHAIN=auto`)
- [x] Section follows Section 1 (What Is wtmcp) in document order
- [x] No source code changes — documentation only

Closes #58