### PR TITLE
feat: add PR/MR creation tools for GitHub and GitLab

### DIFF
--- a/plugins/github/plugin.yaml
+++ b/plugins/github/plugin.yaml
@@ -382,6 +382,44 @@ tools:
         default: true
         description: "Preview without posting (default: true)"
 
+  - name: github_create_pull_request
+    access: write
+    description: >
+      Create a new pull request. Defaults to dry_run=true which returns a
+      preview without creating. Set dry_run=false to create.
+    params:
+      repo:
+        type: string
+        required: true
+        description: "Repository as owner/repo"
+      title:
+        type: string
+        required: true
+        description: "PR title"
+      head:
+        type: string
+        required: true
+        description: "Source branch (e.g. 'mybranch' or 'owner:mybranch' for forks)"
+      base:
+        type: string
+        required: true
+        description: "Target branch to merge into"
+      body:
+        type: string
+        description: "PR description body (markdown)"
+      draft:
+        type: boolean
+        default: false
+        description: "Create as draft PR"
+      maintainer_can_modify:
+        type: boolean
+        default: true
+        description: "Allow maintainers to push to the head branch"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without creating (default: true)"
+
 setup:
   credentials:
     GITHUB_TOKEN:

--- a/plugins/github/tests/test_tools_write.py
+++ b/plugins/github/tests/test_tools_write.py
@@ -655,45 +655,31 @@ class TestCreatePullRequest:
 
     def test_missing_repo(self):
         with pytest.raises(ValueError, match="invalid repo"):
-            tools_write.create_pull_request(
-                {"title": "t", "head": "h", "base": "b"}
-            )
+            tools_write.create_pull_request({"title": "t", "head": "h", "base": "b"})
 
     def test_missing_title(self):
         with pytest.raises(ValueError, match="title is required"):
-            tools_write.create_pull_request(
-                {"repo": "org/repo", "head": "h", "base": "b"}
-            )
+            tools_write.create_pull_request({"repo": "org/repo", "head": "h", "base": "b"})
 
     def test_missing_head(self):
         with pytest.raises(ValueError, match="head is required"):
-            tools_write.create_pull_request(
-                {"repo": "org/repo", "title": "t", "base": "b"}
-            )
+            tools_write.create_pull_request({"repo": "org/repo", "title": "t", "base": "b"})
 
     def test_missing_base(self):
         with pytest.raises(ValueError, match="base is required"):
-            tools_write.create_pull_request(
-                {"repo": "org/repo", "title": "t", "head": "h"}
-            )
+            tools_write.create_pull_request({"repo": "org/repo", "title": "t", "head": "h"})
 
     def test_whitespace_head(self):
         with pytest.raises(ValueError, match="head is required"):
-            tools_write.create_pull_request(
-                {"repo": "org/repo", "title": "t", "head": "   ", "base": "b"}
-            )
+            tools_write.create_pull_request({"repo": "org/repo", "title": "t", "head": "   ", "base": "b"})
 
     def test_whitespace_base(self):
         with pytest.raises(ValueError, match="base is required"):
-            tools_write.create_pull_request(
-                {"repo": "org/repo", "title": "t", "head": "h", "base": "   "}
-            )
+            tools_write.create_pull_request({"repo": "org/repo", "title": "t", "head": "h", "base": "   "})
 
     def test_empty_title(self):
         with pytest.raises(ValueError, match="title is required"):
-            tools_write.create_pull_request(
-                {"repo": "org/repo", "title": "  ", "head": "h", "base": "b"}
-            )
+            tools_write.create_pull_request({"repo": "org/repo", "title": "  ", "head": "h", "base": "b"})
 
     def test_body_too_long(self):
         with pytest.raises(ValueError, match="character limit"):
@@ -709,9 +695,7 @@ class TestCreatePullRequest:
 
     def test_invalid_repo(self):
         with pytest.raises(ValueError, match="invalid repo"):
-            tools_write.create_pull_request(
-                {"repo": "bad", "title": "t", "head": "h", "base": "b"}
-            )
+            tools_write.create_pull_request({"repo": "bad", "title": "t", "head": "h", "base": "b"})
 
     def test_dry_run_does_not_call_api(self):
         with _mock_http(201, {}) as mock_http, _mock_invalidate() as inv:

--- a/plugins/github/tests/test_tools_write.py
+++ b/plugins/github/tests/test_tools_write.py
@@ -535,6 +535,211 @@ class TestAddComment:
             )
 
 
+# --- github_create_pull_request ---
+
+
+class TestCreatePullRequest:
+    def test_dry_run_default(self):
+        result = tools_write.create_pull_request(
+            {
+                "repo": "org/repo",
+                "title": "Add new feature",
+                "head": "feature-branch",
+                "base": "main",
+                "body": "This PR adds a new feature.",
+            }
+        )
+        assert result["dry_run"] is True
+        assert result["action"] == "github_create_pull_request"
+        assert result["head"] == "feature-branch"
+        assert result["base"] == "main"
+        assert result["title"] == "Add new feature"
+        assert result["body_preview"] == "This PR adds a new feature."
+        assert result["draft"] is False
+        assert result["maintainer_can_modify"] is True
+
+    def test_dry_run_no_body(self):
+        result = tools_write.create_pull_request(
+            {
+                "repo": "org/repo",
+                "title": "Fix bug",
+                "head": "fix-branch",
+                "base": "main",
+            }
+        )
+        assert result["dry_run"] is True
+        assert "body_preview" not in result
+
+    def test_dry_run_draft(self):
+        result = tools_write.create_pull_request(
+            {
+                "repo": "org/repo",
+                "title": "WIP: new feature",
+                "head": "wip-branch",
+                "base": "main",
+                "draft": True,
+            }
+        )
+        assert result["dry_run"] is True
+        assert result["draft"] is True
+
+    def test_dry_run_body_truncated(self):
+        result = tools_write.create_pull_request(
+            {
+                "repo": "org/repo",
+                "title": "t",
+                "head": "h",
+                "base": "b",
+                "body": "x" * 300,
+            }
+        )
+        assert len(result["body_preview"]) == 200
+
+    def test_success(self):
+        pr_response = {
+            "id": 1234567,
+            "number": 42,
+            "html_url": "https://github.com/org/repo/pull/42",
+            "state": "open",
+            "draft": False,
+        }
+        with _mock_http(201, pr_response) as mock_http, _mock_invalidate() as inv:
+            result = tools_write.create_pull_request(
+                {
+                    "repo": "org/repo",
+                    "title": "Add feature",
+                    "head": "feature-branch",
+                    "base": "main",
+                    "body": "Description here",
+                    "dry_run": False,
+                }
+            )
+        assert result["id"] is not None
+        assert result["number"] == 42
+        assert result["html_url"] == "https://github.com/org/repo/pull/42"
+        assert result["state"] == "open"
+        inv.assert_called_once()
+        _, kwargs = mock_http.call_args
+        assert kwargs["body"]["title"] == "Add feature"
+        assert kwargs["body"]["head"] == "feature-branch"
+        assert kwargs["body"]["base"] == "main"
+        assert kwargs["body"]["body"] == "Description here"
+
+    def test_success_no_body(self):
+        pr_response = {"number": 7, "html_url": "url", "state": "open", "draft": False}
+        with _mock_http(201, pr_response), _mock_invalidate():
+            result = tools_write.create_pull_request(
+                {
+                    "repo": "org/repo",
+                    "title": "Fix bug",
+                    "head": "fix-branch",
+                    "base": "main",
+                    "dry_run": False,
+                }
+            )
+        assert result["number"] == 7
+
+    def test_http_error(self):
+        with _mock_http(422, {"message": "Validation Failed"}):
+            result = tools_write.create_pull_request(
+                {
+                    "repo": "org/repo",
+                    "title": "t",
+                    "head": "h",
+                    "base": "b",
+                    "dry_run": False,
+                }
+            )
+        assert "error" in result
+        assert "422" in result["error"]
+
+    def test_missing_repo(self):
+        with pytest.raises(ValueError, match="invalid repo"):
+            tools_write.create_pull_request(
+                {"title": "t", "head": "h", "base": "b"}
+            )
+
+    def test_missing_title(self):
+        with pytest.raises(ValueError, match="title is required"):
+            tools_write.create_pull_request(
+                {"repo": "org/repo", "head": "h", "base": "b"}
+            )
+
+    def test_missing_head(self):
+        with pytest.raises(ValueError, match="head is required"):
+            tools_write.create_pull_request(
+                {"repo": "org/repo", "title": "t", "base": "b"}
+            )
+
+    def test_missing_base(self):
+        with pytest.raises(ValueError, match="base is required"):
+            tools_write.create_pull_request(
+                {"repo": "org/repo", "title": "t", "head": "h"}
+            )
+
+    def test_whitespace_head(self):
+        with pytest.raises(ValueError, match="head is required"):
+            tools_write.create_pull_request(
+                {"repo": "org/repo", "title": "t", "head": "   ", "base": "b"}
+            )
+
+    def test_whitespace_base(self):
+        with pytest.raises(ValueError, match="base is required"):
+            tools_write.create_pull_request(
+                {"repo": "org/repo", "title": "t", "head": "h", "base": "   "}
+            )
+
+    def test_empty_title(self):
+        with pytest.raises(ValueError, match="title is required"):
+            tools_write.create_pull_request(
+                {"repo": "org/repo", "title": "  ", "head": "h", "base": "b"}
+            )
+
+    def test_body_too_long(self):
+        with pytest.raises(ValueError, match="character limit"):
+            tools_write.create_pull_request(
+                {
+                    "repo": "org/repo",
+                    "title": "t",
+                    "head": "h",
+                    "base": "b",
+                    "body": "x" * 65001,
+                }
+            )
+
+    def test_invalid_repo(self):
+        with pytest.raises(ValueError, match="invalid repo"):
+            tools_write.create_pull_request(
+                {"repo": "bad", "title": "t", "head": "h", "base": "b"}
+            )
+
+    def test_dry_run_does_not_call_api(self):
+        with _mock_http(201, {}) as mock_http, _mock_invalidate() as inv:
+            tools_write.create_pull_request(
+                {
+                    "repo": "org/repo",
+                    "title": "t",
+                    "head": "h",
+                    "base": "b",
+                }
+            )
+        mock_http.assert_not_called()
+        inv.assert_not_called()
+
+    def test_error_does_not_invalidate(self):
+        with _mock_http(422, {"message": "err"}), _mock_invalidate() as inv:
+            tools_write.create_pull_request(
+                {
+                    "repo": "org/repo",
+                    "title": "t",
+                    "head": "h",
+                    "base": "b",
+                    "dry_run": False,
+                }
+            )
+        inv.assert_not_called()
+
+
 # --- Cache invalidation ---
 
 

--- a/plugins/github/tools_write.py
+++ b/plugins/github/tools_write.py
@@ -277,8 +277,77 @@ def add_comment(params):
     return result
 
 
+def create_pull_request(params):
+    """Create a new pull request."""
+    repo = params.get("repo", "")
+    title = params.get("title", "")
+    head = params.get("head", "")
+    base = params.get("base", "")
+    body = params.get("body", "")
+    draft = params.get("draft", False)
+    maintainer_can_modify = params.get("maintainer_can_modify", True)
+    dry_run = params.get("dry_run", True)
+
+    _validate_repo(repo)
+    owner, name = _split_repo(repo)
+
+    if not title or not title.strip():
+        raise ValueError("title is required and must be non-empty")
+    if not head or not head.strip():
+        raise ValueError("head is required and must be non-empty")
+    if not base or not base.strip():
+        raise ValueError("base is required and must be non-empty")
+    if body and len(body) > _MAX_BODY_LEN:
+        raise ValueError(f"body exceeds {_MAX_BODY_LEN} character limit ({len(body)} chars)")
+
+    if dry_run:
+        preview = {
+            "dry_run": True,
+            "action": "github_create_pull_request",
+            "repo": repo,
+            "head": head,
+            "base": base,
+            "title": title,
+            "draft": draft,
+            "maintainer_can_modify": maintainer_can_modify,
+        }
+        if body:
+            preview["body_preview"] = body[:200]
+        return preview
+
+    api_body = {
+        "title": title,
+        "head": head,
+        "base": base,
+        "draft": draft,
+        "maintainer_can_modify": maintainer_can_modify,
+    }
+    if body:
+        api_body["body"] = body
+
+    status, resp, headers = handler.http(
+        "POST",
+        f"/repos/{owner}/{name}/pulls",
+        body=api_body,
+    )
+    if status < 200 or status >= 300:
+        return _http_error(status, resp)
+
+    handler.invalidate_cache()
+    result = {
+        "id": resp.get("id") if isinstance(resp, dict) else None,
+        "number": resp.get("number") if isinstance(resp, dict) else None,
+        "html_url": resp.get("html_url") if isinstance(resp, dict) else None,
+        "state": resp.get("state") if isinstance(resp, dict) else None,
+        "draft": resp.get("draft") if isinstance(resp, dict) else None,
+    }
+    _check_rate_limit(headers, result)
+    return result
+
+
 WRITE_TOOLS = {
     "github_create_review": create_review,
     "github_add_pr_comment": add_pr_comment,
     "github_add_comment": add_comment,
+    "github_create_pull_request": create_pull_request,
 }

--- a/plugins/github/tools_write.py
+++ b/plugins/github/tools_write.py
@@ -91,7 +91,7 @@ def create_review(params):
 
     comments = [_validate_comment(c, i) for i, c in enumerate(comments_raw)]
 
-    if dry_run:
+    if dry_run is not False:
         preview = {
             "dry_run": True,
             "action": "github_create_review",
@@ -177,7 +177,7 @@ def add_pr_comment(params):
         if validated_start_line >= line:
             raise ValueError(f"start_line ({validated_start_line}) must be less than line ({line})")
 
-    if dry_run:
+    if dry_run is not False:
         preview = {
             "dry_run": True,
             "action": "github_add_pr_comment",
@@ -251,7 +251,7 @@ def add_comment(params):
     if len(body) > _MAX_BODY_LEN:
         raise ValueError(f"body exceeds {_MAX_BODY_LEN} character limit")
 
-    if dry_run:
+    if dry_run is not False:
         return {
             "dry_run": True,
             "action": "github_add_comment",
@@ -300,7 +300,7 @@ def create_pull_request(params):
     if body and len(body) > _MAX_BODY_LEN:
         raise ValueError(f"body exceeds {_MAX_BODY_LEN} character limit ({len(body)} chars)")
 
-    if dry_run:
+    if dry_run is not False:
         preview = {
             "dry_run": True,
             "action": "github_create_pull_request",

--- a/plugins/gitlab/main.go
+++ b/plugins/gitlab/main.go
@@ -34,6 +34,7 @@ func main() {
 	p.Handle("gitlab_list_merge_requests", toolListMergeRequests)
 
 	// Write tools
+	p.Handle("gitlab_create_merge_request", toolCreateMergeRequest)
 	p.Handle("gitlab_create_mr_discussion", toolCreateMRDiscussion)
 	p.Handle("gitlab_add_mr_note", toolAddMRNote)
 

--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -300,6 +300,51 @@ tools:
         type: integer
         default: 20
 
+  - name: gitlab_create_merge_request
+    access: write
+    description: >
+      Create a new merge request. Defaults to dry_run=true which returns a
+      preview without creating. Set dry_run=false to create.
+    params:
+      instance:
+        type: string
+      project_id:
+        type: string
+        required: true
+        description: "Project ID or path (e.g. 'group/project')"
+      source_branch:
+        type: string
+        required: true
+        description: "Branch to merge from"
+      target_branch:
+        type: string
+        required: true
+        description: "Branch to merge into"
+      title:
+        type: string
+        required: true
+        description: "MR title"
+      description:
+        type: string
+        description: "MR description body"
+      labels:
+        type: array
+        description: "Labels to apply"
+      remove_source_branch:
+        type: boolean
+        description: "Delete source branch on merge"
+      squash:
+        type: boolean
+        description: "Squash commits on merge"
+      draft:
+        type: boolean
+        default: false
+        description: "Create as draft MR (prepends 'Draft: ' to title)"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without creating (default: true)"
+
   - name: gitlab_create_mr_discussion
     access: write
     description: >

--- a/plugins/gitlab/tools_write.go
+++ b/plugins/gitlab/tools_write.go
@@ -191,6 +191,111 @@ func toolAddMRNote(params, _ json.RawMessage) (any, error) {
 	}, nil
 }
 
+// --- gitlab_create_merge_request ---
+
+type createMergeRequestParams struct {
+	instanceParam
+	ProjectID          string   `json:"project_id"`
+	SourceBranch       string   `json:"source_branch"`
+	TargetBranch       string   `json:"target_branch"`
+	Title              string   `json:"title"`
+	Description        string   `json:"description"`
+	Labels             []string `json:"labels"`
+	RemoveSourceBranch *bool    `json:"remove_source_branch"`
+	Squash             *bool    `json:"squash"`
+	Draft              bool     `json:"draft"`
+	DryRun             *bool    `json:"dry_run"`
+}
+
+func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
+	var p createMergeRequestParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.ProjectID == "" {
+		return nil, fmt.Errorf("project_id is required")
+	}
+	if strings.TrimSpace(p.SourceBranch) == "" {
+		return nil, fmt.Errorf("source_branch is required")
+	}
+	if strings.TrimSpace(p.TargetBranch) == "" {
+		return nil, fmt.Errorf("target_branch is required")
+	}
+	if strings.TrimSpace(p.Title) == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+	if len([]rune(p.Description)) > maxBodyLen {
+		return nil, fmt.Errorf("description exceeds %d character limit (%d chars)", maxBodyLen, len([]rune(p.Description)))
+	}
+
+	title := p.Title
+	if p.Draft && !strings.HasPrefix(p.Title, "Draft: ") {
+		title = "Draft: " + title
+	}
+
+	if isDryRun(p.DryRun) {
+		m := map[string]any{
+			"dry_run":       true,
+			"action":        "gitlab_create_merge_request",
+			"project_id":    p.ProjectID,
+			"source_branch": p.SourceBranch,
+			"target_branch": p.TargetBranch,
+			"title":         title,
+		}
+		if p.Description != "" {
+			runes := []rune(p.Description)
+			if len(runes) > 200 {
+				runes = runes[:200]
+			}
+			m["description_preview"] = string(runes)
+		}
+		if len(p.Labels) > 0 {
+			m["labels"] = p.Labels
+		}
+		return m, nil
+	}
+
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &gogitlab.CreateMergeRequestOptions{
+		Title:        &title,
+		SourceBranch: &p.SourceBranch,
+		TargetBranch: &p.TargetBranch,
+	}
+	if p.RemoveSourceBranch != nil {
+		opts.RemoveSourceBranch = p.RemoveSourceBranch
+	}
+	if p.Squash != nil {
+		opts.Squash = p.Squash
+	}
+	if p.Description != "" {
+		opts.Description = &p.Description
+	}
+	if len(p.Labels) > 0 {
+		labels := gogitlab.LabelOptions(p.Labels)
+		opts.Labels = &labels
+	}
+
+	mr, _, err := client.MergeRequests.CreateMergeRequest(p.ProjectID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create merge request: %w", err)
+	}
+
+	return map[string]any{
+		"iid":           mr.IID,
+		"project_id":    p.ProjectID,
+		"title":         mr.Title,
+		"web_url":       mr.WebURL,
+		"state":         mr.State,
+		"source_branch": mr.SourceBranch,
+		"target_branch": mr.TargetBranch,
+		"created":       true,
+	}, nil
+}
+
 // --- helpers ---
 
 func fetchDiffRefs(client *gogitlab.Client, pid string, mrIID int64) (baseSHA, headSHA, startSHA string, err error) {

--- a/plugins/gitlab/tools_write.go
+++ b/plugins/gitlab/tools_write.go
@@ -229,8 +229,13 @@ func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
 	}
 
 	title := p.Title
-	if p.Draft && !strings.HasPrefix(p.Title, "Draft: ") {
+	if p.Draft && !strings.HasPrefix(strings.ToLower(p.Title), "draft: ") {
 		title = "Draft: " + title
+	}
+
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
 	}
 
 	if isDryRun(p.DryRun) {
@@ -252,12 +257,16 @@ func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
 		if len(p.Labels) > 0 {
 			m["labels"] = p.Labels
 		}
+		if p.Draft {
+			m["draft"] = true
+		}
+		if p.RemoveSourceBranch != nil {
+			m["remove_source_branch"] = *p.RemoveSourceBranch
+		}
+		if p.Squash != nil {
+			m["squash"] = *p.Squash
+		}
 		return m, nil
-	}
-
-	client, err := resolveInstance(p.Instance)
-	if err != nil {
-		return nil, err
 	}
 
 	opts := &gogitlab.CreateMergeRequestOptions{

--- a/plugins/gitlab/tools_write_test.go
+++ b/plugins/gitlab/tools_write_test.go
@@ -29,6 +29,272 @@ func TestIsDryRunFalse(t *testing.T) {
 	}
 }
 
+// --- gitlab_create_merge_request ---
+
+func TestCreateMergeRequestDryRun(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP calls in dry run")
+		http.NotFound(w, r)
+	})
+
+	result, err := toolCreateMergeRequest(mustJSON(t, map[string]any{
+		"project_id":    "team/proj",
+		"source_branch": "feature-x",
+		"target_branch": "main",
+		"title":         "Add feature X",
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateMergeRequest: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["dry_run"] != true {
+		t.Errorf("dry_run = %v, want true", m["dry_run"])
+	}
+	if m["action"] != "gitlab_create_merge_request" {
+		t.Errorf("action = %v", m["action"])
+	}
+	if m["title"] != "Add feature X" {
+		t.Errorf("title = %v", m["title"])
+	}
+}
+
+func TestCreateMergeRequestDraftTitle(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP calls in dry run")
+		http.NotFound(w, r)
+	})
+
+	result, err := toolCreateMergeRequest(mustJSON(t, map[string]any{
+		"project_id":    "team/proj",
+		"source_branch": "wip",
+		"target_branch": "main",
+		"title":         "Work in progress",
+		"draft":         true,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateMergeRequest: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["title"] != "Draft: Work in progress" {
+		t.Errorf("title = %q, want 'Draft: Work in progress'", m["title"])
+	}
+}
+
+func TestCreateMergeRequestDraftTitleAlreadyPrefixed(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP calls in dry run")
+		http.NotFound(w, r)
+	})
+
+	result, err := toolCreateMergeRequest(mustJSON(t, map[string]any{
+		"project_id":    "team/proj",
+		"source_branch": "wip",
+		"target_branch": "main",
+		"title":         "Draft: Already prefixed",
+		"draft":         true,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateMergeRequest: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["title"] != "Draft: Already prefixed" {
+		t.Errorf("title = %q, want no double prefix", m["title"])
+	}
+}
+
+
+func TestCreateMergeRequestDryRunPreview(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP calls in dry run")
+		http.NotFound(w, r)
+	})
+
+	result, err := toolCreateMergeRequest(mustJSON(t, map[string]any{
+		"project_id":    "team/proj",
+		"source_branch": "feat",
+		"target_branch": "main",
+		"title":         "My MR",
+		"description":   "A detailed description",
+		"labels":        []string{"bug", "help wanted"},
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateMergeRequest: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["description_preview"] != "A detailed description" {
+		t.Errorf("description_preview = %v", m["description_preview"])
+	}
+	labels, ok := m["labels"].([]string)
+	if !ok || len(labels) != 2 {
+		t.Errorf("labels = %v", m["labels"])
+	}
+}
+
+func TestCreateMergeRequestExecute(t *testing.T) {
+	var gotBody map[string]any
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/merge_requests") {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Errorf("decode request body: %v", err)
+			}
+			jsonResponse(w, `{
+				"iid": 42,
+				"title": "Add feature X",
+				"web_url": "https://gitlab.com/team/proj/-/merge_requests/42",
+				"state": "opened",
+				"source_branch": "feature-x",
+				"target_branch": "main"
+			}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	dryRun := false
+	result, err := toolCreateMergeRequest(mustJSON(t, map[string]any{
+		"project_id":    "team/proj",
+		"source_branch": "feature-x",
+		"target_branch": "main",
+		"title":         "Add feature X",
+		"description":   "Implements the X feature",
+		"dry_run":       dryRun,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateMergeRequest: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["iid"] != int64(42) {
+		t.Errorf("iid = %v (%T), want 42", m["iid"], m["iid"])
+	}
+	if m["state"] != "opened" {
+		t.Errorf("state = %v, want opened", m["state"])
+	}
+	if m["web_url"] == "" {
+		t.Error("web_url should not be empty")
+	}
+
+	if gotBody == nil {
+		t.Fatal("expected POST body to be captured")
+	}
+	if m["created"] != true {
+		t.Errorf("created = %v, want true", m["created"])
+	}
+	if m["project_id"] != "team/proj" {
+		t.Errorf("project_id = %v, want team/proj", m["project_id"])
+	}
+	if gotBody["description"] != "Implements the X feature" {
+		t.Errorf("posted description = %v", gotBody["description"])
+	}
+	if gotBody["title"] != "Add feature X" {
+		t.Errorf("posted title = %v", gotBody["title"])
+	}
+}
+
+func TestCreateMergeRequestExecuteDraft(t *testing.T) {
+	var gotTitle string
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/merge_requests") {
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode request body: %v", err)
+			}
+			gotTitle, _ = body["title"].(string)
+			jsonResponse(w, `{
+				"iid": 7,
+				"title": "Draft: My feature",
+				"web_url": "https://gitlab.com/team/proj/-/merge_requests/7",
+				"state": "opened",
+				"source_branch": "feat",
+				"target_branch": "main"
+			}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	dryRun := false
+	_, err := toolCreateMergeRequest(mustJSON(t, map[string]any{
+		"project_id":    "team/proj",
+		"source_branch": "feat",
+		"target_branch": "main",
+		"title":         "My feature",
+		"draft":         true,
+		"dry_run":       dryRun,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateMergeRequest: %v", err)
+	}
+	if gotTitle != "Draft: My feature" {
+		t.Errorf("sent title = %q, want 'Draft: My feature'", gotTitle)
+	}
+}
+
+func TestCreateMergeRequestValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+		errMsg string
+	}{
+		{
+			name:   "missing project_id",
+			params: map[string]any{"source_branch": "feat", "target_branch": "main", "title": "t"},
+			errMsg: "project_id is required",
+		},
+		{
+			name:   "missing source_branch",
+			params: map[string]any{"project_id": "p", "target_branch": "main", "title": "t"},
+			errMsg: "source_branch is required",
+		},
+		{
+			name:   "missing target_branch",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "title": "t"},
+			errMsg: "target_branch is required",
+		},
+		{
+			name:   "missing title",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main"},
+			errMsg: "title is required",
+		},
+		{
+			name:   "whitespace title",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main", "title": "   "},
+			errMsg: "title is required",
+		},
+		{
+			name:   "whitespace source_branch",
+			params: map[string]any{"project_id": "p", "source_branch": "   ", "target_branch": "main", "title": "t"},
+			errMsg: "source_branch is required",
+		},
+		{
+			name:   "whitespace target_branch",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "   ", "title": "t"},
+			errMsg: "target_branch is required",
+		},
+		{
+			name:   "description too long",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main", "title": "t", "description": strings.Repeat("x", maxBodyLen+1)},
+			errMsg: "description exceeds",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := toolCreateMergeRequest(mustJSON(t, tc.params), nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tc.errMsg)
+			}
+		})
+	}
+}
+
 // --- gitlab_create_mr_discussion ---
 
 func TestCreateMRDiscussionDryRun(t *testing.T) {

--- a/plugins/gitlab/tools_write_test.go
+++ b/plugins/gitlab/tools_write_test.go
@@ -105,7 +105,6 @@ func TestCreateMergeRequestDraftTitleAlreadyPrefixed(t *testing.T) {
 	}
 }
 
-
 func TestCreateMergeRequestDryRunPreview(t *testing.T) {
 	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not make any HTTP calls in dry run")


### PR DESCRIPTION
Add `github_create_pull_request` to the GitHub plugin and `gitlab_create_merge_request` to the GitLab plugin.

Both tools default to `dry_run=true` for safety.

### GitHub — `github_create_pull_request`

Required: `repo`, `title`, `head`, `base`
Optional: `body`, `draft`, `maintainer_can_modify`, `dry_run`

### GitLab — `gitlab_create_merge_request`

Required: `project_id`, `source_branch`, `target_branch`, `title`
Optional: `instance`, `description`, `labels`, `remove_source_branch`, `squash`, `draft` (prepends `Draft: ` unless already prefixed), `dry_run`

### Testing
- Added unit tests for both plugins covering the new write tools