### PR TITLE
chore(deps): bump arapuca submodule to v0.2.4, go-arapuca to v0.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
-	github.com/sergio-correia/go-arapuca v0.2.1
+	github.com/sergio-correia/go-arapuca v0.2.2
 	github.com/spf13/cobra v1.10.2
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	golang.org/x/net v0.56.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/sebdah/goldie/v2 v2.8.0 h1:dZb9wR8q5++oplmEiJT+U/5KyotVD+HNGCAc5gNr8r
 github.com/sebdah/goldie/v2 v2.8.0/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/sergio-correia/go-arapuca v0.2.1 h1:u4xZZJ6PL5urfup0TxCLah9KKDb8dW7lbA3FIjoRk4A=
-github.com/sergio-correia/go-arapuca v0.2.1/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
+github.com/sergio-correia/go-arapuca v0.2.2 h1:NinN0AqOgiMR9kRBHGJcisDACRmKvyy9Mto9az31SIc=
+github.com/sergio-correia/go-arapuca v0.2.2/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=


### PR DESCRIPTION
The go-arapuca v0.2.2 bindings reference C functions (arapuca_profile_set_seccomp, arapuca_profile_set_pidns, arapuca_profile_set_dns_capture, arapuca_profile_set_max_open_files) that were added in arapuca v0.2.4. The submodule was at a pre-v0.2.4 commit that lacked these exports, causing CGo build failures.

Bump both in lockstep so the Go bindings and C library match.