### PR TITLE
fix(google-docs): anchor links and numbered list rendering

### DIFF
--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -811,7 +811,8 @@ func detectCode(doc *docs.Document) *CodeAnnotations {
 }
 
 // indentDepth converts a leading whitespace string to a nesting depth.
-// Per the markdown standard, each nesting level requires 4 spaces or 1 tab.
+// Each tab or 4-space group adds one level. A trailing group of 2-3
+// spaces also counts as one level, matching common markdown conventions.
 func indentDepth(indent string) int {
 	depth := 0
 	i := 0
@@ -824,7 +825,11 @@ func indentDepth(indent string) int {
 			depth++
 			i += 4
 		default:
-			i++
+			remaining := len(indent) - i
+			if remaining >= 2 {
+				depth++
+			}
+			i = len(indent)
 		}
 	}
 	return depth

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -1727,6 +1727,10 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 			}
 		}
 
+		// Resolve anchor links now, while Phase 1 indices are still valid.
+		// Phase 2 cell population shifts post-table indices forward.
+		anchorWarnings := resolveAnchorLinks(docID, allDeferredAnchors)
+
 		// --- Phase 2: populate all table cells (chunked) ---
 		//
 		// Tables are processed in reverse document order so that cell
@@ -1749,8 +1753,6 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 			}
 			totalReplies += len(resp.Replies)
 		}
-
-		anchorWarnings := resolveAnchorLinks(docID, allDeferredAnchors)
 
 		result := map[string]any{
 			"document_id":  docID,

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -1750,16 +1750,20 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 			totalReplies += len(resp.Replies)
 		}
 
-		resolveAnchorLinks(docID, allDeferredAnchors)
+		anchorWarnings := resolveAnchorLinks(docID, allDeferredAnchors)
 
-		return map[string]any{
+		result := map[string]any{
 			"document_id":  docID,
 			"title":        title,
 			"status":       "success",
 			"insert_index": insertIndex,
 			"replies":      totalReplies,
 			"tables":       tableCount,
-		}, nil
+		}
+		if len(anchorWarnings) > 0 {
+			result["unresolved_anchors"] = anchorWarnings
+		}
+		return result, nil
 	}
 
 	// No tables — single-batch insertion.
@@ -1770,16 +1774,20 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 		return nil, fmt.Errorf("batch update: %w", err)
 	}
 
-	resolveAnchorLinks(docID, deferredAnchors)
+	anchorWarnings := resolveAnchorLinks(docID, deferredAnchors)
 
-	return map[string]any{
+	result := map[string]any{
 		"document_id":  docID,
 		"title":        title,
 		"status":       "success",
 		"insert_index": insertIndex,
 		"replies":      len(resp.Replies),
 		"tables":       0,
-	}, nil
+	}
+	if len(anchorWarnings) > 0 {
+		result["unresolved_anchors"] = anchorWarnings
+	}
+	return result, nil
 }
 
 // collectTableCellRequests builds all cell-population requests for a table in
@@ -1996,8 +2004,10 @@ func populateTableCell(cell *tableCell, cellStartIndex int64) []*docs.Request {
 }
 
 type deferredAnchor struct {
-	text string
-	slug string
+	startIndex    int64
+	endIndex      int64
+	tabsAtCollect int64
+	slug          string
 }
 
 // convertMarkdownToRequests converts markdown segments to Google Docs API requests.
@@ -2529,8 +2539,10 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 			fields = []string{"weightedFontFamily", "bold", "italic", "underline", "strikethrough"}
 			if seg.anchorSlug != "" {
 				deferredAnchors = append(deferredAnchors, deferredAnchor{
-					text: seg.text,
-					slug: seg.anchorSlug,
+					startIndex:    currentIndex,
+					endIndex:      endIndex,
+					tabsAtCollect: tabsInserted,
+					slug:          seg.anchorSlug,
 				})
 			} else if seg.linkURL != "" {
 				textStyle.Link = &docs.Link{
@@ -2548,8 +2560,10 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 
 			if seg.anchorSlug != "" {
 				deferredAnchors = append(deferredAnchors, deferredAnchor{
-					text: seg.text,
-					slug: seg.anchorSlug,
+					startIndex:    currentIndex,
+					endIndex:      endIndex,
+					tabsAtCollect: tabsInserted,
+					slug:          seg.anchorSlug,
 				})
 			} else if seg.linkURL != "" {
 				textStyle.Link = &docs.Link{
@@ -2655,15 +2669,14 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 	return requests, currentIndex - tabsInserted, deferredAnchors
 }
 
-func resolveAnchorLinks(docID string, anchors []deferredAnchor) {
+func resolveAnchorLinks(docID string, anchors []deferredAnchor) []string {
 	if len(anchors) == 0 {
-		return
+		return nil
 	}
 
 	doc, err := docsSvc.Documents.Get(docID).Do()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: resolveAnchorLinks: failed to read document for heading resolution: %v\n", err)
-		return
+		return []string{fmt.Sprintf("failed to read document for heading resolution: %v", err)}
 	}
 
 	headingMap := make(map[string]string)
@@ -2690,58 +2703,44 @@ func resolveAnchorLinks(docID string, anchors []deferredAnchor) {
 		}
 	}
 
+	var warnings []string
 	var requests []*docs.Request
 	for _, anchor := range anchors {
 		headingID, ok := headingMap[anchor.slug]
 		if !ok {
+			warnings = append(warnings, anchor.slug)
 			continue
 		}
-		for _, elem := range doc.Body.Content {
-			if elem.Paragraph == nil {
-				continue
-			}
-			for _, e := range elem.Paragraph.Elements {
-				if e.TextRun == nil || e.TextRun.Content == "" {
-					continue
-				}
-				idx := strings.Index(e.TextRun.Content, anchor.text)
-				if idx < 0 {
-					continue
-				}
-				startIdx := e.StartIndex + int64(idx)
-				endIdx := startIdx + int64(len(anchor.text))
-				requests = append(requests, &docs.Request{
-					UpdateTextStyle: &docs.UpdateTextStyleRequest{
-						Range: &docs.Range{
-							StartIndex: startIdx,
-							EndIndex:   endIdx,
+		adjustedStart := anchor.startIndex - anchor.tabsAtCollect
+		adjustedEnd := anchor.endIndex - anchor.tabsAtCollect
+		requests = append(requests, &docs.Request{
+			UpdateTextStyle: &docs.UpdateTextStyleRequest{
+				Range: &docs.Range{
+					StartIndex: adjustedStart,
+					EndIndex:   adjustedEnd,
+				},
+				TextStyle: &docs.TextStyle{
+					Link: &docs.Link{
+						Heading: &docs.HeadingLink{
+							Id: headingID,
 						},
-						TextStyle: &docs.TextStyle{
-							Link: &docs.Link{
-								Heading: &docs.HeadingLink{
-									Id: headingID,
-								},
-							},
-						},
-						Fields: "link",
 					},
-				})
-				goto nextAnchor
-			}
+				},
+				Fields: "link",
+			},
+		})
+	}
+
+	if len(requests) > 0 {
+		_, err = docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+			Requests: requests,
+		}).Do()
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to apply heading links: %v", err))
 		}
-	nextAnchor:
 	}
 
-	if len(requests) == 0 {
-		return
-	}
-
-	_, err = docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
-		Requests: requests,
-	}).Do()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: resolveAnchorLinks: failed to apply heading links: %v\n", err)
-	}
+	return warnings
 }
 
 const maxReadFileSize = 10 << 20 // 10 MB

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -2648,6 +2648,96 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 	return requests, currentIndex - tabsInserted, deferredAnchors
 }
 
+func resolveAnchorLinks(docID string, anchors []deferredAnchor) error {
+	if len(anchors) == 0 {
+		return nil
+	}
+
+	doc, err := docsSvc.Documents.Get(docID).Do()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: resolveAnchorLinks: failed to read document for heading resolution: %v\n", err)
+		return nil
+	}
+
+	headingMap := make(map[string]string)
+	for _, elem := range doc.Body.Content {
+		if elem.Paragraph == nil || elem.Paragraph.ParagraphStyle == nil {
+			continue
+		}
+		style := elem.Paragraph.ParagraphStyle
+		if !strings.HasPrefix(style.NamedStyleType, "HEADING_") || style.HeadingId == "" {
+			continue
+		}
+		var text strings.Builder
+		for _, e := range elem.Paragraph.Elements {
+			if e.TextRun != nil {
+				text.WriteString(e.TextRun.Content)
+			}
+		}
+		slug := slugifyHeading(strings.TrimSpace(text.String()))
+		if slug == "" {
+			continue
+		}
+		if _, exists := headingMap[slug]; !exists {
+			headingMap[slug] = style.HeadingId
+		}
+	}
+
+	var requests []*docs.Request
+	for _, anchor := range anchors {
+		headingID, ok := headingMap[anchor.slug]
+		if !ok {
+			continue
+		}
+		for _, elem := range doc.Body.Content {
+			if elem.Paragraph == nil {
+				continue
+			}
+			for _, e := range elem.Paragraph.Elements {
+				if e.TextRun == nil || e.TextRun.Content == "" {
+					continue
+				}
+				idx := strings.Index(e.TextRun.Content, anchor.text)
+				if idx < 0 {
+					continue
+				}
+				startIdx := e.StartIndex + int64(idx)
+				endIdx := startIdx + int64(len(anchor.text))
+				requests = append(requests, &docs.Request{
+					UpdateTextStyle: &docs.UpdateTextStyleRequest{
+						Range: &docs.Range{
+							StartIndex: startIdx,
+							EndIndex:   endIdx,
+						},
+						TextStyle: &docs.TextStyle{
+							Link: &docs.Link{
+								Heading: &docs.HeadingLink{
+									Id: headingID,
+								},
+							},
+						},
+						Fields: "link",
+					},
+				})
+				goto nextAnchor
+			}
+		}
+	nextAnchor:
+	}
+
+	if len(requests) == 0 {
+		return nil
+	}
+
+	_, err = docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests: requests,
+	}).Do()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: resolveAnchorLinks: failed to apply heading links: %v\n", err)
+	}
+	return nil
+}
+
 const maxReadFileSize = 10 << 20 // 10 MB
 
 func readFileForWrite(filePath string) ([]byte, error) {

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/LeGambiArt/wtmcp/pkg/pathutil"
@@ -1454,6 +1455,28 @@ func isAllowedLinkScheme(rawURL string) bool {
 	return strings.HasPrefix(lower, "https://") ||
 		strings.HasPrefix(lower, "http://") ||
 		strings.HasPrefix(lower, "mailto:")
+}
+
+// slugifyHeading produces a GFM-compatible anchor slug from a heading string.
+// It lowercases, keeps letters/digits/spaces/hyphens, converts spaces to
+// hyphens, and trims leading/trailing hyphens.
+func slugifyHeading(text string) string {
+	lower := strings.ToLower(text)
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range lower {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			prevHyphen = false
+		case r == ' ' || r == '-':
+			if !prevHyphen {
+				b.WriteRune('-')
+				prevHyphen = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 // mergeSegments combines consecutive segments with identical formatting properties

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -1466,7 +1466,7 @@ func slugifyHeading(text string) string {
 	prevHyphen := false
 	for _, r := range lower {
 		switch {
-		case unicode.IsLetter(r) || unicode.IsDigit(r):
+		case unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_':
 			b.WriteRune(r)
 			prevHyphen = false
 		case r == ' ' || r == '-':
@@ -2525,6 +2525,15 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 		var textStyle *docs.TextStyle
 		var fields []string
 
+		if seg.anchorSlug != "" {
+			deferredAnchors = append(deferredAnchors, deferredAnchor{
+				startIndex:    currentIndex,
+				endIndex:      endIndex,
+				tabsAtCollect: tabsInserted,
+				slug:          seg.anchorSlug,
+			})
+		}
+
 		if seg.isInlineCode {
 			// Inline code: apply Courier New font, preserve bold/italic/underline
 			textStyle = &docs.TextStyle{
@@ -2537,14 +2546,7 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 				Strikethrough: seg.strikethrough,
 			}
 			fields = []string{"weightedFontFamily", "bold", "italic", "underline", "strikethrough"}
-			if seg.anchorSlug != "" {
-				deferredAnchors = append(deferredAnchors, deferredAnchor{
-					startIndex:    currentIndex,
-					endIndex:      endIndex,
-					tabsAtCollect: tabsInserted,
-					slug:          seg.anchorSlug,
-				})
-			} else if seg.linkURL != "" {
+			if seg.anchorSlug == "" && seg.linkURL != "" {
 				textStyle.Link = &docs.Link{
 					Url: seg.linkURL,
 				}
@@ -2558,14 +2560,7 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 				Strikethrough: seg.strikethrough,
 			}
 
-			if seg.anchorSlug != "" {
-				deferredAnchors = append(deferredAnchors, deferredAnchor{
-					startIndex:    currentIndex,
-					endIndex:      endIndex,
-					tabsAtCollect: tabsInserted,
-					slug:          seg.anchorSlug,
-				})
-			} else if seg.linkURL != "" {
+			if seg.anchorSlug == "" && seg.linkURL != "" {
 				textStyle.Link = &docs.Link{
 					Url: seg.linkURL,
 				}
@@ -2677,6 +2672,10 @@ func resolveAnchorLinks(docID string, anchors []deferredAnchor) []string {
 	doc, err := docsSvc.Documents.Get(docID).Do()
 	if err != nil {
 		return []string{fmt.Sprintf("failed to read document for heading resolution: %v", err)}
+	}
+
+	if doc.Body == nil {
+		return []string{"document body is empty, cannot resolve heading anchors"}
 	}
 
 	headingMap := make(map[string]string)

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -1625,6 +1625,7 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 		totalReplies := 0
 		var pendingSegments []markdownSegment
 		var tables []tableRecord
+		var allDeferredAnchors []deferredAnchor
 
 		// --- Phase 1: create document structure (text + empty tables) ---
 
@@ -1633,7 +1634,8 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 				// Flush preceding text via BatchUpdate; use the returned
 				// final index instead of a Documents.Get round-trip.
 				if len(pendingSegments) > 0 {
-					textReqs, finalIdx, _ := convertMarkdownToRequests(pendingSegments, currentIndex, false)
+					textReqs, finalIdx, anchors := convertMarkdownToRequests(pendingSegments, currentIndex, false)
+					allDeferredAnchors = append(allDeferredAnchors, anchors...)
 					if len(textReqs) > 0 {
 						resp, err := docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 							Requests: textReqs,
@@ -1712,7 +1714,8 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 
 		// Flush any trailing text after the last table.
 		if len(pendingSegments) > 0 {
-			textReqs, _, _ := convertMarkdownToRequests(pendingSegments, currentIndex, true)
+			textReqs, _, anchors := convertMarkdownToRequests(pendingSegments, currentIndex, true)
+			allDeferredAnchors = append(allDeferredAnchors, anchors...)
 			if len(textReqs) > 0 {
 				resp, err := docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 					Requests: textReqs,
@@ -1747,6 +1750,10 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 			totalReplies += len(resp.Replies)
 		}
 
+		if err := resolveAnchorLinks(docID, allDeferredAnchors); err != nil {
+			return nil, err
+		}
+
 		return map[string]any{
 			"document_id":  docID,
 			"title":        title,
@@ -1758,11 +1765,15 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 	}
 
 	// No tables — single-batch insertion.
-	requests, _, _ := convertMarkdownToRequests(segments, insertIndex, true)
+	requests, _, deferredAnchors := convertMarkdownToRequests(segments, insertIndex, true)
 	batchUpdateReq := &docs.BatchUpdateDocumentRequest{Requests: requests}
 	resp, err := docsSvc.Documents.BatchUpdate(docID, batchUpdateReq).Do()
 	if err != nil {
 		return nil, fmt.Errorf("batch update: %w", err)
+	}
+
+	if err := resolveAnchorLinks(docID, deferredAnchors); err != nil {
+		return nil, err
 	}
 
 	return map[string]any{

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -663,6 +663,7 @@ type markdownSegment struct {
 	underline         bool
 	strikethrough     bool
 	linkURL           string
+	anchorSlug        string // heading anchor for intra-document links (e.g. "my-heading" from "#my-heading")
 	heading           int    // 0 for normal, 1-6 for heading levels
 	headingLineID     int    // unique ID per heading line, used to detect paragraph boundaries
 	orderedListItem   bool   // true if this is an ordered list item
@@ -1422,6 +1423,15 @@ func parseSimpleFormattingWithDepth(text string, depth int) []markdownSegment {
 				pos += linkMatch[1]
 				continue
 			}
+			// Anchor link — strip markdown syntax, defer resolution to heading bookmarks
+			if strings.HasPrefix(linkURL, "#") {
+				segments = append(segments, markdownSegment{
+					text:       linkText,
+					anchorSlug: linkURL[1:],
+				})
+				pos += linkMatch[1]
+				continue
+			}
 			// Rejected scheme — emit opening bracket as plain text and
 			// let the rest be parsed normally on subsequent iterations.
 		}
@@ -1472,6 +1482,7 @@ func mergeSegments(segments []markdownSegment) []markdownSegment {
 			curr.underline == prev.underline &&
 			curr.strikethrough == prev.strikethrough &&
 			curr.linkURL == prev.linkURL &&
+			curr.anchorSlug == prev.anchorSlug &&
 			curr.heading == prev.heading &&
 			curr.headingLineID == prev.headingLineID &&
 			curr.orderedListItem == prev.orderedListItem &&

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -1750,9 +1750,7 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 			totalReplies += len(resp.Replies)
 		}
 
-		if err := resolveAnchorLinks(docID, allDeferredAnchors); err != nil {
-			return nil, err
-		}
+		resolveAnchorLinks(docID, allDeferredAnchors)
 
 		return map[string]any{
 			"document_id":  docID,
@@ -1772,9 +1770,7 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 		return nil, fmt.Errorf("batch update: %w", err)
 	}
 
-	if err := resolveAnchorLinks(docID, deferredAnchors); err != nil {
-		return nil, err
-	}
+	resolveAnchorLinks(docID, deferredAnchors)
 
 	return map[string]any{
 		"document_id":  docID,
@@ -2659,15 +2655,15 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 	return requests, currentIndex - tabsInserted, deferredAnchors
 }
 
-func resolveAnchorLinks(docID string, anchors []deferredAnchor) error {
+func resolveAnchorLinks(docID string, anchors []deferredAnchor) {
 	if len(anchors) == 0 {
-		return nil
+		return
 	}
 
 	doc, err := docsSvc.Documents.Get(docID).Do()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: resolveAnchorLinks: failed to read document for heading resolution: %v\n", err)
-		return nil
+		return
 	}
 
 	headingMap := make(map[string]string)
@@ -2737,7 +2733,7 @@ func resolveAnchorLinks(docID string, anchors []deferredAnchor) error {
 	}
 
 	if len(requests) == 0 {
-		return nil
+		return
 	}
 
 	_, err = docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
@@ -2746,7 +2742,6 @@ func resolveAnchorLinks(docID string, anchors []deferredAnchor) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: resolveAnchorLinks: failed to apply heading links: %v\n", err)
 	}
-	return nil
 }
 
 const maxReadFileSize = 10 << 20 // 10 MB

--- a/plugins/google-docs/tools.go
+++ b/plugins/google-docs/tools.go
@@ -1633,7 +1633,7 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 				// Flush preceding text via BatchUpdate; use the returned
 				// final index instead of a Documents.Get round-trip.
 				if len(pendingSegments) > 0 {
-					textReqs, finalIdx := convertMarkdownToRequests(pendingSegments, currentIndex, false)
+					textReqs, finalIdx, _ := convertMarkdownToRequests(pendingSegments, currentIndex, false)
 					if len(textReqs) > 0 {
 						resp, err := docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 							Requests: textReqs,
@@ -1712,7 +1712,7 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 
 		// Flush any trailing text after the last table.
 		if len(pendingSegments) > 0 {
-			textReqs, _ := convertMarkdownToRequests(pendingSegments, currentIndex, true)
+			textReqs, _, _ := convertMarkdownToRequests(pendingSegments, currentIndex, true)
 			if len(textReqs) > 0 {
 				resp, err := docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 					Requests: textReqs,
@@ -1758,7 +1758,7 @@ func insertMarkdownWithTables(docID string, title string, segments []markdownSeg
 	}
 
 	// No tables — single-batch insertion.
-	requests, _ := convertMarkdownToRequests(segments, insertIndex, true)
+	requests, _, _ := convertMarkdownToRequests(segments, insertIndex, true)
 	batchUpdateReq := &docs.BatchUpdateDocumentRequest{Requests: requests}
 	resp, err := docsSvc.Documents.BatchUpdate(docID, batchUpdateReq).Do()
 	if err != nil {
@@ -1988,14 +1988,20 @@ func populateTableCell(cell *tableCell, cellStartIndex int64) []*docs.Request {
 	return requests
 }
 
+type deferredAnchor struct {
+	text string
+	slug string
+}
+
 // convertMarkdownToRequests converts markdown segments to Google Docs API requests.
 // When stripTrailingNewline is true, the trailing \n is removed from the last
 // text segment to avoid an unwanted empty paragraph at the document end.
 // Pass false when flushing mid-document text before a table.
-func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, stripTrailingNewline bool) ([]*docs.Request, int64) {
+func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, stripTrailingNewline bool) ([]*docs.Request, int64, []deferredAnchor) {
 	var requests []*docs.Request
 	currentIndex := startIndex
 	var tabsInserted int64
+	var deferredAnchors []deferredAnchor
 
 	// Merge consecutive segments with identical formatting to reduce API requests
 	segments = mergeSegments(segments)
@@ -2514,7 +2520,12 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 				Strikethrough: seg.strikethrough,
 			}
 			fields = []string{"weightedFontFamily", "bold", "italic", "underline", "strikethrough"}
-			if seg.linkURL != "" {
+			if seg.anchorSlug != "" {
+				deferredAnchors = append(deferredAnchors, deferredAnchor{
+					text: seg.text,
+					slug: seg.anchorSlug,
+				})
+			} else if seg.linkURL != "" {
 				textStyle.Link = &docs.Link{
 					Url: seg.linkURL,
 				}
@@ -2528,7 +2539,12 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 				Strikethrough: seg.strikethrough,
 			}
 
-			if seg.linkURL != "" {
+			if seg.anchorSlug != "" {
+				deferredAnchors = append(deferredAnchors, deferredAnchor{
+					text: seg.text,
+					slug: seg.anchorSlug,
+				})
+			} else if seg.linkURL != "" {
 				textStyle.Link = &docs.Link{
 					Url: seg.linkURL,
 				}
@@ -2539,7 +2555,7 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 			// monospace font (e.g. from an adjacent inline-code segment) is
 			// cleared and the document default font is restored.
 			fields = []string{"weightedFontFamily", "bold", "italic", "underline", "strikethrough"}
-			if seg.linkURL != "" {
+			if seg.linkURL != "" && seg.anchorSlug == "" {
 				fields = append(fields, "link")
 			}
 		}
@@ -2629,7 +2645,7 @@ func convertMarkdownToRequests(segments []markdownSegment, startIndex int64, str
 	// CreateParagraphBullets removes the leading tabs that were prepended
 	// for list nesting.  Subtract them so the returned index reflects the
 	// document state after the BatchUpdate executes.
-	return requests, currentIndex - tabsInserted
+	return requests, currentIndex - tabsInserted, deferredAnchors
 }
 
 const maxReadFileSize = 10 << 20 // 10 MB

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -43,16 +43,20 @@ func TestIndentDepth(t *testing.T) {
 		indent string
 		want   int
 	}{
-		{"no indent", "", 0},
-		{"one tab", "\t", 1},
-		{"two tabs", "\t\t", 2},
-		{"four spaces", "    ", 1},
-		{"eight spaces", "        ", 2},
-		{"mixed tab and spaces", "\t    ", 2},
-		{"three spaces (partial)", "   ", 0},
-		{"five spaces", "     ", 1},
+		{"empty", "", 0},
+		{"1 space", " ", 0},
+		{"2 spaces", "  ", 1},
+		{"3 spaces", "   ", 1},
+		{"4 spaces", "    ", 1},
+		{"5 spaces", "     ", 1},
+		{"6 spaces", "      ", 2},
+		{"7 spaces", "       ", 2},
+		{"8 spaces", "        ", 2},
+		{"tab", "\t", 1},
+		{"tab+2spaces", "\t  ", 2},
+		{"4spaces+tab", "    \t", 2},
+		{"4spaces+2spaces", "    " + "  ", 2},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := indentDepth(tt.indent)
@@ -150,6 +154,31 @@ func TestParseMarkdownLists(t *testing.T) {
 			t.Errorf("max depth = %d, want 1", maxDepth)
 		}
 	})
+}
+
+func TestOrderedListWithNestedSubBullets(t *testing.T) {
+	md := "1. First\n   - sub-a\n   - sub-b\n1. Second\n1. Third"
+	segments := parseMarkdown(md)
+	merged := mergeSegments(segments)
+
+	for _, seg := range merged {
+		if seg.unorderedListItem && seg.listDepth == 0 {
+			t.Errorf("sub-bullet %q has depth 0, want depth >= 1", seg.text)
+		}
+	}
+
+	// Count ordered list items by newlines within merged ordered segments.
+	// mergeSegments combines adjacent segments with identical attributes,
+	// so "Second\nThird\n" is one segment containing two items.
+	orderedItems := 0
+	for _, seg := range merged {
+		if seg.orderedListItem && seg.listDepth == 0 {
+			orderedItems += strings.Count(seg.text, "\n")
+		}
+	}
+	if orderedItems != 3 {
+		t.Errorf("expected 3 top-level ordered items, got %d", orderedItems)
+	}
 }
 
 func TestParseStrikethrough(t *testing.T) {

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -6574,3 +6574,31 @@ func TestMergeSegmentsAnchorLink(t *testing.T) {
 		t.Errorf("middle segment anchorSlug = %q, want %q", merged[1].anchorSlug, "heading")
 	}
 }
+
+func TestSlugifyHeading(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple", "My Heading", "my-heading"},
+		{"mixed case", "PostgreSQL Tuning", "postgresql-tuning"},
+		{"with numbers", "Step 3 Plan", "step-3-plan"},
+		{"punctuation stripped", "What's Next?", "whats-next"},
+		{"hyphens preserved", "io2-block-express", "io2-block-express"},
+		{"multiple spaces", "too  many   spaces", "too-many-spaces"},
+		{"leading trailing", " -heading- ", "heading"},
+		{"unicode accents", "Résumé Overview", "résumé-overview"},
+		{"special chars", "Cost: $2,560/mo", "cost-2560mo"},
+		{"empty", "", ""},
+		{"only punctuation", "!@#$%", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slugifyHeading(tt.input)
+			if got != tt.want {
+				t.Errorf("slugifyHeading(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -6591,6 +6591,7 @@ func TestSlugifyHeading(t *testing.T) {
 		{"unicode accents", "Résumé Overview", "résumé-overview"},
 		{"special chars", "Cost: $2,560/mo", "cost-2560mo"},
 		{"empty", "", ""},
+		{"underscores preserved", "My_Function_Name", "my_function_name"},
 		{"only punctuation", "!@#$%", ""},
 	}
 	for _, tt := range tests {

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -317,7 +317,7 @@ func TestStrikethroughWithDateChips(t *testing.T) {
 func TestStrikethroughInRequests(t *testing.T) {
 	t.Run("strikethrough creates correct style request", func(t *testing.T) {
 		segments := parseMarkdown("~~strikethrough text~~")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		foundStrikethroughStyle := false
 		for _, req := range requests {
@@ -1528,7 +1528,7 @@ func TestHeadingFollowedByNormalText(t *testing.T) {
 
 	t.Run("convertMarkdownToRequests applies heading style but not NORMAL_TEXT", func(t *testing.T) {
 		segments := parseMarkdown("# Heading\nNormal text")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Look for UpdateParagraphStyle requests
 		foundHeadingStyle := false
@@ -1888,7 +1888,7 @@ func TestParagraphJoining(t *testing.T) {
 func TestNoTrailingEmptyParagraph(t *testing.T) {
 	t.Run("last text segment has no trailing newline", func(t *testing.T) {
 		segments := parseMarkdown("# Heading\n\nText")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Find the last InsertText request
 		var lastInsertText string
@@ -1905,7 +1905,7 @@ func TestNoTrailingEmptyParagraph(t *testing.T) {
 
 	t.Run("heading only document has no trailing newline", func(t *testing.T) {
 		segments := parseMarkdown("# Only heading")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Find the InsertText request
 		var insertText string
@@ -1923,7 +1923,7 @@ func TestNoTrailingEmptyParagraph(t *testing.T) {
 
 	t.Run("normal text only document has no trailing newline", func(t *testing.T) {
 		segments := parseMarkdown("Just text")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Find the InsertText request
 		var insertText string
@@ -2000,7 +2000,7 @@ func TestCRLFNormalization(t *testing.T) {
 func TestHeadingWithFormattedText(t *testing.T) {
 	t.Run("heading with bold text creates single heading", func(t *testing.T) {
 		segments := parseMarkdown("# **Bold** Normal")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Count InsertText requests - should only insert text that will form ONE heading paragraph
 		var insertTexts []string
@@ -2028,7 +2028,7 @@ func TestHeadingWithFormattedText(t *testing.T) {
 
 	t.Run("heading with formatted text followed by normal text", func(t *testing.T) {
 		segments := parseMarkdown("# **Bold** Normal\n\nText")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Count heading-styled paragraphs
 		headingStyleCount := 0
@@ -2087,7 +2087,7 @@ func TestHeadingWithFormattedText(t *testing.T) {
 	t.Run("complex formatted text creates correct requests", func(t *testing.T) {
 		markdown := "**This is** some _heavily_ __formatted__ text."
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Verify we have InsertText and UpdateTextStyle requests
 		var insertCount, boldStyleCount, italicStyleCount, underlineStyleCount int
@@ -2130,7 +2130,7 @@ func TestHeadingWithFormattedText(t *testing.T) {
 func TestConsecutiveSameLevelHeadings(t *testing.T) {
 	t.Run("two H1s no blank line", func(t *testing.T) {
 		segments := parseMarkdown("# A\n# B")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Count heading paragraph style requests
 		headingStyleCount := 0
@@ -2159,7 +2159,7 @@ func TestConsecutiveSameLevelHeadings(t *testing.T) {
 
 	t.Run("two H1s with blank line", func(t *testing.T) {
 		segments := parseMarkdown("# A\n\n# B")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		headingStyleCount := 0
 		for _, req := range requests {
@@ -2175,7 +2175,7 @@ func TestConsecutiveSameLevelHeadings(t *testing.T) {
 
 	t.Run("three consecutive H2s", func(t *testing.T) {
 		segments := parseMarkdown("## A\n## B\n## C")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		headingStyleCount := 0
 		for _, req := range requests {
@@ -2192,7 +2192,7 @@ func TestConsecutiveSameLevelHeadings(t *testing.T) {
 	t.Run("multi-segment heading stays single paragraph", func(t *testing.T) {
 		// "# **Bold** Normal" should still produce one heading paragraph
 		segments := parseMarkdown("# **Bold** Normal\n# Another")
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		headingStyleCount := 0
 		for _, req := range requests {
@@ -3931,7 +3931,7 @@ func TestParseSimpleFormatting_InlineCodeBoundaryFullPipeline(t *testing.T) {
 	// Now test convertMarkdownToRequests - check that the UpdateTextStyle for
 	// text after the closing backtick includes weightedFontFamily in its fields
 	// so that the font is explicitly reset to the document default (not Courier New).
-	requests, _ := convertMarkdownToRequests(segments, 1, true)
+	requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 	// Find the InsertText for ". This" and its corresponding UpdateTextStyle
 	for i, req := range requests {
@@ -4079,7 +4079,7 @@ func TestConvertMarkdownToRequestsFinalIndex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			segments := parseMarkdown(tt.markdown)
-			_, finalIndex := convertMarkdownToRequests(segments, startIndex, true)
+			_, finalIndex, _ := convertMarkdownToRequests(segments, startIndex, true)
 			if finalIndex != tt.want {
 				t.Errorf("finalIndex = %d, want %d", finalIndex, tt.want)
 			}
@@ -4103,7 +4103,7 @@ func TestConvertMarkdownToRequestsFinalIndex(t *testing.T) {
 	for _, tt := range noStripTests {
 		t.Run("no_strip/"+tt.name, func(t *testing.T) {
 			segments := parseMarkdown(tt.markdown)
-			_, finalIndex := convertMarkdownToRequests(segments, startIndex, false)
+			_, finalIndex, _ := convertMarkdownToRequests(segments, startIndex, false)
 			if finalIndex != tt.want {
 				t.Errorf("finalIndex = %d, want %d", finalIndex, tt.want)
 			}
@@ -4113,7 +4113,7 @@ func TestConvertMarkdownToRequestsFinalIndex(t *testing.T) {
 
 func TestFormattedNestedListNoMidTextTabs(t *testing.T) {
 	segments := parseMarkdown("    - **bold** text\n")
-	requests, _ := convertMarkdownToRequests(segments, 1, true)
+	requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 	tabCount := 0
 	for _, req := range requests {
@@ -4130,7 +4130,7 @@ func TestConvertMarkdownToRequests_CodeBlock(t *testing.T) {
 	t.Run("code block applies Courier New font", func(t *testing.T) {
 		markdown := "```\nfmt.Println(\"hello\")\n```"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Should have at least one InsertText with the code content
 		foundInsert := false
@@ -4164,7 +4164,7 @@ func TestConvertMarkdownToRequests_CodeBlock(t *testing.T) {
 	t.Run("code block does not apply bold/italic/underline", func(t *testing.T) {
 		markdown := "```\ncode\n```"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		for _, req := range requests {
 			if req.UpdateTextStyle != nil &&
@@ -4190,7 +4190,7 @@ func TestConvertMarkdownToRequests_CodeBlock(t *testing.T) {
 	t.Run("code block followed by normal text", func(t *testing.T) {
 		markdown := "```\ncode\n```\nNormal text"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Verify both code and normal text are inserted
 		var insertTexts []string
@@ -4235,7 +4235,7 @@ func TestConvertMarkdownToRequests_InlineCode(t *testing.T) {
 	t.Run("inline code applies Courier New font", func(t *testing.T) {
 		markdown := "Use `fmt.Println` to print"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		// Should have UpdateTextStyle with Courier New for the inline code segment
 		foundCourierNew := false
@@ -4258,7 +4258,7 @@ func TestConvertMarkdownToRequests_InlineCode(t *testing.T) {
 	t.Run("inline code preserves formatting fields", func(t *testing.T) {
 		markdown := "Use `code` here"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		for _, req := range requests {
 			if req.UpdateTextStyle != nil &&
@@ -4294,7 +4294,7 @@ func TestConvertMarkdownToRequests_InlineCode(t *testing.T) {
 	t.Run("bold inline code preserves bold formatting", func(t *testing.T) {
 		markdown := "Use **`code`** here"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		foundBoldCode := false
 		for _, req := range requests {
@@ -4321,7 +4321,7 @@ func TestConvertMarkdownToRequests_InlineCode(t *testing.T) {
 	t.Run("italic inline code preserves italic formatting", func(t *testing.T) {
 		markdown := "Use *`code`* here"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		foundItalicCode := false
 		for _, req := range requests {
@@ -4342,7 +4342,7 @@ func TestConvertMarkdownToRequests_InlineCode(t *testing.T) {
 	t.Run("non-code text does not get Courier New", func(t *testing.T) {
 		markdown := "Regular text without code"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		for _, req := range requests {
 			if req.UpdateTextStyle != nil &&
@@ -4356,7 +4356,7 @@ func TestConvertMarkdownToRequests_InlineCode(t *testing.T) {
 	t.Run("inline code in heading applies Courier New", func(t *testing.T) {
 		markdown := "# Heading with `code`"
 		segments := parseMarkdown(markdown)
-		requests, _ := convertMarkdownToRequests(segments, 1, true)
+		requests, _, _ := convertMarkdownToRequests(segments, 1, true)
 
 		foundCourierNew := false
 		for _, req := range requests {
@@ -5910,7 +5910,7 @@ func TestRoundTrip_CodeBlock(t *testing.T) {
 	segments := parseMarkdown(originalMarkdown)
 
 	// Convert segments to requests (simulating write to Google Docs)
-	_, _ = convertMarkdownToRequests(segments, 1, true)
+	_, _, _ = convertMarkdownToRequests(segments, 1, true)
 
 	// Create a mock Google Docs document with the expected structure
 	doc := &docs.Document{

--- a/plugins/google-docs/tools_test.go
+++ b/plugins/google-docs/tools_test.go
@@ -6511,3 +6511,66 @@ func TestToolWriteContentResolution(t *testing.T) {
 		}
 	})
 }
+
+func TestParseAnchorLink(t *testing.T) {
+	segments := parseSimpleFormatting("[Click here](#my-section)")
+	merged := mergeSegments(segments)
+
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 segment, got %d: %+v", len(merged), merged)
+	}
+	seg := merged[0]
+	if seg.text != "Click here" {
+		t.Errorf("text = %q, want %q", seg.text, "Click here")
+	}
+	if seg.anchorSlug != "my-section" {
+		t.Errorf("anchorSlug = %q, want %q", seg.anchorSlug, "my-section")
+	}
+	if seg.linkURL != "" {
+		t.Errorf("linkURL = %q, want empty", seg.linkURL)
+	}
+}
+
+func TestParseAnchorLinkPreservesHttpLinks(t *testing.T) {
+	segments := parseSimpleFormatting("[Go](https://golang.org)")
+	merged := mergeSegments(segments)
+
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(merged))
+	}
+	if merged[0].linkURL != "https://golang.org" {
+		t.Errorf("linkURL = %q, want %q", merged[0].linkURL, "https://golang.org")
+	}
+	if merged[0].anchorSlug != "" {
+		t.Errorf("anchorSlug = %q, want empty", merged[0].anchorSlug)
+	}
+}
+
+func TestParseAnchorLinkRejectsOtherSchemes(t *testing.T) {
+	segments := parseSimpleFormatting("[evil](javascript:alert(1))")
+	merged := mergeSegments(segments)
+
+	fullText := ""
+	for _, seg := range merged {
+		fullText += seg.text
+	}
+	if !strings.Contains(fullText, "[") {
+		t.Error("expected raw bracket in output for rejected scheme")
+	}
+}
+
+func TestMergeSegmentsAnchorLink(t *testing.T) {
+	segments := []markdownSegment{
+		{text: "before "},
+		{text: "link text", anchorSlug: "heading"},
+		{text: " after"},
+	}
+	merged := mergeSegments(segments)
+
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 segments (anchor prevents merging), got %d: %+v", len(merged), merged)
+	}
+	if merged[1].anchorSlug != "heading" {
+		t.Errorf("middle segment anchorSlug = %q, want %q", merged[1].anchorSlug, "heading")
+	}
+}


### PR DESCRIPTION
## Summary

- **Anchor links** (`[text](#section)`) now resolve to Google Docs internal heading bookmarks instead of rendering as raw markdown syntax
- **Numbered lists** no longer restart at 1 when sub-bullets with 2-3 space indent are present

## Changes

- `indentDepth`: accept 2+ remaining spaces as one nesting level (matches GFM conventions)
- `markdownSegment`: new `anchorSlug` field for `#fragment` links
- `parseSimpleFormattingWithDepth`: intercept `#anchor` URLs before the rejected-scheme fallback
- `mergeSegments`: prevent anchor segments from merging with adjacent plain text
- `slugifyHeading`: new GFM-compatible, unicode-safe heading slug function
- `convertMarkdownToRequests`: collect deferred anchors (new third return value)
- `resolveAnchorLinks`: new function — reads doc post-insert, maps slugs to `HeadingId`, applies `UpdateTextStyle` with `Link.Heading`; degrades gracefully on API errors

## Test plan

- [x] `TestIndentDepth` — 13 cases (0-8 spaces, tabs, mixed)
- [x] `TestOrderedListWithNestedSubBullets` — 3-space sub-bullets at depth 1
- [x] `TestParseAnchorLink` — `[text](#slug)` → anchorSlug segment
- [x] `TestParseAnchorLinkPreservesHttpLinks` — no regression for https links
- [x] `TestParseAnchorLinkRejectsOtherSchemes` — javascript: still rejected
- [x] `TestMergeSegmentsAnchorLink` — anchor segments stay separate
- [x] `TestSlugifyHeading` — 11 cases (ASCII, unicode, punctuation, edge cases)
- [x] golangci-lint clean
- [ ] Manual: write markdown with anchor links to a test Google Doc, verify heading links work

Closes #141

🤖 Generated with [Claude Code](https://claude.ai/claude-code)