### PR TITLE
proxy(saml): fix multi-leg SSO flows for Workday-style providers

### DIFF
--- a/internal/proxy/saml.go
+++ b/internal/proxy/saml.go
@@ -310,13 +310,16 @@ func (p *peekReadCloser) Close() error { return p.orig.Close() }
 
 // isSAMLChallenge checks if an 8KB peek from a 200 text/html
 // response looks like a SAML challenge. Fast substring pre-filter;
-// structural confirmation via parseSAMLForm happens after the full
-// body is read.
+// structural confirmation via parseSAMLForm or handleSAMLSSO happens
+// after the full body is read.
 func isSAMLChallenge(peek []byte) bool {
 	lower := bytes.ToLower(peek)
-	return bytes.Contains(lower, []byte("<form")) &&
+	if bytes.Contains(lower, []byte("<form")) &&
 		(bytes.Contains(peek, []byte("SAMLRequest")) ||
-			bytes.Contains(peek, []byte("SAMLResponse")))
+			bytes.Contains(peek, []byte("SAMLResponse"))) {
+		return true
+	}
+	return bytes.Contains(lower, []byte("<script")) && jsRedirectRe.Match(peek)
 }
 
 // trySAMLSSO checks if an HTTP response is a SAML SSO auth challenge

--- a/internal/proxy/saml.go
+++ b/internal/proxy/saml.go
@@ -172,6 +172,14 @@ func isDomainAllowedForSSO(rawURL string, baseURL string, allowedDomains []strin
 	return domaincheck.Contains(allowedDomains, host)
 }
 
+func samlCooldownKey(pluginName, fullURL string) string {
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return pluginName + "|" + fullURL
+	}
+	return pluginName + "|" + u.Host + u.Path
+}
+
 func extractHostname(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -297,6 +305,7 @@ func handleSAMLSSO(ctx context.Context, client *http.Client, body []byte, baseUR
 
 const samlInitBodyLimit = 1 << 20 // 1MB
 const samlPeekSize = 8 * 1024     // 8KB
+const samlCooldownDuration = 60 * time.Second
 
 // peekReadCloser wraps a MultiReader (peek + original body) while
 // preserving the original body's Close(). Without this, wrapping in
@@ -345,10 +354,12 @@ func (p *Proxy) trySAMLSSO(ctx context.Context, pluginName string, pa *PluginAut
 		return resp
 	}
 
-	if v, ok := p.samlCooldowns.Load(pluginName); ok {
-		if time.Since(time.Unix(0, v.(int64))) < 60*time.Second {
+	cooldownKey := samlCooldownKey(pluginName, fullURL)
+	if v, ok := p.samlCooldowns.Load(cooldownKey); ok {
+		if ts, ok := v.(int64); ok && time.Since(time.Unix(0, ts)) < samlCooldownDuration {
 			return resp
 		}
+		p.samlCooldowns.Delete(cooldownKey)
 	}
 
 	peek := make([]byte, samlPeekSize)
@@ -369,8 +380,6 @@ func (p *Proxy) trySAMLSSO(ctx context.Context, pluginName string, pa *PluginAut
 		}
 		return resp
 	}
-
-	p.samlCooldowns.Store(pluginName, time.Now().UnixNano())
 
 	rest, err := io.ReadAll(io.LimitReader(resp.Body, samlInitBodyLimit-int64(n)))
 	resp.Body.Close() //nolint:errcheck,gosec
@@ -402,6 +411,10 @@ func (p *Proxy) trySAMLSSO(ctx context.Context, pluginName string, pa *PluginAut
 	}
 	if !ssoOK && action == "" {
 		ssoOK = handleSAMLSSO(ctx, client, body, baseURL, pa.AllowedDomains)
+	}
+
+	if ssoOK {
+		p.samlCooldowns.Store(cooldownKey, time.Now().UnixNano())
 	}
 
 	if !ssoOK {

--- a/internal/proxy/saml.go
+++ b/internal/proxy/saml.go
@@ -19,6 +19,20 @@ import (
 	"github.com/LeGambiArt/wtmcp/internal/protocol"
 )
 
+const (
+	samlUserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
+	samlAccept    = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+	samlMaxLegs   = 5
+)
+
+func setSAMLHeaders(req *http.Request, origin string) {
+	req.Header.Set("User-Agent", samlUserAgent)
+	req.Header.Set("Accept", samlAccept)
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+}
+
 func isAuthRedirect(statusCode int, contentType string) bool {
 	return (statusCode == 401 || statusCode == 403) && strings.Contains(contentType, "text/html")
 }
@@ -247,6 +261,7 @@ func handleSAMLSSO(ctx context.Context, client *http.Client, body []byte, baseUR
 		log.Printf("proxy: saml: invalid redirect URL %q: %v", redirectURL, err)
 		return false
 	}
+	setSAMLHeaders(idpReq, "")
 
 	idpResp, err := safeClient.Do(idpReq)
 	if err != nil {
@@ -286,21 +301,96 @@ func handleSAMLSSO(ctx context.Context, client *http.Client, body []byte, baseUR
 		return false
 	}
 	formReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	setSAMLHeaders(formReq, idpBase)
 
 	formResp, err := safeClient.Do(formReq)
 	if err != nil {
 		log.Printf("proxy: saml: SAML form POST failed: %v", err)
 		return false
 	}
-	io.Copy(io.Discard, formResp.Body) //nolint:errcheck,gosec
-	formResp.Body.Close()              //nolint:errcheck,gosec
-
-	if formResp.StatusCode >= 200 && formResp.StatusCode < 400 {
-		log.Printf("proxy: saml: SSO login completed")
-		return true
+	acsBody, err := io.ReadAll(io.LimitReader(formResp.Body, samlInitBodyLimit))
+	formResp.Body.Close() //nolint:errcheck,gosec
+	if err != nil {
+		log.Printf("proxy: saml: error reading ACS response body: %v", err)
 	}
-	log.Printf("proxy: saml: SAML form POST returned status %d", formResp.StatusCode)
-	return false
+
+	if formResp.StatusCode < 200 || formResp.StatusCode >= 400 {
+		log.Printf("proxy: saml: SAML form POST returned status %d", formResp.StatusCode)
+		return false
+	}
+
+	if legs := followSAMLChain(ctx, safeClient, acsBody, formResp.Request.URL.String(), baseURL, allowedDomains); legs > 0 {
+		log.Printf("proxy: saml: SSO login completed (%d post-ACS legs followed)", legs)
+	} else {
+		log.Printf("proxy: saml: SSO login completed")
+	}
+	return true
+}
+
+// followSAMLChain follows a chain of auto-submit forms or JS
+// redirects in an ACS response. Some SPs (notably Workday) return
+// an HTML page after processing the SAMLResponse that contains a
+// form targeting the auth gateway, which must be submitted to
+// complete session establishment.
+func followSAMLChain(ctx context.Context, client *http.Client, body []byte, currentBase, baseURL string, allowedDomains []string) int {
+	completed := 0
+	for leg := range samlMaxLegs {
+		if len(body) == 0 {
+			break
+		}
+
+		if nextAction, nextData, ok := parseSAMLForm(body, currentBase); ok && len(nextData) > 0 {
+			if !isDomainAllowedForSSO(nextAction, baseURL, allowedDomains) {
+				log.Printf("proxy: saml: post-ACS form action %q not in allowed domains (leg %d)", nextAction, leg+1)
+				break
+			}
+			log.Printf("proxy: saml: ACS response contains form, following (leg %d)", leg+1)
+			followReq, err := http.NewRequestWithContext(ctx, "POST", nextAction, strings.NewReader(nextData.Encode()))
+			if err != nil {
+				log.Printf("proxy: saml: post-ACS chain leg %d: build request failed: %v", leg+1, err)
+				break
+			}
+			followReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			setSAMLHeaders(followReq, "")
+			followResp, err := client.Do(followReq)
+			if err != nil {
+				log.Printf("proxy: saml: post-ACS chain leg %d: request failed: %v", leg+1, err)
+				break
+			}
+			body, _ = io.ReadAll(io.LimitReader(followResp.Body, samlInitBodyLimit))
+			followResp.Body.Close() //nolint:errcheck,gosec
+			currentBase = followResp.Request.URL.String()
+			completed++
+			continue
+		}
+
+		if jsRedirect := extractRedirectURL(body, currentBase); jsRedirect != "" {
+			if !isDomainAllowedForSSO(jsRedirect, baseURL, allowedDomains) {
+				log.Printf("proxy: saml: post-ACS redirect %q not in allowed domains (leg %d)", jsRedirect, leg+1)
+				break
+			}
+			log.Printf("proxy: saml: ACS response contains redirect, following (leg %d)", leg+1)
+			followReq, err := http.NewRequestWithContext(ctx, "GET", jsRedirect, nil)
+			if err != nil {
+				log.Printf("proxy: saml: post-ACS chain leg %d: build request failed: %v", leg+1, err)
+				break
+			}
+			setSAMLHeaders(followReq, "")
+			followResp, err := client.Do(followReq)
+			if err != nil {
+				log.Printf("proxy: saml: post-ACS chain leg %d: request failed: %v", leg+1, err)
+				break
+			}
+			body, _ = io.ReadAll(io.LimitReader(followResp.Body, samlInitBodyLimit))
+			followResp.Body.Close() //nolint:errcheck,gosec
+			currentBase = followResp.Request.URL.String()
+			completed++
+			continue
+		}
+
+		break
+	}
+	return completed
 }
 
 const samlInitBodyLimit = 1 << 20 // 1MB
@@ -409,7 +499,7 @@ func (p *Proxy) trySAMLSSO(ctx context.Context, pluginName string, pa *PluginAut
 		err := followSAMLFormChain(ctx, client, action, formData, baseURL, pa.AllowedDomains)
 		ssoOK = (err == nil)
 	}
-	if !ssoOK && action == "" {
+	if !ssoOK {
 		ssoOK = handleSAMLSSO(ctx, client, body, baseURL, pa.AllowedDomains)
 	}
 
@@ -502,6 +592,7 @@ func InitSAMLSession(ctx context.Context, client *http.Client, initURL, baseURL 
 	if err != nil {
 		return fmt.Errorf("build request for %s: %w", fullURL, err)
 	}
+	setSAMLHeaders(req, "")
 
 	resp, err := safeClient.Do(req)
 	if err != nil {
@@ -542,6 +633,7 @@ func followSAMLFormChain(ctx context.Context, client *http.Client, idpURL string
 		return fmt.Errorf("build IdP request: %w", err)
 	}
 	idpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	setSAMLHeaders(idpReq, "")
 
 	idpResp, err := safeClient.Do(idpReq)
 	if err != nil {
@@ -568,17 +660,23 @@ func followSAMLFormChain(ctx context.Context, client *http.Client, idpURL string
 		return fmt.Errorf("build final SAML request: %w", err)
 	}
 	finalReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	setSAMLHeaders(finalReq, idpBase)
 
 	finalResp, err := safeClient.Do(finalReq)
 	if err != nil {
 		return fmt.Errorf("final SAML POST failed: %w", err)
 	}
-	io.Copy(io.Discard, finalResp.Body) //nolint:errcheck,gosec
-	finalResp.Body.Close()              //nolint:errcheck,gosec
+	finalBody, _ := io.ReadAll(io.LimitReader(finalResp.Body, samlInitBodyLimit))
+	finalResp.Body.Close() //nolint:errcheck,gosec
 
-	if finalResp.StatusCode >= 200 && finalResp.StatusCode < 400 {
-		log.Printf("proxy: saml: proactive SSO login completed")
-		return nil
+	if finalResp.StatusCode < 200 || finalResp.StatusCode >= 400 {
+		return fmt.Errorf("final SAML POST returned status %d", finalResp.StatusCode)
 	}
-	return fmt.Errorf("final SAML POST returned status %d", finalResp.StatusCode)
+
+	if legs := followSAMLChain(ctx, safeClient, finalBody, finalResp.Request.URL.String(), baseURL, allowedDomains); legs > 0 {
+		log.Printf("proxy: saml: proactive SSO login completed (%d post-ACS legs followed)", legs)
+	} else {
+		log.Printf("proxy: saml: proactive SSO login completed")
+	}
+	return nil
 }

--- a/internal/proxy/saml_test.go
+++ b/internal/proxy/saml_test.go
@@ -1302,6 +1302,37 @@ func TestTrySAMLSSO200UppercaseForm(t *testing.T) {
 	}
 }
 
+func TestIsSAMLChallengeJSRedirect(t *testing.T) {
+	tests := []struct {
+		name string
+		peek string
+	}{
+		{
+			"var redirectUrl",
+			`<html><script>var redirectUrl = 'https://wd5.myworkday.com/wday/authgwy/redhat/login.htmld';</script></html>`,
+		},
+		{
+			"var redirectUrl with query params",
+			`<html><script>var redirectUrl = 'https://example.com/authgwy?returnTo=%2fapp';</script></html>`,
+		},
+		{
+			"window.location assignment",
+			`<html><script>window.location = 'https://idp.example.com/sso';</script></html>`,
+		},
+		{
+			"window.location.href assignment",
+			`<html><script>window.location.href = 'https://idp.example.com/auth';</script></html>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !isSAMLChallenge([]byte(tt.peek)) {
+				t.Errorf("isSAMLChallenge should detect JS redirect for %q", tt.name)
+			}
+		})
+	}
+}
+
 func TestIsSAMLChallengeNegative(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1311,6 +1342,9 @@ func TestIsSAMLChallengeNegative(t *testing.T) {
 		{"form without SAML", `<html><form action="/search"><input type="text"/></form></html>`},
 		{"empty", ""},
 		{"json-like", `{"SAMLRequest": "value"}`},
+		{"plain text", `<html><p>Hello world</p></html>`},
+		{"redirectUrl in text", `<html><p>Set redirectUrl param</p></html>`},
+		{"window.location in conditional", `<html><script>if (window.location.hash) { history.replaceState(null, '', window.location.pathname); }</script></html>`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/proxy/saml_test.go
+++ b/internal/proxy/saml_test.go
@@ -1193,6 +1193,75 @@ func TestTrySAMLSSO200Cooldown(t *testing.T) {
 	}
 }
 
+func TestTrySAMLSSO200CooldownAfterFalsePositive(t *testing.T) {
+	var apiCalls, idpCalls atomic.Int32
+	mux := http.NewServeMux()
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/page", func(w http.ResponseWriter, _ *http.Request) {
+		n := apiCalls.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		if n <= 2 {
+			// First two calls: page with JS redirect to self (not a SAML challenge).
+			// This triggers isSAMLChallenge (has <script> + redirectUrl assignment)
+			// but structural validation finds no SAMLRequest/SAMLResponse form
+			// and handleSAMLSSO's redirect leads to a non-SAML page.
+			_, _ = fmt.Fprintf(w, `<html><script>var redirectUrl = '%s/page';</script><p>Normal page</p></html>`, srv.URL)
+			return
+		}
+		// Third call: real SAML challenge
+		_, _ = fmt.Fprintf(w, `<html><form action="%s/idp">
+			<input type="hidden" name="SAMLRequest" value="req"/>
+		</form></html>`, srv.URL)
+	})
+	mux.HandleFunc("/idp", func(w http.ResponseWriter, _ *http.Request) {
+		idpCalls.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><form action="%s/acs">
+			<input type="hidden" name="SAMLResponse" value="resp"/>
+		</form></html>`, srv.URL)
+	})
+	mux.HandleFunc("/acs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	jar, _ := cookiejar.New(nil)
+	client := srv.Client()
+	client.Jar = jar
+
+	p := newTestProxy(client)
+	pa := testPluginAuth(srv.URL)
+	pa.Client = client
+	pa.IsKerberos = true
+	p.RegisterPlugin("testfpcooldown", pa)
+
+	// First call: false positive — isSAMLChallenge triggers but SSO fails
+	p.Execute(context.Background(), "testfpcooldown", protocol.Message{
+		ID: "req-fp1", Type: protocol.TypeHTTPRequest,
+		Method: "GET", Path: "/page",
+	})
+	if idpCalls.Load() != 0 {
+		t.Fatalf("IdP should not be called on false positive (got %d)", idpCalls.Load())
+	}
+
+	// Second call: another false positive — must NOT be blocked by cooldown
+	// (cooldown should not have been set on the failed first attempt)
+	p.Execute(context.Background(), "testfpcooldown", protocol.Message{
+		ID: "req-fp2", Type: protocol.TypeHTTPRequest,
+		Method: "GET", Path: "/page",
+	})
+
+	// Third call: real SAML challenge — must trigger SSO
+	p.Execute(context.Background(), "testfpcooldown", protocol.Message{
+		ID: "req-real", Type: protocol.TypeHTTPRequest,
+		Method: "GET", Path: "/page",
+	})
+	if idpCalls.Load() != 1 {
+		t.Errorf("IdP calls = %d, want 1 (real SAML challenge should trigger SSO even after false positives)", idpCalls.Load())
+	}
+}
+
 func TestTrySAMLSSO200RetryStillSAML(t *testing.T) {
 	var apiCalls atomic.Int32
 	mux := http.NewServeMux()

--- a/internal/proxy/saml_test.go
+++ b/internal/proxy/saml_test.go
@@ -362,6 +362,137 @@ func TestHandleSAMLSSO(t *testing.T) {
 	}
 }
 
+func TestHandleSAMLSSOMultiLeg(t *testing.T) {
+	var (
+		idpHit  atomic.Int32
+		acsHit  atomic.Int32
+		leg2Hit atomic.Int32
+	)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	srvHost, _ := url.Parse(srv.URL)
+
+	mux.HandleFunc("/idp", func(w http.ResponseWriter, _ *http.Request) {
+		idpHit.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><body class="saml-post-binding">
+			<form action="%s/acs">
+				<input type="hidden" name="SAMLResponse" value="resp" />
+			</form></body></html>`, srv.URL)
+	})
+	mux.HandleFunc("/acs", func(w http.ResponseWriter, _ *http.Request) {
+		acsHit.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><body onload="document.forms[0].submit()">
+			<form action="%s/authgwy/acs">
+				<input type="hidden" name="token" value="session-token" />
+			</form></body></html>`, srv.URL)
+	})
+	mux.HandleFunc("/authgwy/acs", func(w http.ResponseWriter, _ *http.Request) {
+		leg2Hit.Add(1)
+		http.SetCookie(w, &http.Cookie{Name: "JSESSIONID", Value: "main-app", Path: "/", HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode}) //nolint:gosec
+		w.WriteHeader(200)
+	})
+
+	jar, _ := cookiejar.New(nil)
+	client := srv.Client()
+	client.Jar = jar
+
+	body := fmt.Sprintf(`<html><meta http-equiv="refresh" content="0;url=%s/idp" /></html>`, srv.URL)
+	ok := handleSAMLSSO(context.Background(), client, []byte(body), srv.URL, []string{srvHost.Hostname()})
+	if !ok {
+		t.Fatal("expected handleSAMLSSO to succeed")
+	}
+	if idpHit.Load() != 1 {
+		t.Errorf("IdP hit = %d, want 1", idpHit.Load())
+	}
+	if acsHit.Load() != 1 {
+		t.Errorf("ACS hit = %d, want 1", acsHit.Load())
+	}
+	if leg2Hit.Load() != 1 {
+		t.Errorf("leg 2 hit = %d, want 1", leg2Hit.Load())
+	}
+}
+
+func TestHandleSAMLSSOMultiLegDomainBlock(t *testing.T) {
+	var acsHit atomic.Int32
+
+	mux := http.NewServeMux()
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	srvHost, _ := url.Parse(srv.URL)
+
+	mux.HandleFunc("/idp", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><body class="saml-post-binding">
+			<form action="%s/acs">
+				<input type="hidden" name="SAMLResponse" value="resp" />
+			</form></body></html>`, srv.URL)
+	})
+	mux.HandleFunc("/acs", func(w http.ResponseWriter, _ *http.Request) {
+		acsHit.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, `<html><form action="https://evil.example.com/steal">
+			<input type="hidden" name="token" value="secret" />
+		</form></html>`)
+	})
+
+	jar, _ := cookiejar.New(nil)
+	client := srv.Client()
+	client.Jar = jar
+
+	body := fmt.Sprintf(`<html><meta http-equiv="refresh" content="0;url=%s/idp" /></html>`, srv.URL)
+	ok := handleSAMLSSO(context.Background(), client, []byte(body), srv.URL, []string{srvHost.Hostname()})
+	if !ok {
+		t.Fatal("SSO should succeed (ACS POST worked), but leg 2 should be blocked")
+	}
+	if acsHit.Load() != 1 {
+		t.Errorf("ACS hit = %d, want 1", acsHit.Load())
+	}
+}
+
+func TestHandleSAMLSSOMultiLegCap(t *testing.T) {
+	var legHits atomic.Int32
+
+	mux := http.NewServeMux()
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	srvHost, _ := url.Parse(srv.URL)
+
+	mux.HandleFunc("/idp", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><body class="saml-post-binding">
+			<form action="%s/acs">
+				<input type="hidden" name="SAMLResponse" value="resp" />
+			</form></body></html>`, srv.URL)
+	})
+	mux.HandleFunc("/acs", func(w http.ResponseWriter, _ *http.Request) {
+		legHits.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><form action="%s/acs">
+			<input type="hidden" name="loop" value="again" />
+		</form></html>`, srv.URL)
+	})
+
+	jar, _ := cookiejar.New(nil)
+	client := srv.Client()
+	client.Jar = jar
+
+	body := fmt.Sprintf(`<html><meta http-equiv="refresh" content="0;url=%s/idp" /></html>`, srv.URL)
+	_ = handleSAMLSSO(context.Background(), client, []byte(body), srv.URL, []string{srvHost.Hostname()})
+
+	// 1 initial ACS hit + samlMaxLegs follow-up hits
+	want := int32(1 + samlMaxLegs)
+	if legHits.Load() != want {
+		t.Errorf("ACS hit count = %d, want %d (1 initial + %d capped legs)", legHits.Load(), want, samlMaxLegs)
+	}
+}
+
 func TestHandleSAMLSSONoRedirect(t *testing.T) {
 	body := `<html><body>Access denied, no redirect</body></html>`
 	ok := handleSAMLSSO(context.Background(), &http.Client{}, []byte(body), "https://example.com", nil)
@@ -621,6 +752,61 @@ func TestInitSAMLSessionIdPDomainBlocked(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not in allowed domains") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestInitSAMLSessionFormFirstMultiLeg(t *testing.T) {
+	var step atomic.Int32
+	mux := http.NewServeMux()
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	// Step 1: init URL returns form with SAMLRequest
+	mux.HandleFunc("/saml.redirect", func(w http.ResponseWriter, _ *http.Request) {
+		step.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><form action="%s/idp/saml">
+			<input type="hidden" name="SAMLRequest" value="req"/>
+			<input type="hidden" name="RelayState" value="/"/>
+		</form></html>`, srv.URL)
+	})
+
+	// Step 2: IdP returns SAMLResponse
+	mux.HandleFunc("/idp/saml", func(w http.ResponseWriter, _ *http.Request) {
+		step.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><form action="%s/saml.digest">
+			<input type="hidden" name="SAMLResponse" value="resp"/>
+			<input type="hidden" name="RelayState" value="/"/>
+		</form></html>`, srv.URL)
+	})
+
+	// Step 3: ACS processes SAMLResponse, returns form to auth gateway
+	mux.HandleFunc("/saml.digest", func(w http.ResponseWriter, _ *http.Request) {
+		step.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><form action="%s/authgwy/acs">
+			<input type="hidden" name="token" value="session-token"/>
+		</form></html>`, srv.URL)
+	})
+
+	// Step 4: auth gateway sets session cookie
+	mux.HandleFunc("/authgwy/acs", func(w http.ResponseWriter, _ *http.Request) {
+		step.Add(1)
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "authenticated", HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode})
+		w.WriteHeader(200)
+	})
+
+	jar, _ := cookiejar.New(nil)
+	client := srv.Client()
+	client.Jar = jar
+
+	err := InitSAMLSession(context.Background(), client, "/saml.redirect", srv.URL, []string{})
+	if err != nil {
+		t.Fatalf("InitSAMLSession failed: %v", err)
+	}
+	if step.Load() != 4 {
+		t.Errorf("expected 4 steps, got %d (multi-leg chain not fully followed)", step.Load())
 	}
 }
 
@@ -1100,6 +1286,75 @@ func TestTrySAMLSSO200POSTNotReplayed(t *testing.T) {
 	}
 	if resp.Status != 200 {
 		t.Errorf("status = %d, want 200", resp.Status)
+	}
+}
+
+func TestTrySAMLSSO200WithNonSAMLFormAndRedirect(t *testing.T) {
+	var apiCalls atomic.Int32
+	mux := http.NewServeMux()
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	srvHost, _ := url.Parse(srv.URL)
+
+	mux.HandleFunc("/page", func(w http.ResponseWriter, _ *http.Request) {
+		n := apiCalls.Add(1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "text/html")
+			// Page with a non-SAML first form (search bar with hidden
+			// CSRF token) AND a second form with SAMLRequest. The
+			// pre-filter triggers (page has <form> + SAMLRequest),
+			// but parseSAMLForm picks up the first form (search bar).
+			// formData.Get("SAMLRequest") is empty, so followSAMLFormChain
+			// is not called. Without the widened fallback, the condition
+			// action == "" is false → handleSAMLSSO is skipped.
+			// With the widened fallback, handleSAMLSSO is tried and
+			// follows the meta-refresh redirect.
+			_, _ = fmt.Fprintf(w, `<html>
+				<meta http-equiv="refresh" content="0;url=%s/idp/sso" />
+				<form action="%s/search">
+					<input type="hidden" name="csrf" value="tok"/>
+				</form>
+				<form action="%s/idp/sso">
+					<input type="hidden" name="SAMLRequest" value="req"/>
+				</form>
+				</html>`, srv.URL, srv.URL, srv.URL)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"data":"ok"}`)
+	})
+	mux.HandleFunc("/idp/sso", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><body class="saml-post-binding">
+			<form action="%s/saml/consume">
+				<input type="hidden" name="SAMLResponse" value="resp"/>
+			</form></body></html>`, srv.URL)
+	})
+	mux.HandleFunc("/saml/consume", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	jar, _ := cookiejar.New(nil)
+	client := srv.Client()
+	client.Jar = jar
+
+	p := newTestProxy(client)
+	pa := testPluginAuth(srv.URL)
+	pa.Client = client
+	pa.IsKerberos = true
+	pa.AllowedDomains = []string{srvHost.Hostname()}
+	p.RegisterPlugin("testfallback", pa)
+
+	resp := p.Execute(context.Background(), "testfallback", protocol.Message{
+		ID: "req-fallback", Type: protocol.TypeHTTPRequest,
+		Method: "GET", Path: "/page",
+	})
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	if apiCalls.Load() != 2 {
+		t.Errorf("api calls = %d, want 2 (non-SAML form should not block redirect-based SSO fallback)", apiCalls.Load())
 	}
 }
 


### PR DESCRIPTION
Fix SAML SSO for service providers that use multi-leg auth chains (e.g., Workday) by
following form-based redirects after the ACS POST, detecting JS redirect patterns as
SAML challenges, and scoping SSO cooldown per-URL instead of per-plugin so different
endpoints on the same service can authenticate independently.