### PR TITLE
sandbox: allow EvalSymlinks to resolve paths within session directory

### DIFF
--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -1116,6 +1116,12 @@ func (m *Manager) LoadedPlugins() []string {
 	return names
 }
 
+// SessionDir returns the session directory (caller's CWD at startup).
+// Empty if no session directory was determined.
+func (m *Manager) SessionDir() string {
+	return m.sessionDir
+}
+
 // ToolOwner returns the plugin name that owns a tool.
 func (m *Manager) ToolOwner(toolName string) string {
 	name, _ := m.CallTool(context.Background(), toolName)

--- a/internal/plugin/testing.go
+++ b/internal/plugin/testing.go
@@ -20,6 +20,11 @@ func (m *Manager) SetHandle(name string) {
 	m.handles[name] = &Handle{manifest: manifest}
 }
 
+// SetSessionDir sets the session directory for testing.
+func (m *Manager) SetSessionDir(dir string) {
+	m.sessionDir = dir
+}
+
 // SetDisabledPlugin marks a plugin as disabled for testing.
 func (m *Manager) SetDisabledPlugin(name, reason string) {
 	if m.disabled == nil {

--- a/internal/sandbox/integration_test.go
+++ b/internal/sandbox/integration_test.go
@@ -360,6 +360,80 @@ func TestIntegration_EnvPassthrough(t *testing.T) {
 	}
 }
 
+// TestIntegration_SessionDirAccess verifies that a sandboxed process can
+// access files in the session directory. This guards against regressions
+// where path confinement functions fail inside the sandbox (e.g., using
+// filepath.EvalSymlinks which walks ancestors denied by the sandbox).
+//
+// Skipped on macOS: Go's t.TempDir() lives under /var/folders/... whose
+// ancestor directories are not in the Seatbelt profile. When a macOS CI
+// runner is available, consider a variant that uses a stable path with
+// known ancestors (e.g., under /tmp which is /private/tmp on macOS).
+func TestIntegration_SessionDirAccess(t *testing.T) {
+	skipIfIntegrationDisabled(t)
+	if runtime.GOOS == "darwin" {
+		t.Skip("Seatbelt profile does not allow temp dir ancestor paths used by Go tests")
+	}
+
+	bin := buildProbe(t)
+	mgr := integrationTestManager(t)
+
+	// Use a separate directory for SessionDir so we can verify the
+	// sandbox profile grants access via the SessionDir rule, not
+	// just the Dir rule (which always includes the plugin directory).
+	sessionDir := t.TempDir()
+
+	markerPath := filepath.Join(sessionDir, "session-marker.txt")
+	if err := os.WriteFile(markerPath, []byte("session-accessible"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	info := PluginInfo{
+		Name:       "session-access",
+		Dir:        filepath.Dir(bin),
+		Handler:    filepath.Base(bin),
+		SessionDir: sessionDir,
+	}
+
+	t.Run("stat_session_dir", func(t *testing.T) {
+		resp := runProbe(t, mgr, info, nil, probeRequest{Cmd: "stat", Path: sessionDir})
+		if !resp.OK {
+			t.Fatalf("os.Stat(sessionDir) failed inside sandbox: %s", resp.Error)
+		}
+	})
+
+	t.Run("eval_symlinks_session_dir", func(t *testing.T) {
+		// EvalSymlinks succeeds here because sessionDir is in the
+		// sandbox ReadPaths and Landlock grants implicit traversal
+		// of ancestor directories for path_beneath rules.
+		resp := runProbe(t, mgr, info, nil, probeRequest{Cmd: "eval_symlinks", Path: sessionDir})
+		if !resp.OK {
+			t.Fatalf("filepath.EvalSymlinks(sessionDir) failed inside sandbox: %s", resp.Error)
+		}
+	})
+
+	t.Run("read_file_in_session_dir", func(t *testing.T) {
+		resp := runProbe(t, mgr, info, nil, probeRequest{Cmd: "read_file", Path: markerPath})
+		if !resp.OK {
+			t.Fatalf("read file in session dir failed: %s", resp.Error)
+		}
+		if resp.Data != "session-accessible" {
+			t.Errorf("data = %q, want %q", resp.Data, "session-accessible")
+		}
+	})
+
+	t.Run("cannot_write_to_session_dir", func(t *testing.T) {
+		resp := runProbe(t, mgr, info, nil, probeRequest{
+			Cmd:  "write_file",
+			Path: filepath.Join(sessionDir, "hacked.txt"),
+			Data: "pwned",
+		})
+		if resp.OK {
+			t.Error("sandboxed process should NOT be able to write to session dir")
+		}
+	})
+}
+
 func TestIntegration_TmpdirOverride(t *testing.T) {
 	skipIfIntegrationDisabled(t)
 

--- a/internal/sandbox/testdata/probe.go
+++ b/internal/sandbox/testdata/probe.go
@@ -7,6 +7,8 @@
 //	{"cmd": "echo", "msg": "hello"}
 //	{"cmd": "env", "key": "GITLAB_TOKEN"}
 //	{"cmd": "tmpdir"}
+//	{"cmd": "stat", "path": "/some/dir"}
+//	{"cmd": "eval_symlinks", "path": "/some/dir"}
 package main
 
 import (
@@ -14,6 +16,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -73,6 +76,22 @@ func main() {
 
 	case "tmpdir":
 		writeResponse(response{OK: true, Data: os.TempDir()})
+
+	case "stat":
+		info, err := os.Stat(req.Path)
+		if err != nil {
+			writeResponse(response{Error: err.Error()})
+			return
+		}
+		writeResponse(response{OK: true, Data: fmt.Sprintf("mode=%s size=%d", info.Mode(), info.Size())})
+
+	case "eval_symlinks":
+		resolved, err := filepath.EvalSymlinks(req.Path)
+		if err != nil {
+			writeResponse(response{Error: err.Error()})
+			return
+		}
+		writeResponse(response{OK: true, Data: resolved})
 
 	default:
 		writeResponse(response{Error: fmt.Sprintf("unknown cmd: %s", req.Cmd)})

--- a/internal/server/discovery_test.go
+++ b/internal/server/discovery_test.go
@@ -189,6 +189,87 @@ func TestNewSandboxInactiveInjectsWarning(t *testing.T) {
 	}
 }
 
+func TestRegisterSessionResource(t *testing.T) {
+	mgr := plugin.NewManagerForTest()
+	mgr.SetSessionDir("/mock/session/dir")
+	mgr.SetManifest("beta", &plugin.Manifest{Name: "beta"})
+	mgr.SetHandle("beta")
+	mgr.SetManifest("alpha", &plugin.Manifest{Name: "alpha"})
+	mgr.SetHandle("alpha")
+
+	cfg := config.DefaultConfig()
+	index := NewToolIndex(mgr, false)
+	srv, _ := New("test", mgr, cfg, index, nil, nil, nil, nil, true)
+
+	// Initialize the server (required before resource reads).
+	resp := srv.HandleMessage(context.Background(), json.RawMessage(`{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": {"protocolVersion": "2025-03-26",
+		           "clientInfo": {"name": "test", "version": "1"},
+		           "capabilities": {}}
+	}`))
+	initResp, ok := resp.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected JSONRPCResponse for initialize, got %T", resp)
+	}
+	b, _ := json.Marshal(initResp.Result)
+	if !strings.Contains(string(b), "/mock/session/dir") {
+		t.Errorf("initialize instructions should contain session dir, got: %s", b)
+	}
+
+	// Read the session resource.
+	readResp := srv.HandleMessage(context.Background(), json.RawMessage(`{
+		"jsonrpc": "2.0", "id": 2, "method": "resources/read",
+		"params": {"uri": "wtmcp://server/session"}
+	}`))
+	r, ok := readResp.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected JSONRPCResponse for resources/read, got %T", readResp)
+	}
+	rb, _ := json.Marshal(r.Result)
+	content := string(rb)
+	if !strings.Contains(content, "/mock/session/dir") {
+		t.Errorf("session resource should contain session dir, got: %s", content)
+	}
+	// Plugins should appear sorted (alpha before beta).
+	alphaIdx := strings.Index(content, "alpha")
+	betaIdx := strings.Index(content, "beta")
+	if alphaIdx < 0 || betaIdx < 0 {
+		t.Errorf("session resource should list plugin names, got: %s", content)
+	} else if alphaIdx > betaIdx {
+		t.Errorf("plugins should be sorted: alpha (%d) should appear before beta (%d)", alphaIdx, betaIdx)
+	}
+}
+
+func TestRegisterSessionResourceSkippedWithoutSessionDir(t *testing.T) {
+	mgr := plugin.NewManagerForTest()
+	cfg := config.DefaultConfig()
+	index := NewToolIndex(mgr, false)
+	srv, _ := New("test", mgr, cfg, index, nil, nil, nil, nil, true)
+
+	// Initialize.
+	srv.HandleMessage(context.Background(), json.RawMessage(`{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": {"protocolVersion": "2025-03-26",
+		           "clientInfo": {"name": "test", "version": "1"},
+		           "capabilities": {}}
+	}`))
+
+	// List resources — session resource should not appear.
+	listResp := srv.HandleMessage(context.Background(), json.RawMessage(`{
+		"jsonrpc": "2.0", "id": 2, "method": "resources/list",
+		"params": {}
+	}`))
+	r, ok := listResp.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected JSONRPCResponse for resources/list, got %T", listResp)
+	}
+	rb, _ := json.Marshal(r.Result)
+	if strings.Contains(string(rb), "wtmcp://server/session") {
+		t.Error("session resource should NOT be registered when sessionDir is empty")
+	}
+}
+
 func TestDiscoveryFullModeBackwardCompatible(t *testing.T) {
 	mgr := plugin.NewManagerForTest()
 	mgr.SetManifest("alpha", &plugin.Manifest{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -94,12 +95,24 @@ func New(version string, manager *plugin.Manager, cfg *config.Config, index *Too
 	if cfg.Security.ElicitationEnabled() {
 		opts = append(opts, mcpserver.WithElicitation())
 	}
+	var instructions []string
 	if !sandboxBuilt {
-		opts = append(opts, mcpserver.WithInstructions(
+		instructions = append(instructions,
 			"WARNING: This server is running WITHOUT sandbox isolation. "+
 				"Plugin processes have unrestricted access to the filesystem and network. "+
 				"This configuration is unsafe for production use. "+
-				"Exercise caution with tools that write files or make network requests."))
+				"Exercise caution with tools that write files or make network requests.")
+	}
+	if sd := manager.SessionDir(); sd != "" {
+		instructions = append(instructions,
+			fmt.Sprintf("Session directory: %s — "+
+				"file_path parameters in tools that accept local files "+
+				"resolve relative paths against this directory. "+
+				"Output files are written to %s/.wtmcp-data/<plugin>/.",
+				sd, sd))
+	}
+	if len(instructions) > 0 {
+		opts = append(opts, mcpserver.WithInstructions(strings.Join(instructions, "\n\n")))
 	}
 	srv := mcpserver.NewMCPServer("wtmcp", version, opts...)
 
@@ -138,6 +151,9 @@ func New(version string, manager *plugin.Manager, cfg *config.Config, index *Too
 
 	// Register context files as MCP resources
 	registerContextResources(srv, manager, collector)
+
+	// Register session directory info as a server-level resource
+	registerSessionResource(srv, manager, collector)
 
 	// Register resources from resource provider plugins
 	RegisterPluginResources(srv, manager, collector)
@@ -814,6 +830,43 @@ func registerPluginContextResources(srv *mcpserver.MCPServer, manifest *plugin.M
 			},
 		)
 	}
+}
+
+func registerSessionResource(srv *mcpserver.MCPServer, mgr *plugin.Manager, collector *stats.Collector) {
+	sd := mgr.SessionDir()
+	if sd == "" {
+		return
+	}
+	const uri = "wtmcp://server/session"
+	srv.AddResource(
+		mcp.NewResource(uri, "Session directory info",
+			mcp.WithResourceDescription("Session directory, output paths, and file_path resolution"),
+			mcp.WithMIMEType("text/plain"),
+		),
+		func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			var b strings.Builder
+			fmt.Fprintf(&b, "Session directory: %s\n\n", sd)
+			fmt.Fprintf(&b, "Tools that accept a file_path parameter resolve relative paths against this directory.\n")
+			fmt.Fprintf(&b, "Output files are written under: %s/.wtmcp-data/<plugin-name>/\n\n", sd)
+			fmt.Fprintf(&b, "Per-plugin output directories:\n")
+			names := mgr.LoadedPlugins()
+			sort.Strings(names)
+			for _, name := range names {
+				fmt.Fprintf(&b, "  %s: %s/.wtmcp-data/%s/\n", name, sd, name)
+			}
+			content := b.String()
+			if collector != nil {
+				collector.RecordResourceRead(uri, "server", "session", content)
+			}
+			return []mcp.ResourceContents{
+				mcp.TextResourceContents{
+					URI:      uri,
+					MIMEType: "text/plain",
+					Text:     content,
+				},
+			}, nil
+		},
+	)
 }
 
 // processToolActions handles side effects declared in tool results.

--- a/pkg/pathutil/pathutil.go
+++ b/pkg/pathutil/pathutil.go
@@ -1,0 +1,36 @@
+// Package pathutil provides path resolution utilities for plugin
+// handlers running inside OS sandboxes (Seatbelt, Landlock).
+package pathutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ResolvePath resolves a filesystem path using EvalSymlinks when
+// possible. If EvalSymlinks fails with a permission error (expected
+// inside OS sandboxes where lstat on ancestor directories is denied),
+// it falls back to Clean+Abs. Any other EvalSymlinks failure (ELOOP,
+// ENOENT, EIO) is treated as a hard error to prevent symlink bypass
+// when running without a sandbox.
+func ResolvePath(path string) (string, error) {
+	abs, err := filepath.Abs(path) // Abs calls Clean internally
+	if err != nil {
+		return "", fmt.Errorf("abs path: %w", err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err == nil {
+		return resolved, nil
+	}
+	if !os.IsPermission(err) {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+
+	// Permission denied — expected inside the OS sandbox where
+	// lstat on ancestor directories (e.g. /Users) is denied.
+	// Fall back to the cleaned absolute path; the sandbox enforces
+	// symlink confinement at the kernel level.
+	return abs, nil
+}

--- a/pkg/pathutil/pathutil_test.go
+++ b/pkg/pathutil/pathutil_test.go
@@ -1,0 +1,152 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestResolvePath_RealPath(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolvePath(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want, err := filepath.EvalSymlinks(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("ResolvePath = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePath_Symlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+
+	got, err := ResolvePath(link)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("ResolvePath(symlink) = %q, want %q (resolved target)", got, want)
+	}
+}
+
+func TestResolvePath_DanglingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "dangling")
+	if err := os.Symlink("/nonexistent/target", link); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+
+	_, err := ResolvePath(link)
+	if err == nil {
+		t.Fatal("expected error for dangling symlink")
+	}
+}
+
+func TestResolvePath_NonexistentPath(t *testing.T) {
+	_, err := ResolvePath("/tmp/nonexistent-path-for-test-" + t.Name())
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+}
+
+func TestResolvePath_SymlinkLoop(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink loops behave differently on Windows")
+	}
+
+	dir := t.TempDir()
+	linkA := filepath.Join(dir, "loop-a")
+	linkB := filepath.Join(dir, "loop-b")
+	if err := os.Symlink(linkB, linkA); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+	if err := os.Symlink(linkA, linkB); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+
+	_, err := ResolvePath(linkA)
+	if err == nil {
+		t.Fatal("expected error for symlink loop")
+	}
+}
+
+func TestResolvePath_PermissionDeniedFallback(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("cannot test permission denial as root")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod semantics differ on Windows")
+	}
+
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "restricted", "subdir")
+	if err := os.MkdirAll(inner, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(inner, "file.txt")
+	if err := os.WriteFile(target, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove read+execute from the restricted directory so lstat
+	// on subdir fails with EPERM/EACCES — simulating the sandbox.
+	restricted := filepath.Join(outer, "restricted")
+	if err := os.Chmod(restricted, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(restricted, 0o700) }) //nolint:gosec // directory needs execute bit
+
+	got, err := ResolvePath(target)
+	if err != nil {
+		t.Fatalf("ResolvePath should fall back on permission error, got: %v", err)
+	}
+
+	want, err := filepath.Abs(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("ResolvePath = %q, want %q (Clean+Abs fallback)", got, want)
+	}
+}
+
+func TestResolvePath_Directory(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := ResolvePath(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("ResolvePath(dir) = %q, want %q", got, want)
+	}
+}

--- a/plugins/bugzilla/helpers.go
+++ b/plugins/bugzilla/helpers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/LeGambiArt/wtmcp/pkg/handler"
+	"github.com/LeGambiArt/wtmcp/pkg/pathutil"
 )
 
 var cfg struct {
@@ -211,31 +212,33 @@ func confineRead(filePath string, allowedDirs ...string) (string, error) {
 	if filePath == "" {
 		return "", fmt.Errorf("file path is required")
 	}
-	cleaned := filepath.Clean(filePath)
 
-	resolved, err := filepath.EvalSymlinks(cleaned)
-	if err != nil {
-		return "", fmt.Errorf("resolve path: %w", err)
+	if !filepath.IsAbs(filePath) && len(allowedDirs) > 0 && allowedDirs[0] != "" {
+		filePath = filepath.Join(allowedDirs[0], filePath)
 	}
 
-	info, err := os.Stat(resolved)
+	absFile, err := pathutil.ResolvePath(filePath)
 	if err != nil {
-		return "", fmt.Errorf("stat: %w", err)
-	}
-	if !info.Mode().IsRegular() {
-		return "", fmt.Errorf("not a regular file")
+		return "", err
 	}
 
 	for _, dir := range allowedDirs {
 		if dir == "" {
 			continue
 		}
-		resolvedDir, err := filepath.EvalSymlinks(dir)
+		absDir, err := pathutil.ResolvePath(dir)
 		if err != nil {
 			continue
 		}
-		if strings.HasPrefix(resolved, resolvedDir+string(os.PathSeparator)) {
-			return resolved, nil
+		if strings.HasPrefix(absFile, absDir+string(os.PathSeparator)) {
+			info, err := os.Stat(absFile)
+			if err != nil {
+				return "", fmt.Errorf("stat: %w", err)
+			}
+			if !info.Mode().IsRegular() {
+				return "", fmt.Errorf("not a regular file")
+			}
+			return absFile, nil
 		}
 	}
 	return "", fmt.Errorf("path escapes allowed directories")

--- a/plugins/bugzilla/helpers_test.go
+++ b/plugins/bugzilla/helpers_test.go
@@ -357,12 +357,12 @@ func TestConfineRead(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		resolvedDir, err := filepath.EvalSymlinks(dir)
+		expected, err := filepath.EvalSymlinks(dir)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("EvalSymlinks: %v", err)
 		}
-		if !strings.HasPrefix(got, resolvedDir) {
-			t.Errorf("result %q not under dir %q", got, resolvedDir)
+		if !strings.HasPrefix(got, expected) {
+			t.Errorf("result %q not under dir %q", got, expected)
 		}
 	})
 
@@ -396,6 +396,41 @@ func TestConfineRead(t *testing.T) {
 		_, err := confineRead("", dir)
 		if err == nil {
 			t.Fatal("expected error for empty path")
+		}
+	})
+
+	t.Run("symlink escape rejected", func(t *testing.T) {
+		link := filepath.Join(dir, "escape-link")
+		if err := os.Symlink("/etc/passwd", link); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+
+		_, err := confineRead(link, dir)
+		if err == nil {
+			t.Error("expected error for symlink pointing outside allowed dir")
+		}
+	})
+
+	t.Run("symlink loop returns error", func(t *testing.T) {
+		linkA := filepath.Join(dir, "loop-a")
+		linkB := filepath.Join(dir, "loop-b")
+		if err := os.Symlink(linkB, linkA); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+		if err := os.Symlink(linkA, linkB); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+
+		_, err := confineRead(linkA, dir)
+		if err == nil {
+			t.Fatal("expected error for symlink loop")
+		}
+	})
+
+	t.Run("relative traversal rejected", func(t *testing.T) {
+		_, err := confineRead("../../../etc/passwd", dir)
+		if err == nil {
+			t.Fatal("expected error for relative path traversal")
 		}
 	})
 }

--- a/plugins/google-docs/main.go
+++ b/plugins/google-docs/main.go
@@ -11,12 +11,14 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/LeGambiArt/wtmcp/pkg/handler"
+	"github.com/LeGambiArt/wtmcp/pkg/pathutil"
 )
 
 var (
-	docsSvc    *docs.Service
-	sessionDir string
-	plug       *handler.Plugin
+	docsSvc            *docs.Service
+	sessionDir         string
+	resolvedSessionDir string
+	plug               *handler.Plugin
 )
 
 func main() {
@@ -34,6 +36,13 @@ func main() {
 		var cfg map[string]string
 		if err := json.Unmarshal(cfgRaw, &cfg); err == nil {
 			sessionDir = cfg["_session_dir"]
+			if sessionDir != "" {
+				var err error
+				resolvedSessionDir, err = pathutil.ResolvePath(sessionDir)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "warning: resolve session dir: %v\n", err)
+				}
+			}
 		}
 		return nil
 	})

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/LeGambiArt/wtmcp/pkg/pathutil"
 	"github.com/LeGambiArt/wtmcp/plugins/google-docs/highlighter"
 	"google.golang.org/api/docs/v1"
 )
@@ -2603,29 +2604,24 @@ func readFileForWrite(filePath string) ([]byte, error) {
 		filePath = filepath.Join(sessionDir, filePath)
 	}
 
-	resolvedSession, err := filepath.EvalSymlinks(sessionDir)
-	if err != nil {
-		return nil, fmt.Errorf("resolve session dir: %w", err)
+	absSession := resolvedSessionDir
+	if absSession == "" {
+		var err error
+		absSession, err = pathutil.ResolvePath(sessionDir)
+		if err != nil {
+			return nil, fmt.Errorf("resolve session dir: %w", err)
+		}
 	}
-	resolved, err := filepath.EvalSymlinks(filePath)
+	absFile, err := pathutil.ResolvePath(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("resolve path: %w", err)
+		return nil, err
+	}
+	if !strings.HasPrefix(absFile, absSession+string(os.PathSeparator)) &&
+		absFile != absSession {
+		return nil, fmt.Errorf("file path escapes session directory")
 	}
 
-	absSession, err := filepath.Abs(resolvedSession)
-	if err != nil {
-		return nil, fmt.Errorf("abs session dir: %w", err)
-	}
-	absResolved, err := filepath.Abs(resolved)
-	if err != nil {
-		return nil, fmt.Errorf("abs file path: %w", err)
-	}
-	if !strings.HasPrefix(absResolved, absSession+string(os.PathSeparator)) &&
-		absResolved != absSession {
-		return nil, fmt.Errorf("file path escapes session directory: %s", filePath)
-	}
-
-	info, err := os.Stat(resolved)
+	info, err := os.Stat(absFile)
 	if err != nil {
 		return nil, fmt.Errorf("stat file: %w", err)
 	}
@@ -2636,7 +2632,7 @@ func readFileForWrite(filePath string) ([]byte, error) {
 		return nil, fmt.Errorf("file too large: %d bytes (max %d)", info.Size(), maxReadFileSize)
 	}
 
-	return os.ReadFile(resolved)
+	return os.ReadFile(absFile) //nolint:gosec // path validated by ResolvePath+HasPrefix above
 }
 
 type writeParams struct {

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -6243,6 +6243,9 @@ func TestReadFileForWrite(t *testing.T) {
 			t.Skipf("symlinks not supported: %v", err)
 		}
 
+		// Outside the sandbox, EvalSymlinks succeeds and resolves the
+		// symlink target, so the prefix check rejects it. Inside the
+		// sandbox, EvalSymlinks fails but the OS blocks the access.
 		_, err := readFileForWrite(linkPath)
 		if err == nil {
 			t.Fatal("expected error for symlink outside sessionDir")

--- a/plugins/google-drive/main.go
+++ b/plugins/google-drive/main.go
@@ -11,12 +11,14 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/LeGambiArt/wtmcp/pkg/handler"
+	"github.com/LeGambiArt/wtmcp/pkg/pathutil"
 )
 
 var (
-	driveSvc   *drive.Service
-	sessionDir string
-	plug       *handler.Plugin
+	driveSvc           *drive.Service
+	sessionDir         string
+	resolvedSessionDir string
+	plug               *handler.Plugin
 )
 
 func main() {
@@ -34,6 +36,13 @@ func main() {
 		var cfg map[string]string
 		if err := json.Unmarshal(cfgRaw, &cfg); err == nil {
 			sessionDir = cfg["_session_dir"]
+			if sessionDir != "" {
+				var err error
+				resolvedSessionDir, err = pathutil.ResolvePath(sessionDir)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "warning: resolve session dir: %v\n", err)
+				}
+			}
 		}
 		return nil
 	})

--- a/plugins/google-drive/tools.go
+++ b/plugins/google-drive/tools.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
+	"github.com/LeGambiArt/wtmcp/pkg/pathutil"
 	"google.golang.org/api/drive/v3"
 	googleapi "google.golang.org/api/googleapi"
 )
@@ -522,29 +523,24 @@ func confineToSessionDir(filePath string) (string, error) {
 		filePath = filepath.Join(sessionDir, filePath)
 	}
 
-	resolvedSession, err := filepath.EvalSymlinks(sessionDir)
-	if err != nil {
-		return "", fmt.Errorf("resolve session dir: %w", err)
+	absSession := resolvedSessionDir
+	if absSession == "" {
+		var err error
+		absSession, err = pathutil.ResolvePath(sessionDir)
+		if err != nil {
+			return "", fmt.Errorf("resolve session dir: %w", err)
+		}
 	}
-	resolved, err := filepath.EvalSymlinks(filePath)
+	absFile, err := pathutil.ResolvePath(filePath)
 	if err != nil {
-		return "", fmt.Errorf("resolve path: %w", err)
-	}
-
-	absSession, err := filepath.Abs(resolvedSession)
-	if err != nil {
-		return "", fmt.Errorf("abs session dir: %w", err)
-	}
-	absResolved, err := filepath.Abs(resolved)
-	if err != nil {
-		return "", fmt.Errorf("abs file path: %w", err)
+		return "", err
 	}
 
-	if !strings.HasPrefix(absResolved, absSession+string(os.PathSeparator)) &&
-		absResolved != absSession {
+	if !strings.HasPrefix(absFile, absSession+string(os.PathSeparator)) &&
+		absFile != absSession {
 		return "", fmt.Errorf("file_path must be under the session directory")
 	}
-	return absResolved, nil
+	return absFile, nil
 }
 
 var errNoWriteScope = fmt.Errorf("write operations require re-authorization with drive (read-write) scope; " +

--- a/plugins/google-drive/tools_test.go
+++ b/plugins/google-drive/tools_test.go
@@ -1100,6 +1100,10 @@ func TestConfineToSessionDir(t *testing.T) {
 			t.Skipf("symlinks not supported: %v", err)
 		}
 
+		// Outside the sandbox, EvalSymlinks succeeds and resolves the
+		// symlink target, so the prefix check rejects it. Inside the
+		// sandbox, EvalSymlinks fails (ancestor lstat denied) but the
+		// OS sandbox blocks access to the target at the kernel level.
 		if _, err := confineToSessionDir(link); err == nil {
 			t.Error("expected error for symlink pointing outside session dir")
 		}
@@ -1125,6 +1129,13 @@ func TestConfineToSessionDir(t *testing.T) {
 		_, err = confineToSessionDir(filepath.Join(home, ".ssh", "id_rsa"))
 		if err == nil {
 			t.Error("expected error for path under $HOME but outside session dir")
+		}
+	})
+
+	t.Run("relative traversal rejected", func(t *testing.T) {
+		_, err := confineToSessionDir("../../../etc/passwd")
+		if err == nil {
+			t.Fatal("expected error for relative path traversal")
 		}
 	})
 }


### PR DESCRIPTION
Fix `file_path` parameter failing with `lstat /Users: operation not permitted` when `wtmcp`runs sandboxed: the confinement check's `EvalSymlinks` call walks from root, hitting path components not individually listed in the sandbox profile.