### PR TITLE
build: add make nosandbox target

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -32,7 +32,8 @@ from the `third_party/arapuca` submodule (requires a Rust toolchain).
 To build without sandbox support:
 
 ```bash
-make build-nosandbox
+make nosandbox
+WTMCP_UNSANDBOXED=1 ./wtmcp   # required at runtime
 ```
 
 ## Verify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 
 ```bash
 make build       # Build wtmcp, wtmcpctl, and all plugins
+make nosandbox   # Build without arapuca sandbox (WTMCP_UNSANDBOXED=1 at runtime)
 make test        # go test -v -race ./... (requires libarapuca)
 make lint        # golangci-lint run ./...
 make fmt         # gofmt -l -w .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build plugins test test-nosandbox lint fmt vet tidy clean help govulncheck
+.PHONY: all build nosandbox plugins test test-nosandbox lint fmt vet tidy clean help govulncheck
 
 # Go toolchain version — derived from go.mod to stay in sync with dependency bumps
 GO_TOOLCHAIN_VERSION := $(shell sed -n 's/^go //p' go.mod)
@@ -34,6 +34,16 @@ wtmcp: arapuca $(shell find cmd/wtmcp -name '*.go') $(shell find internal -name 
 wtmcpctl: arapuca $(shell find cmd/wtmcpctl -name '*.go') $(shell find internal -name '*.go')
 	@echo "Building wtmcpctl..."
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o wtmcpctl ./cmd/wtmcpctl
+
+# Build without arapuca sandbox (no libarapuca needed).
+# Requires WTMCP_UNSANDBOXED=1 at runtime.
+nosandbox: plugins
+	@echo "Building wtmcp (nosandbox)..."
+	go build -tags nosandbox $(GOFLAGS) -ldflags "$(LDFLAGS)" -o wtmcp ./cmd/wtmcp
+	@echo "Building wtmcpctl (nosandbox)..."
+	go build -tags nosandbox $(GOFLAGS) -ldflags "$(LDFLAGS)" -o wtmcpctl ./cmd/wtmcpctl
+	@echo ""
+	@echo "Built without sandbox. Run with: WTMCP_UNSANDBOXED=1 ./wtmcp"
 
 # Build all plugins that have a Makefile
 plugins:
@@ -137,6 +147,7 @@ help:
 	@echo "Available targets:"
 	@echo "  all            - Build everything (default)"
 	@echo "  build          - Build all binaries and plugins"
+	@echo "  nosandbox      - Build without arapuca sandbox (no libarapuca needed)"
 	@echo "  arapuca        - Build libarapuca (auto-detected: system or submodule)"
 	@echo "  wtmcp          - Build wtmcp binary"
 	@echo "  wtmcpctl       - Build wtmcpctl binary"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ make build    # auto-detects system libarapuca or builds from submodule
 To build **without** sandbox (debug/development only):
 
 ```bash
-go build -tags nosandbox ./cmd/wtmcp
+make nosandbox
 WTMCP_UNSANDBOXED=1 ./wtmcp   # required at runtime
 ```
 

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -1016,7 +1016,7 @@ def _validate_export_path(file_path):
     return resolved
 ```
 
-Under sandbox (`make build-sandbox`), `_session_dir` is in the
+Under sandbox (`make build`), `_session_dir` is in the
 sandbox's read paths and `_output_dir` is in the write paths.
 Attempting to access files outside these directories will fail with
 `EACCES`.
@@ -1024,9 +1024,9 @@ Attempting to access files outside these directories will fail with
 ## Security
 
 - Plugins are semi-trusted: without sandboxing they run with the
-  same OS privileges as the core. With sandbox enabled (`-tags
-  sandbox`), plugins are confined via Landlock, cgroups, and network
-  namespaces. Only install plugins you trust.
+  same OS privileges as the core. With sandbox enabled (the default
+  `make build`), plugins are confined via Landlock, cgroups, and
+  network namespaces. Only install plugins you trust.
 - **User plugins** (in `{workdir}/plugins/`) are disabled by default.
   Enable with `user_plugins: true` in `config.yaml`. User plugins
   cannot override system plugins, declare `provides.auth`, or claim
@@ -1060,7 +1060,7 @@ Attempting to access files outside these directories will fail with
   and DELETE are rejected with `method_not_allowed`.
 - Cache namespaces are isolated — plugins cannot read other plugins'
   cached data.
-- **Sandboxing** (optional, `make build-sandbox`): Landlock
+- **Sandboxing** (default `make build`; disable with `make nosandbox`): Landlock
   filesystem confinement restricts read/write to declared paths.
   cgroup v2 resource limits cap memory, CPU, PIDs, and file size
   per plugin. Network namespace isolation forces all traffic through

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -308,7 +308,7 @@ func Load(configPath, workdir string) (*Config, error) {
 		if sb, ok := raw["sandbox"].(map[string]any); ok {
 			if _, hasEnabled := sb["enabled"]; hasEnabled {
 				log.Printf("WARNING: sandbox.enabled was removed — sandbox is now always active "+
-					"when built with libarapuca; to build without sandbox use -tags nosandbox. "+
+					"when built with libarapuca; to build without sandbox use `make nosandbox`. "+
 					"Remove the field from %s to silence this warning.", configPath)
 			}
 		}


### PR DESCRIPTION
Building without the arapuca sandbox previously required knowing the raw go build invocation with -tags nosandbox. Several documentation files also referenced stale target names like build-nosandbox and build-sandbox that do not exist in the current Makefile.

Add a nosandbox target that builds both wtmcp and wtmcpctl with the nosandbox build tag, depending on plugins but skipping the arapuca dependency. Update references in BUILDING.md, CLAUDE.md, README.md, the plugin guide, and the config.go deprecation warning to use the new target name consistently.