### PR TITLE
go: bump toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LeGambiArt/wtmcp
 
-go 1.26.4
+go 1.26.5
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
Fixes GO-2026-5856 (crypto/tls ECH privacy leak).