### PR TITLE
fix(jira): set_text_field handle array fields

### DIFF
--- a/plugins/jenkins/tests/test_handler.py
+++ b/plugins/jenkins/tests/test_handler.py
@@ -93,7 +93,7 @@ class TestHttpUrlConstruction:
     """Test that http() constructs full URLs from _jenkins_url."""
 
     def test_url_constructed_from_jenkins_url(self, capsys):
-        handler._jenkins_url = "https://jenkins.example.com"  # type: ignore
+        handler._jenkins_url = "https://jenkins.example.com"
 
         captured_msgs = []
         original_send = handler._send
@@ -115,7 +115,7 @@ class TestHttpUrlConstruction:
         assert msg["domains"] == ["jenkins.example.com"]
 
     def test_explicit_url_overrides_jenkins_url(self, capsys):
-        handler._jenkins_url = "https://jenkins.example.com"  # type: ignore
+        handler._jenkins_url = "https://jenkins.example.com"
 
         captured_msgs = []
         original_send = handler._send

--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -363,9 +363,12 @@ tools:
   - name: jira_set_text_field
     access: write
     description: >
-      Set a text field on a Jira issue (e.g. summary, description).
+      Set a text field on a Jira issue (e.g. summary, description, fixVersions).
       Cloud descriptions are converted to ADF automatically.
-      Defaults to dry_run=true.
+      Name-array fields (fixVersions, versions, affectsVersions, components)
+      accept a string or list and are auto-wrapped to [{"name": ...}].
+      For components and labels, prefer the dedicated jira_set_components
+      and jira_set_labels tools. Defaults to dry_run=true.
     params:
       issue_key:
         type: string
@@ -373,7 +376,7 @@ tools:
       field_name:
         type: string
         required: true
-        description: "Field name (e.g. summary, description, fixVersions)"
+        description: "Field name (e.g. summary, description, fixVersions, versions, affectsVersions)"
       value:
         type: string
         required: true

--- a/plugins/jira/tests/test_tools_write.py
+++ b/plugins/jira/tests/test_tools_write.py
@@ -359,6 +359,38 @@ class TestSetTextField:
         )
         assert "name" in result["value_preview"]
 
+    def test_affectsversions_string_to_name_array(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "affectsVersions", "value": "1.0", "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["affectsVersions"] == [{"name": "1.0"}]
+
+    def test_fixversions_list_of_strings_normalized(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "fixVersions", "value": ["v1", "v2"], "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["fixVersions"] == [{"name": "v1"}, {"name": "v2"}]
+
+    def test_components_string_normalized(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "components", "value": "Web", "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["components"] == [{"name": "Web"}]
+
+    def test_components_empty_string_sends_empty_list(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "components", "value": "", "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["components"] == []
+
     def test_plain_string_field_unchanged(self):
         with _mock_http(204, {}) as mock_http:
             tools_write.set_text_field(

--- a/plugins/jira/tests/test_tools_write.py
+++ b/plugins/jira/tests/test_tools_write.py
@@ -321,6 +321,52 @@ class TestSetTextField:
             call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
             assert call_body["fields"]["description"]["type"] == "doc"
 
+    def test_fixversions_string_to_name_array(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "fixVersions", "value": "Acme v2.7", "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["fixVersions"] == [{"name": "Acme v2.7"}]
+
+    def test_versions_string_to_name_array(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "versions", "value": "Acme v2.7", "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["versions"] == [{"name": "Acme v2.7"}]
+
+    def test_fixversions_empty_string_sends_empty_list(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "fixVersions", "value": "", "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["fixVersions"] == []
+
+    def test_fixversions_list_passthrough(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "fixVersions", "value": [{"name": "Acme v2.7"}], "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["fixVersions"] == [{"name": "Acme v2.7"}]
+
+    def test_fixversions_dry_run_shows_converted(self):
+        result = tools_write.set_text_field(
+            {"issue_key": "PROJ-1", "field_name": "fixVersions", "value": "Acme v2.7", "dry_run": True}
+        )
+        assert "name" in result["value_preview"]
+
+    def test_plain_string_field_unchanged(self):
+        with _mock_http(204, {}) as mock_http:
+            tools_write.set_text_field(
+                {"issue_key": "PROJ-1", "field_name": "summary", "value": "New title", "dry_run": False}
+            )
+            call_body = mock_http.call_args[1].get("body") or mock_http.call_args[0][3]
+            assert call_body["fields"]["summary"] == "New title"
+
 
 # --- jira_set_custom_field ---
 

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -267,7 +267,7 @@ def set_text_field(params):
         }
 
     # Cloud v3 API requires ADF for description
-    if handler.is_cloud and field_name == "description":
+    if handler.is_cloud and field_name == "description" and isinstance(value, (str, dict, type(None))):
         value = text_to_adf(value)
 
     status, body, _ = handler.http("PUT", f"/rest/api/2/issue/{issue_key}", body={"fields": {field_name: value}})

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -250,10 +250,12 @@ def set_text_field(params):
     value = params.get("value", "")
     dry_run = params.get("dry_run", True)
 
-    # Version fields expect [{"name": ...}] arrays
-    if field_name in ("fixVersions", "versions"):
+    # Name-array fields expect [{"name": ...}]
+    if field_name in ("fixVersions", "versions", "affectsVersions", "components"):
         if isinstance(value, str):
             value = [{"name": value}] if value.strip() else []
+        elif isinstance(value, list):
+            value = normalize_components(value)
 
     if dry_run:
         return {

--- a/plugins/jira/tools_write.py
+++ b/plugins/jira/tools_write.py
@@ -250,6 +250,11 @@ def set_text_field(params):
     value = params.get("value", "")
     dry_run = params.get("dry_run", True)
 
+    # Version fields expect [{"name": ...}] arrays
+    if field_name in ("fixVersions", "versions"):
+        if isinstance(value, str):
+            value = [{"name": value}] if value.strip() else []
+
     if dry_run:
         return {
             "dry_run": True,


### PR DESCRIPTION
## Problem

`jira_set_text_field` sent values as-is to the Jira API, which fails for fields that expect `[{"name": ...}]` arrays. For example, `fixVersions` expects `[{"name": "Acme v2.7"}]` but received the plain string `"Acme v2.7"`, causing the API to return "data was not an array."

No dedicated tools exist for `fixVersions`, `versions`, or `affectsVersions`, so callers had no working path for these fields. An LLM could also pass `field_name="components"` here instead of using the dedicated `jira_set_components` tool, causing the same silent failure.

## Solution

Detect known name-array fields and auto-wrap values to `[{"name": ...}]` before the PUT call:

- **String input** (`"Acme v2.7"`) → `[{"name": "Acme v2.7"}]`
- **Empty string** (`""`) → `[]` (clears the field)
- **List of strings** (`["v1", "v2"]`) → normalized via `normalize_components` (dicts pass through unchanged)

Converted fields: `fixVersions`, `versions`, `affectsVersions`, `components`. Scalar fields like `summary` are unchanged.

## Details

- Conversion runs before the dry-run check so previews reflect the actual payload sent to Jira.
- `components` is included as a safety net — callers are steered toward the dedicated `jira_set_components` tool via the updated tool description.
- Updated `plugin.yaml` description to list supported array fields and mention the dedicated component/label tools.

<br>
Assisted-by: Claude Opus 4.6