### PR TITLE
Add read/write tools to GitHub and GitLab plugins, harden existing handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
           submodules: true
 
       - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -71,7 +73,9 @@ jobs:
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y libkrb5-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -209,12 +209,15 @@ type ParamDef struct {
 	Description string    `yaml:"description"`
 	Required    bool      `yaml:"required"`
 	Default     any       `yaml:"default"`
+	Enum        []any     `yaml:"enum,omitempty"`
 	Items       *ItemsDef `yaml:"items"`
 }
 
 // ItemsDef describes array item types.
 type ItemsDef struct {
-	Type string `yaml:"type"`
+	Type       string              `yaml:"type"`
+	Properties map[string]ParamDef `yaml:"properties,omitempty"`
+	Required   []string            `yaml:"required,omitempty"`
 }
 
 // IsEnabled returns whether the plugin is enabled (defaults to true).
@@ -335,6 +338,14 @@ func cloneTools(tools []ToolDef) []ToolDef {
 			for k, p := range t.Params {
 				if p.Items != nil {
 					items := *p.Items
+					if items.Properties != nil {
+						props := make(map[string]ParamDef, len(items.Properties))
+						for pk, pv := range items.Properties {
+							props[pk] = pv
+						}
+						items.Properties = props
+					}
+					items.Required = slices.Clone(items.Required)
 					p.Items = &items
 				}
 				if p.Default != nil {
@@ -417,7 +428,10 @@ func LoadManifest(path string) (*Manifest, error) {
 	return &m, nil
 }
 
-// Validate checks the manifest for correctness.
+// Validate checks the manifest for correctness and auto-fixes certain
+// schema issues (e.g., array params missing an items definition get a
+// default of {type: string} with a warning). Callers should expect
+// mutation of the manifest.
 func (m *Manifest) Validate() error {
 	if !pluginNamePattern.MatchString(m.Name) {
 		return fmt.Errorf("invalid plugin name %q: must match [a-z0-9][a-z0-9_-]{0,62}[a-z0-9]", m.Name)
@@ -550,6 +564,12 @@ func (m *Manifest) Validate() error {
 			if len(param.Description) > maxParamDescriptionLen {
 				return fmt.Errorf("tool %s param %s: description exceeds %d bytes", tool.Name, pname, maxParamDescriptionLen)
 			}
+			if param.Type == "array" && param.Items == nil {
+				fmt.Fprintf(os.Stderr, "WARN: tool %s param %s: array type missing "+
+					"items definition, defaulting to {type: string}\n", tool.Name, pname)
+				param.Items = &ItemsDef{Type: "string"}
+				tool.Params[pname] = param
+			}
 		}
 	}
 
@@ -585,8 +605,32 @@ func (t *ToolDef) ParamsSchema() map[string]any {
 		if p.Default != nil {
 			prop["default"] = p.Default
 		}
+		if len(p.Enum) > 0 {
+			prop["enum"] = p.Enum
+		}
 		if p.Type == "array" && p.Items != nil {
-			prop["items"] = map[string]any{"type": p.Items.Type}
+			itemSchema := map[string]any{"type": p.Items.Type}
+			if len(p.Items.Properties) > 0 {
+				itemProps := make(map[string]any, len(p.Items.Properties))
+				for pn, pp := range p.Items.Properties {
+					iprop := map[string]any{"type": pp.Type}
+					if pp.Description != "" {
+						iprop["description"] = pp.Description
+					}
+					if pp.Default != nil {
+						iprop["default"] = pp.Default
+					}
+					if len(pp.Enum) > 0 {
+						iprop["enum"] = pp.Enum
+					}
+					itemProps[pn] = iprop
+				}
+				itemSchema["properties"] = itemProps
+			}
+			if len(p.Items.Required) > 0 {
+				itemSchema["required"] = p.Items.Required
+			}
+			prop["items"] = itemSchema
 		}
 		properties[name] = prop
 		if p.Required {

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -336,6 +336,59 @@ func TestParamsSchema(t *testing.T) {
 	}
 }
 
+func TestParamsSchemaObjectItems(t *testing.T) {
+	tool := ToolDef{
+		Name: "test",
+		Params: map[string]ParamDef{
+			"comments": {
+				Type: "array",
+				Items: &ItemsDef{
+					Type: "object",
+					Properties: map[string]ParamDef{
+						"path": {Type: "string", Description: "File path"},
+						"line": {Type: "integer"},
+						"body": {Type: "string"},
+					},
+					Required: []string{"path", "line", "body"},
+				},
+			},
+		},
+	}
+
+	schema := tool.ParamsSchema()
+	props := schema["properties"].(map[string]any)
+	commentsProp := props["comments"].(map[string]any)
+	items := commentsProp["items"].(map[string]any)
+
+	if items["type"] != "object" {
+		t.Errorf("items type = %v, want object", items["type"])
+	}
+
+	itemProps, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("items properties missing")
+	}
+	if len(itemProps) != 3 {
+		t.Errorf("got %d item properties, want 3", len(itemProps))
+	}
+
+	pathProp := itemProps["path"].(map[string]any)
+	if pathProp["type"] != "string" {
+		t.Errorf("path type = %v", pathProp["type"])
+	}
+	if pathProp["description"] != "File path" {
+		t.Errorf("path description = %v", pathProp["description"])
+	}
+
+	itemRequired, ok := items["required"].([]string)
+	if !ok {
+		t.Fatal("items required missing")
+	}
+	if len(itemRequired) != 3 {
+		t.Errorf("items required = %v, want 3 entries", itemRequired)
+	}
+}
+
 func TestManifestAuthVariantOrder(t *testing.T) {
 	dir := t.TempDir()
 	handlerPath := filepath.Join(dir, "handler")
@@ -903,8 +956,18 @@ func TestManifestCloneIndependence(t *testing.T) {
 		Config:       map[string]string{"k": "v"},
 		Tools: []ToolDef{
 			{
-				Name:   "tool1",
-				Params: map[string]ParamDef{"p1": {Type: "string"}},
+				Name: "tool1",
+				Params: map[string]ParamDef{
+					"p1": {Type: "string"},
+					"arr": {
+						Type: "array",
+						Items: &ItemsDef{
+							Type:       "object",
+							Properties: map[string]ParamDef{"nested": {Type: "string"}},
+							Required:   []string{"nested"},
+						},
+					},
+				},
 			},
 		},
 		Services: ServiceConfig{
@@ -946,6 +1009,8 @@ func TestManifestCloneIndependence(t *testing.T) {
 	clone.ContextFiles[0] = "MUTATED"
 	clone.Config["k"] = "MUTATED"
 	clone.Tools[0].Params["p1"] = ParamDef{Type: "MUTATED"}
+	clone.Tools[0].Params["arr"].Items.Properties["nested"] = ParamDef{Type: "MUTATED"}
+	clone.Tools[0].Params["arr"].Items.Required[0] = "MUTATED"
 	clone.Services.Auth.Scopes[0] = "MUTATED"
 	clone.Services.Auth.VariantOrder[0] = "MUTATED"
 	clone.Services.Auth.Variants["v1"] = AuthServiceConfig{Scopes: []string{"MUTATED"}}
@@ -1305,4 +1370,69 @@ func FuzzValidatePluginName(f *testing.F) {
 				name, pluginNameRE.String())
 		}
 	})
+}
+
+func TestValidateArrayWithoutItemsAutoFix(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "handler"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // test needs executable
+		t.Fatal(err)
+	}
+	m := &Manifest{
+		Name:      "test",
+		Handler:   "handler",
+		Execution: "persistent",
+		Dir:       dir,
+		Tools: []ToolDef{
+			{
+				Name:        "test_tool",
+				Description: "d",
+				Params: map[string]ParamDef{
+					"tags": {Type: "array"},
+				},
+			},
+		},
+	}
+
+	if err := m.Validate(); err != nil {
+		t.Fatalf("Validate() returned error for array without items: %v", err)
+	}
+
+	param := m.Tools[0].Params["tags"]
+	if param.Items == nil {
+		t.Fatal("Items was not auto-injected")
+	}
+	if param.Items.Type != "string" {
+		t.Errorf("Items.Type = %q, want \"string\"", param.Items.Type)
+	}
+}
+
+func TestValidateArrayWithItemsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "handler"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // test needs executable
+		t.Fatal(err)
+	}
+	m := &Manifest{
+		Name:      "test",
+		Handler:   "handler",
+		Execution: "persistent",
+		Dir:       dir,
+		Tools: []ToolDef{
+			{
+				Name:        "test_tool",
+				Description: "d",
+				Params: map[string]ParamDef{
+					"ids": {Type: "array", Items: &ItemsDef{Type: "integer"}},
+				},
+			},
+		},
+	}
+
+	if err := m.Validate(); err != nil {
+		t.Fatalf("Validate() returned error for array with items: %v", err)
+	}
+
+	param := m.Tools[0].Params["ids"]
+	if param.Items.Type != "integer" {
+		t.Errorf("Items.Type = %q, want \"integer\" (should not be overwritten)", param.Items.Type)
+	}
 }

--- a/plugins/github/handler.py
+++ b/plugins/github/handler.py
@@ -105,8 +105,8 @@ def invalidate_cache():
     """Flush plugin cache after a write operation (best-effort)."""
     try:
         cache_flush()
-    except Exception:
-        pass
+    except Exception as e:
+        log(f"cache invalidation failed (best-effort): {e}")
 
 
 def _discover_username():

--- a/plugins/github/plugin.yaml
+++ b/plugins/github/plugin.yaml
@@ -265,6 +265,90 @@ tools:
         default: 0
         description: "Starting index for pagination"
 
+  - name: github_get_file_contents
+    access: read
+    description: >
+      Get file or directory contents from a repository. Returns decoded
+      text for files (capped at 50KB), or a list of entries for
+      directories (capped at 200). Use ref to read from a specific
+      branch or commit.
+    params:
+      repo:
+        type: string
+        required: true
+        description: "Repository as owner/repo"
+      path:
+        type: string
+        required: true
+        description: "Path to file or directory"
+      ref:
+        type: string
+        description: "Branch, tag, or commit SHA (default: repo default branch)"
+
+  - name: github_search_code
+    access: read
+    description: >
+      Search for code across repositories. Returns matching file paths
+      and repository names. Query uses GitHub code search syntax.
+    params:
+      query:
+        type: string
+        required: true
+        description: "Search query (GitHub code search syntax)"
+      max_results:
+        type: integer
+        default: 30
+
+  - name: github_search_repositories
+    access: read
+    description: >
+      Search for repositories by name, description, or topic. Returns
+      repository metadata including stars, language, and default branch.
+    params:
+      query:
+        type: string
+        required: true
+        description: "Search query"
+      max_results:
+        type: integer
+        default: 30
+
+  - name: github_list_pull_requests
+    access: read
+    description: >
+      List pull requests for a repository. Filter by state (open,
+      closed, all). Returns PR number, title, author, base/head
+      branches, and labels.
+    params:
+      repo:
+        type: string
+        required: true
+        description: "Repository as owner/repo"
+      state:
+        type: string
+        default: "open"
+        description: "Filter by state: open, closed, all"
+      max_results:
+        type: integer
+        default: 30
+
+  - name: github_list_commits
+    access: read
+    description: >
+      List commits for a repository. Optionally filter by branch, tag,
+      or SHA. Returns commit SHA, message, author, and date.
+    params:
+      repo:
+        type: string
+        required: true
+        description: "Repository as owner/repo"
+      sha:
+        type: string
+        description: "Branch name, tag, or SHA to list commits from (default: repo default branch)"
+      max_results:
+        type: integer
+        default: 20
+
   - name: github_create_review
     access: write
     description: >

--- a/plugins/github/plugin.yaml
+++ b/plugins/github/plugin.yaml
@@ -504,6 +504,61 @@ tools:
         default: true
         description: "Preview without creating (default: true)"
 
+  - name: github_create_branch
+    access: write
+    description: >
+      Create a new branch from a source branch. Fetches the source
+      branch SHA first (even in dry_run) to validate it exists.
+      Defaults to dry_run=true.
+    params:
+      repo:
+        type: string
+        required: true
+        description: "Repository as owner/repo"
+      branch_name:
+        type: string
+        required: true
+        description: "Name for the new branch"
+      source_branch:
+        type: string
+        default: "main"
+        description: "Branch to create from (default: main)"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without creating (default: true)"
+
+  - name: github_create_or_update_file
+    access: write
+    description: >
+      Create or update a file in a repository. Content is plain text
+      (base64-encoded automatically). Checks if the file exists to
+      determine create vs update. Defaults to dry_run=true.
+    params:
+      repo:
+        type: string
+        required: true
+        description: "Repository as owner/repo"
+      path:
+        type: string
+        required: true
+        description: "File path in the repository"
+      content:
+        type: string
+        required: true
+        description: "File content (plain text, max 1MB)"
+      message:
+        type: string
+        required: true
+        description: "Commit message"
+      branch:
+        type: string
+        description: "Target branch (default: repo default branch)"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without creating (default: true)"
+
 setup:
   credentials:
     GITHUB_TOKEN:

--- a/plugins/github/tests/test_tools.py
+++ b/plugins/github/tests/test_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for GitHub plugin tools."""
 
+import base64
 from unittest.mock import patch
 
 import handler
@@ -401,3 +402,247 @@ class TestRateLimit:
         with _mock_cache_get(None), _mock_http(200, PR_RESPONSE, {"X-RateLimit-Remaining": "4999"}), _mock_cache_set():
             result = tools.get_pr({"repo": "org/repo", "pr_number": 42})
             assert "_rate_limit_remaining" not in result
+
+
+# --- github_get_file_contents ---
+
+
+FILE_RESPONSE = {
+    "name": "main.fmf",
+    "path": "tests/main.fmf",
+    "size": 42,
+    "type": "file",
+    "sha": "abc123",
+    "content": base64.b64encode(b"summary: Test plan\n").decode(),
+    "encoding": "base64",
+    "html_url": "https://github.com/org/repo/blob/main/tests/main.fmf",
+}
+
+DIR_RESPONSE = [
+    {"name": "file1.py", "type": "file", "path": "src/file1.py", "size": 100},
+    {"name": "file2.py", "type": "file", "path": "src/file2.py", "size": 200},
+]
+
+
+class TestGetFileContents:
+    def test_file_decoded(self):
+        with _mock_cache_get(None), _mock_http(200, FILE_RESPONSE), _mock_cache_set():
+            result = tools.get_file_contents({"repo": "org/repo", "path": "tests/main.fmf"})
+        assert result["content"] == "summary: Test plan\n"
+        assert result["name"] == "main.fmf"
+
+    def test_directory(self):
+        with _mock_cache_get(None), _mock_http(200, DIR_RESPONSE), _mock_cache_set():
+            result = tools.get_file_contents({"repo": "org/repo", "path": "src"})
+        assert result["type"] == "directory"
+        assert result["count"] == 2
+
+    def test_large_file_truncated(self):
+        big_content = base64.b64encode(b"x" * 60000).decode()
+        resp = {**FILE_RESPONSE, "content": big_content, "size": 60000}
+        with _mock_cache_get(None), _mock_http(200, resp), _mock_cache_set():
+            result = tools.get_file_contents({"repo": "org/repo", "path": "big.txt"})
+        assert "TRUNCATED" in result["content"]
+
+    def test_null_content(self):
+        resp = {**FILE_RESPONSE, "content": None, "size": 2000000}
+        with _mock_cache_get(None), _mock_http(200, resp), _mock_cache_set():
+            result = tools.get_file_contents({"repo": "org/repo", "path": "huge.bin"})
+        assert result["content_available"] is False
+
+    def test_binary_content(self):
+        binary = base64.b64encode(b"\x00\x01\x02binary").decode()
+        resp = {**FILE_RESPONSE, "content": binary, "size": 10}
+        with _mock_cache_get(None), _mock_http(200, resp), _mock_cache_set():
+            result = tools.get_file_contents({"repo": "org/repo", "path": "data.bin"})
+        assert result.get("binary") is True
+        assert result["content_available"] is False
+
+    def test_with_ref(self):
+        with _mock_cache_get(None), _mock_http(200, FILE_RESPONSE) as mock, _mock_cache_set():
+            tools.get_file_contents({"repo": "org/repo", "path": "f.txt", "ref": "feature-branch"})
+        call_args = mock.call_args
+        assert (
+            call_args[1].get("query", {}).get("ref") == "feature-branch"
+            or call_args[0][2].get("ref") == "feature-branch"
+        )
+
+    def test_missing_path(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="path is required"):
+            tools.get_file_contents({"repo": "org/repo"})
+
+    def test_path_traversal_rejected(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="path traversal"):
+            tools.get_file_contents({"repo": "org/repo", "path": "../../etc/passwd"})
+
+    def test_absolute_path_rejected(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="absolute path"):
+            tools.get_file_contents({"repo": "org/repo", "path": "/etc/passwd"})
+
+    def test_invalid_repo(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="invalid repo"):
+            tools.get_file_contents({"repo": "bad", "path": "f.txt"})
+
+    def test_http_error(self):
+        with _mock_cache_get(None), _mock_http(404, {"message": "Not Found"}):
+            result = tools.get_file_contents({"repo": "org/repo", "path": "missing.txt"})
+        assert "error" in result
+
+    def test_cache_hit(self):
+        cached = {"type": "file", "content": "cached"}
+        with _mock_cache_get(cached):
+            result = tools.get_file_contents({"repo": "org/repo", "path": "f.txt"})
+        assert result == cached
+
+
+# --- github_search_code ---
+
+
+class TestSearchCode:
+    def test_basic_search(self):
+        resp = {
+            "total_count": 1,
+            "items": [
+                {
+                    "name": "test.py",
+                    "path": "src/test.py",
+                    "sha": "a" * 40,
+                    "html_url": "url",
+                    "repository": {"full_name": "org/repo"},
+                }
+            ],
+        }
+        with _mock_cache_get(None), _mock_http(200, resp), _mock_cache_set():
+            result = tools.search_code({"query": "def test_login"})
+        assert result["total"] == 1
+        assert result["items"][0]["repo"] == "org/repo"
+
+    def test_empty_query(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="query is required"):
+            tools.search_code({"query": ""})
+
+    def test_http_error(self):
+        with _mock_cache_get(None), _mock_http(422, {"message": "Validation Failed"}):
+            result = tools.search_code({"query": "x"})
+        assert "error" in result
+
+
+# --- github_search_repositories ---
+
+
+class TestSearchRepositories:
+    def test_basic_search(self):
+        resp = {
+            "total_count": 1,
+            "items": [
+                {
+                    "full_name": "org/tests",
+                    "description": "Test repo",
+                    "html_url": "url",
+                    "language": "Python",
+                    "stargazers_count": 5,
+                    "forks_count": 1,
+                    "updated_at": "2026-01-01",
+                    "default_branch": "main",
+                    "archived": False,
+                }
+            ],
+        }
+        with _mock_cache_get(None), _mock_http(200, resp), _mock_cache_set():
+            result = tools.search_repositories({"query": "clevis-tests"})
+        assert result["items"][0]["full_name"] == "org/tests"
+        assert result["items"][0]["stars"] == 5
+
+    def test_empty_query(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="query is required"):
+            tools.search_repositories({"query": ""})
+
+
+# --- github_list_pull_requests ---
+
+
+class TestListPullRequests:
+    def test_basic_list(self):
+        resp = [
+            {
+                "number": 1,
+                "title": "PR 1",
+                "state": "open",
+                "draft": False,
+                "user": {"login": "alice"},
+                "base": {"ref": "main"},
+                "head": {"ref": "fix"},
+                "labels": [],
+                "created_at": "2026-01-01",
+                "updated_at": "2026-01-02",
+                "html_url": "url",
+            }
+        ]
+        with _mock_cache_get(None), _mock_http(200, resp), _mock_cache_set():
+            result = tools.list_pull_requests({"repo": "org/repo"})
+        assert result["count"] == 1
+        assert result["pull_requests"][0]["number"] == 1
+
+    def test_state_filter(self):
+        with _mock_cache_get(None), _mock_http(200, []) as mock, _mock_cache_set():
+            tools.list_pull_requests({"repo": "org/repo", "state": "closed"})
+        query = mock.call_args[1].get("query") or mock.call_args[0][2]
+        assert query["state"] == "closed"
+
+    def test_invalid_state(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="invalid state"):
+            tools.list_pull_requests({"repo": "org/repo", "state": "merged"})
+
+
+# --- github_list_commits ---
+
+
+class TestListCommits:
+    def test_basic_list(self):
+        resp = [
+            {
+                "sha": "a" * 40,
+                "commit": {"message": "fix bug", "author": {"name": "Alice", "date": "2026-01-01"}},
+                "author": {"login": "alice"},
+                "html_url": "url",
+            }
+        ]
+        with _mock_cache_get(None), _mock_http(200, resp), _mock_cache_set():
+            result = tools.list_commits({"repo": "org/repo"})
+        assert result["count"] == 1
+        assert result["commits"][0]["sha"] == "a" * 12
+        assert result["commits"][0]["author"] == "alice"
+        assert "email" not in str(result)
+
+    def test_with_sha(self):
+        with _mock_cache_get(None), _mock_http(200, []) as mock, _mock_cache_set():
+            tools.list_commits({"repo": "org/repo", "sha": "feature-branch"})
+        query = mock.call_args[1].get("query") or mock.call_args[0][2]
+        assert query["sha"] == "feature-branch"
+
+    def test_fallback_to_commit_author_name(self):
+        resp = [
+            {
+                "sha": "b" * 40,
+                "commit": {"message": "msg", "author": {"name": "Bob", "date": "2026-01-01"}},
+                "author": None,
+                "html_url": "url",
+            }
+        ]
+        with _mock_cache_get(None), _mock_http(200, resp), _mock_cache_set():
+            result = tools.list_commits({"repo": "org/repo"})
+        assert result["commits"][0]["author"] == "Bob"

--- a/plugins/github/tests/test_tools.py
+++ b/plugins/github/tests/test_tools.py
@@ -274,6 +274,13 @@ class TestGetPr:
         except ValueError:
             pass
 
+    def test_path_traversal_repo_rejected(self):
+        try:
+            tools.get_pr({"repo": "../..", "pr_number": 1})
+            assert False, "should have raised"
+        except ValueError as e:
+            assert "path traversal" in str(e)
+
 
 # --- github_get_issue ---
 

--- a/plugins/github/tests/test_tools_write.py
+++ b/plugins/github/tests/test_tools_write.py
@@ -782,3 +782,155 @@ class TestCacheInvalidation:
                 }
             )
         inv.assert_not_called()
+
+
+# --- github_create_branch ---
+
+REF_RESPONSE = {"object": {"sha": "a" * 40, "type": "commit"}, "ref": "refs/heads/main"}
+CREATE_REF_RESPONSE = {"ref": "refs/heads/new-branch", "object": {"sha": "a" * 40}}
+
+
+class TestCreateBranch:
+    def test_dry_run(self):
+        with _mock_http(200, REF_RESPONSE), _mock_invalidate() as inv:
+            result = tools_write.create_branch(
+                {"repo": "org/repo", "branch_name": "feature-x", "source_branch": "main"}
+            )
+        assert result["dry_run"] is True
+        assert result["action"] == "github_create_branch"
+        assert result["source_sha"] == "a" * 12
+        inv.assert_not_called()
+
+    def test_success(self):
+        responses = [
+            (200, REF_RESPONSE, {}),
+            (201, CREATE_REF_RESPONSE, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses), _mock_invalidate() as inv:
+            result = tools_write.create_branch({"repo": "org/repo", "branch_name": "feature-x", "dry_run": False})
+        assert result["created"] is True
+        assert result["ref"] == "refs/heads/new-branch"
+        inv.assert_called_once()
+
+    def test_source_not_found(self):
+        with _mock_http(404, {"message": "Not Found"}):
+            result = tools_write.create_branch({"repo": "org/repo", "branch_name": "x", "source_branch": "nonexistent"})
+        assert "error" in result
+
+    def test_invalid_branch_double_dot(self):
+        with pytest.raises(ValueError, match="contains \\.\\. or //"):
+            tools_write.create_branch({"repo": "org/repo", "branch_name": "a..b"})
+
+    def test_invalid_branch_dot_lock(self):
+        with pytest.raises(ValueError, match="ends with \\.lock"):
+            tools_write.create_branch({"repo": "org/repo", "branch_name": "test.lock"})
+
+    def test_invalid_branch_dot_component(self):
+        with pytest.raises(ValueError, match="component starts with"):
+            tools_write.create_branch({"repo": "org/repo", "branch_name": "feature/.hidden"})
+
+    def test_invalid_repo(self):
+        with pytest.raises(ValueError, match="invalid repo"):
+            tools_write.create_branch({"repo": "bad", "branch_name": "x"})
+
+    def test_single_char_branch(self):
+        with _mock_http(200, REF_RESPONSE):
+            result = tools_write.create_branch({"repo": "org/repo", "branch_name": "v"})
+        assert result["dry_run"] is True
+
+    def test_error_does_not_invalidate(self):
+        responses = [
+            (200, REF_RESPONSE, {}),
+            (422, {"message": "Reference already exists"}, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses), _mock_invalidate() as inv:
+            result = tools_write.create_branch({"repo": "org/repo", "branch_name": "main", "dry_run": False})
+        assert "error" in result
+        inv.assert_not_called()
+
+
+# --- github_create_or_update_file ---
+
+
+class TestCreateOrUpdateFile:
+    def test_dry_run_new_file(self):
+        with patch.object(handler, "http", return_value=(404, {"message": "Not Found"}, {})), _mock_invalidate() as inv:
+            result = tools_write.create_or_update_file(
+                {"repo": "org/repo", "path": "test.py", "content": "print(1)", "message": "add test"}
+            )
+        assert result["dry_run"] is True
+        assert result["is_update"] is False
+        inv.assert_not_called()
+
+    def test_dry_run_existing_file(self):
+        with patch.object(handler, "http", return_value=(200, {"sha": "old_sha"}, {})):
+            result = tools_write.create_or_update_file(
+                {"repo": "org/repo", "path": "test.py", "content": "print(2)", "message": "update test"}
+            )
+        assert result["dry_run"] is True
+        assert result["is_update"] is True
+
+    def test_create_success(self):
+        responses = [
+            (404, {"message": "Not Found"}, {}),
+            (201, {"content": {"path": "test.py", "sha": "new_sha", "html_url": "url"}}, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses), _mock_invalidate() as inv:
+            result = tools_write.create_or_update_file(
+                {"repo": "org/repo", "path": "test.py", "content": "print(1)", "message": "add", "dry_run": False}
+            )
+        assert result["created"] is True
+        assert result["is_update"] is False
+        inv.assert_called_once()
+
+    def test_update_includes_sha(self):
+        responses = [
+            (200, {"sha": "old_sha_value"}, {}),
+            (200, {"content": {"path": "test.py", "sha": "new_sha", "html_url": "url"}}, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses) as mock_http, _mock_invalidate():
+            tools_write.create_or_update_file(
+                {"repo": "org/repo", "path": "test.py", "content": "updated", "message": "upd", "dry_run": False}
+            )
+        put_call = mock_http.call_args_list[1]
+        api_body = put_call[1].get("body") or put_call[0][3] if len(put_call[0]) > 3 else put_call[1]["body"]
+        assert api_body["sha"] == "old_sha_value"
+
+    def test_missing_message(self):
+        with pytest.raises(ValueError, match="message is required"):
+            tools_write.create_or_update_file({"repo": "org/repo", "path": "f.py", "content": "x"})
+
+    def test_missing_content(self):
+        with pytest.raises(ValueError, match="content is required"):
+            tools_write.create_or_update_file({"repo": "org/repo", "path": "f.py", "message": "m"})
+
+    def test_missing_path(self):
+        with pytest.raises(ValueError, match="path is required"):
+            tools_write.create_or_update_file({"repo": "org/repo", "content": "x", "message": "m"})
+
+    def test_path_traversal_rejected(self):
+        with pytest.raises(ValueError, match="path traversal"):
+            tools_write.create_or_update_file(
+                {"repo": "org/repo", "path": "../../etc/passwd", "content": "x", "message": "m"}
+            )
+
+    def test_http_error(self):
+        responses = [
+            (404, {"message": "Not Found"}, {}),
+            (422, {"message": "Validation Failed"}, {}),
+        ]
+        with patch.object(handler, "http", side_effect=responses), _mock_invalidate() as inv:
+            result = tools_write.create_or_update_file(
+                {"repo": "org/repo", "path": "f.py", "content": "x", "message": "m", "dry_run": False}
+            )
+        assert "error" in result
+        inv.assert_not_called()
+
+    def test_get_error_surfaces_not_swallowed(self):
+        """Non-404 GET errors should be returned, not silently treated as 'file missing'."""
+        with patch.object(handler, "http", return_value=(500, {"message": "Internal Server Error"}, {})):
+            result = tools_write.create_or_update_file(
+                {"repo": "org/repo", "path": "f.py", "content": "x", "message": "m", "dry_run": False}
+            )
+        assert "error" in result
+        assert "500" in str(result["error"])

--- a/plugins/github/tools.py
+++ b/plugins/github/tools.py
@@ -40,11 +40,15 @@ def _check_rate_limit(headers, result):
 def _validate_org(org):
     if org and not _VALID_ORG.match(org):
         raise ValueError(f"invalid org name: {org!r}")
+    if org == "..":
+        raise ValueError(f"invalid org name: {org!r}")
 
 
 def _validate_repo(repo):
     if not _VALID_REPO.match(repo):
         raise ValueError(f"invalid repo format: {repo!r} (expected owner/repo)")
+    if ".." in repo.split("/"):
+        raise ValueError(f"invalid repo format: {repo!r} (path traversal)")
 
 
 def _validate_path(path):

--- a/plugins/github/tools.py
+++ b/plugins/github/tools.py
@@ -1,5 +1,6 @@
 """GitHub tool implementations."""
 
+import base64
 import hashlib
 import re
 
@@ -8,7 +9,10 @@ import handler
 _VALID_ORG = re.compile(r"^[a-zA-Z0-9._-]+$")
 _VALID_REPO = re.compile(r"^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$")
 _VALID_FILTER = {"assigned", "created", "mentioned", "subscribed", "repos", "all"}
+_VALID_PR_STATE = {"open", "closed", "all"}
 _RATE_LIMIT_WARN = 100
+_MAX_CONTENT_BYTES = 50000
+_MAX_DIR_ENTRIES = 200
 
 
 def _http_error(status, body):
@@ -41,6 +45,15 @@ def _validate_org(org):
 def _validate_repo(repo):
     if not _VALID_REPO.match(repo):
         raise ValueError(f"invalid repo format: {repo!r} (expected owner/repo)")
+
+
+def _validate_path(path):
+    if not path or not path.strip():
+        raise ValueError("path is required")
+    if ".." in path.split("/"):
+        raise ValueError(f"path traversal in path: {path!r}")
+    if path.startswith("/"):
+        raise ValueError(f"absolute path not allowed: {path!r}")
 
 
 def _validate_filter(f):
@@ -523,6 +536,244 @@ def search(params):
     return _search_issues(query, sort, max_results, start_at)
 
 
+def get_file_contents(params):
+    """Get file or directory contents from a repository."""
+    repo = params.get("repo", "")
+    path = params.get("path", "")
+    ref = params.get("ref", "")
+    _validate_repo(repo)
+    _validate_path(path)
+    owner, name = _split_repo(repo)
+
+    query = {}
+    if ref:
+        query["ref"] = ref
+
+    cache_input = f"file:{owner}/{name}/{path}:{ref}"
+    cache_key = f"file:{hashlib.sha256(cache_input.encode()).hexdigest()[:12]}"
+    cached = handler.cache_get(cache_key)
+    if cached:
+        return cached
+
+    status, body, headers = handler.http("GET", f"/repos/{owner}/{name}/contents/{path}", query=query or None)
+    if status < 200 or status >= 300:
+        return _http_error(status, body)
+
+    if isinstance(body, list):
+        entries = [
+            {"name": e.get("name", ""), "type": e.get("type", ""), "path": e.get("path", ""), "size": e.get("size", 0)}
+            for e in body[:_MAX_DIR_ENTRIES]
+        ]
+        result = {"type": "directory", "path": path, "count": len(entries), "entries": entries}
+        if len(body) > _MAX_DIR_ENTRIES:
+            result["truncated"] = True
+        _check_rate_limit(headers, result)
+        handler.cache_set(cache_key, result, ttl=300)
+        return result
+
+    content_b64 = body.get("content")
+    size = body.get("size", 0)
+    result = {
+        "name": body.get("name", ""),
+        "path": body.get("path", ""),
+        "size": size,
+        "type": body.get("type", "file"),
+        "sha": body.get("sha", ""),
+        "html_url": body.get("html_url", ""),
+    }
+
+    if size > 1_000_000:
+        result["content_available"] = False
+        result["download_url"] = body.get("download_url", "")
+        _check_rate_limit(headers, result)
+        handler.cache_set(cache_key, result, ttl=300)
+        return result
+
+    if content_b64 is None:
+        result["content_available"] = False
+        result["download_url"] = body.get("download_url", "")
+        result["git_url"] = body.get("git_url", "")
+    else:
+        try:
+            decoded = base64.b64decode(content_b64)
+            if b"\x00" in decoded[:1024]:
+                result["content_available"] = False
+                result["binary"] = True
+            elif len(decoded) > _MAX_CONTENT_BYTES:
+                result["content"] = decoded[:_MAX_CONTENT_BYTES].decode("utf-8", errors="replace")
+                result["content"] += f"\n[TRUNCATED at {_MAX_CONTENT_BYTES // 1000}KB, full file is {size} bytes]"
+            else:
+                result["content"] = decoded.decode("utf-8", errors="replace")
+        except (ValueError, UnicodeDecodeError):
+            result["content_available"] = False
+            result["encoding"] = body.get("encoding", "")
+
+    _check_rate_limit(headers, result)
+    handler.cache_set(cache_key, result, ttl=300)
+    return result
+
+
+def search_code(params):
+    """Search for code across repositories."""
+    query = params.get("query", "")
+    max_results = min(int(params.get("max_results", 30)), 100)
+    if not query:
+        raise ValueError("query is required")
+
+    cache_input = f"code_search|{query}|{max_results}"
+    cache_key = f"csearch:{hashlib.sha256(cache_input.encode()).hexdigest()[:12]}"
+    cached = handler.cache_get(cache_key)
+    if cached:
+        return cached
+
+    status, body, headers = handler.http("GET", "/search/code", query={"q": query, "per_page": str(max_results)})
+    if status < 200 or status >= 300 or not isinstance(body, dict):
+        return _http_error(status, body)
+
+    items = [
+        {
+            "name": i.get("name", ""),
+            "path": i.get("path", ""),
+            "sha": i.get("sha", "")[:12],
+            "html_url": i.get("html_url", ""),
+            "repo": (i.get("repository") or {}).get("full_name", ""),
+        }
+        for i in body.get("items", [])[:max_results]
+    ]
+
+    result = {"total": body.get("total_count", 0), "count": len(items), "items": items}
+    _check_rate_limit(headers, result)
+    handler.cache_set(cache_key, result, ttl=300)
+    return result
+
+
+def search_repositories(params):
+    """Search for repositories."""
+    query = params.get("query", "")
+    max_results = min(int(params.get("max_results", 30)), 100)
+    if not query:
+        raise ValueError("query is required")
+
+    cache_input = f"repo_search|{query}|{max_results}"
+    cache_key = f"rsearch:{hashlib.sha256(cache_input.encode()).hexdigest()[:12]}"
+    cached = handler.cache_get(cache_key)
+    if cached:
+        return cached
+
+    status, body, headers = handler.http(
+        "GET", "/search/repositories", query={"q": query, "per_page": str(max_results)}
+    )
+    if status < 200 or status >= 300 or not isinstance(body, dict):
+        return _http_error(status, body)
+
+    items = [
+        {
+            "full_name": r.get("full_name", ""),
+            "description": r.get("description", ""),
+            "html_url": r.get("html_url", ""),
+            "language": r.get("language", ""),
+            "stars": r.get("stargazers_count", 0),
+            "forks": r.get("forks_count", 0),
+            "updated_at": r.get("updated_at", ""),
+            "default_branch": r.get("default_branch", ""),
+            "archived": r.get("archived", False),
+        }
+        for r in body.get("items", [])[:max_results]
+    ]
+
+    result = {"total": body.get("total_count", 0), "count": len(items), "items": items}
+    _check_rate_limit(headers, result)
+    handler.cache_set(cache_key, result, ttl=300)
+    return result
+
+
+def list_pull_requests(params):
+    """List pull requests for a repository."""
+    repo = params.get("repo", "")
+    state = params.get("state", "open")
+    max_results = min(int(params.get("max_results", 30)), 100)
+    _validate_repo(repo)
+    if state not in _VALID_PR_STATE:
+        raise ValueError(f"invalid state: {state!r} (valid: {', '.join(sorted(_VALID_PR_STATE))})")
+    owner, name = _split_repo(repo)
+
+    cache_input = f"prs:{owner}/{name}:{state}:{max_results}"
+    cache_key = f"prs:{hashlib.sha256(cache_input.encode()).hexdigest()[:12]}"
+    cached = handler.cache_get(cache_key)
+    if cached:
+        return cached
+
+    status, body, headers = handler.http(
+        "GET",
+        f"/repos/{owner}/{name}/pulls",
+        query={"state": state, "per_page": str(max_results)},
+    )
+    if status < 200 or status >= 300 or not isinstance(body, list):
+        return _http_error(status, body)
+
+    prs = [
+        {
+            "number": pr.get("number"),
+            "title": pr.get("title", ""),
+            "state": pr.get("state", ""),
+            "draft": pr.get("draft", False),
+            "author": (pr.get("user") or {}).get("login", ""),
+            "base": (pr.get("base") or {}).get("ref", ""),
+            "head": (pr.get("head") or {}).get("ref", ""),
+            "labels": [lb.get("name", "") for lb in (pr.get("labels") or [])],
+            "created_at": pr.get("created_at", ""),
+            "updated_at": pr.get("updated_at", ""),
+            "html_url": pr.get("html_url", ""),
+        }
+        for pr in body[:max_results]
+    ]
+
+    result = {"count": len(prs), "pull_requests": prs}
+    _check_rate_limit(headers, result)
+    handler.cache_set(cache_key, result, ttl=300)
+    return result
+
+
+def list_commits(params):
+    """List commits for a repository."""
+    repo = params.get("repo", "")
+    sha = params.get("sha", "")
+    max_results = min(int(params.get("max_results", 20)), 100)
+    _validate_repo(repo)
+    owner, name = _split_repo(repo)
+
+    query = {"per_page": str(max_results)}
+    if sha:
+        query["sha"] = sha
+
+    cache_input = f"commits:{owner}/{name}:{sha}:{max_results}"
+    cache_key = f"commits:{hashlib.sha256(cache_input.encode()).hexdigest()[:12]}"
+    cached = handler.cache_get(cache_key)
+    if cached:
+        return cached
+
+    status, body, headers = handler.http("GET", f"/repos/{owner}/{name}/commits", query=query)
+    if status < 200 or status >= 300 or not isinstance(body, list):
+        return _http_error(status, body)
+
+    commits = [
+        {
+            "sha": c.get("sha", "")[:12],
+            "message": (c.get("commit") or {}).get("message", ""),
+            "author": (c.get("author") or {}).get("login", "")
+            or (c.get("commit", {}).get("author") or {}).get("name", ""),
+            "date": (c.get("commit", {}).get("author") or {}).get("date", ""),
+            "html_url": c.get("html_url", ""),
+        }
+        for c in body[:max_results]
+    ]
+
+    result = {"count": len(commits), "commits": commits}
+    _check_rate_limit(headers, result)
+    handler.cache_set(cache_key, result, ttl=300)
+    return result
+
+
 TOOLS = {
     "github_my_work": my_work,
     "github_my_prs_to_review": my_prs_to_review,
@@ -536,4 +787,9 @@ TOOLS = {
     "github_get_comments": get_comments,
     "github_get_pr_commits": get_pr_commits,
     "github_search": search,
+    "github_get_file_contents": get_file_contents,
+    "github_search_code": search_code,
+    "github_search_repositories": search_repositories,
+    "github_list_pull_requests": list_pull_requests,
+    "github_list_commits": list_commits,
 }

--- a/plugins/github/tools_write.py
+++ b/plugins/github/tools_write.py
@@ -425,6 +425,8 @@ def create_or_update_file(params):
     _validate_repo(repo)
     owner, name = _split_repo(repo)
     _validate_path(path)
+    if branch:
+        _validate_branch(branch)
 
     if not content:
         raise ValueError("content is required")

--- a/plugins/github/tools_write.py
+++ b/plugins/github/tools_write.py
@@ -3,12 +3,31 @@
 All write tools default to dry_run=true for safety.
 """
 
+import base64
+import re
+
 import handler
-from tools import _check_rate_limit, _http_error, _split_repo, _validate_repo
+from tools import _check_rate_limit, _http_error, _split_repo, _validate_path, _validate_repo
 
 _VALID_EVENTS = {"COMMENT", "REQUEST_CHANGES", "APPROVE"}
 _MAX_BODY_LEN = 65000
 _MAX_COMMENTS = 50
+_MAX_FILE_CONTENT = 1_000_000
+_VALID_BRANCH = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._/-]*[a-zA-Z0-9])?$")
+
+
+def _validate_branch(name):
+    """Validate a branch name against git check-ref-format rules."""
+    if not name or not name.strip():
+        raise ValueError("branch name is required")
+    if not _VALID_BRANCH.match(name):
+        raise ValueError(f"invalid branch name: {name!r}")
+    if ".." in name or "//" in name:
+        raise ValueError(f"invalid branch name: {name!r} (contains .. or //)")
+    if name.endswith(".lock"):
+        raise ValueError(f"invalid branch name: {name!r} (ends with .lock)")
+    if "/." in name:
+        raise ValueError(f"invalid branch name: {name!r} (component starts with '.')")
 
 
 def _fetch_head_sha(owner, name, pr_number):
@@ -345,9 +364,129 @@ def create_pull_request(params):
     return result
 
 
+def create_branch(params):
+    """Create a new branch from a source branch."""
+    repo = params.get("repo", "")
+    branch_name = params.get("branch_name", "")
+    source_branch = params.get("source_branch", "main")
+    dry_run = params.get("dry_run", True)
+
+    _validate_repo(repo)
+    _validate_branch(branch_name)
+    _validate_branch(source_branch)
+    owner, name = _split_repo(repo)
+
+    status, body, headers = handler.http("GET", f"/repos/{owner}/{name}/git/ref/heads/{source_branch}")
+    if status < 200 or status >= 300 or not isinstance(body, dict):
+        return _http_error(status, body)
+    source_sha = (body.get("object") or {}).get("sha", "")
+    if not source_sha:
+        return {"error": f"could not resolve SHA for branch {source_branch!r}"}
+
+    if dry_run is not False:
+        result = {
+            "dry_run": True,
+            "action": "github_create_branch",
+            "repo": repo,
+            "branch_name": branch_name,
+            "source_branch": source_branch,
+            "source_sha": source_sha[:12],
+        }
+        _check_rate_limit(headers, result)
+        return result
+
+    status, resp, headers = handler.http(
+        "POST",
+        f"/repos/{owner}/{name}/git/refs",
+        body={"ref": f"refs/heads/{branch_name}", "sha": source_sha},
+    )
+    if status < 200 or status >= 300:
+        return _http_error(status, resp)
+
+    handler.invalidate_cache()
+    result = {
+        "ref": (resp.get("ref", "") if isinstance(resp, dict) else ""),
+        "sha": (resp.get("object", {}).get("sha", "")[:12] if isinstance(resp, dict) else ""),
+        "created": True,
+    }
+    _check_rate_limit(headers, result)
+    return result
+
+
+def create_or_update_file(params):
+    """Create or update a file in a repository."""
+    repo = params.get("repo", "")
+    path = params.get("path", "")
+    content = params.get("content", "")
+    message = params.get("message", "")
+    branch = params.get("branch", "")
+    dry_run = params.get("dry_run", True)
+
+    _validate_repo(repo)
+    owner, name = _split_repo(repo)
+    _validate_path(path)
+
+    if not content:
+        raise ValueError("content is required")
+    if not message or not message.strip():
+        raise ValueError("message is required")
+    if len(content) > _MAX_FILE_CONTENT:
+        raise ValueError(f"content exceeds {_MAX_FILE_CONTENT} character limit ({len(content)} characters)")
+
+    query = {}
+    if branch:
+        query["ref"] = branch
+
+    existing_sha = None
+    status, body, _ = handler.http("GET", f"/repos/{owner}/{name}/contents/{path}", query=query or None)
+    if 200 <= status < 300 and isinstance(body, dict):
+        existing_sha = body.get("sha", "")
+    elif status != 404:
+        return _http_error(status, body)
+    is_update = existing_sha is not None
+
+    if dry_run is not False:
+        preview = {
+            "dry_run": True,
+            "action": "github_create_or_update_file",
+            "repo": repo,
+            "path": path,
+            "is_update": is_update,
+            "message_preview": message[:200],
+        }
+        if branch:
+            preview["branch"] = branch
+        return preview
+
+    encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    api_body = {"message": message, "content": encoded}
+    if existing_sha:
+        api_body["sha"] = existing_sha
+    if branch:
+        api_body["branch"] = branch
+
+    status, resp, headers = handler.http("PUT", f"/repos/{owner}/{name}/contents/{path}", body=api_body)
+    if status < 200 or status >= 300:
+        return _http_error(status, resp)
+
+    handler.invalidate_cache()
+    file_info = (resp.get("content") or {}) if isinstance(resp, dict) else {}
+    result = {
+        "path": file_info.get("path", path),
+        "sha": file_info.get("sha", "")[:12],
+        "html_url": file_info.get("html_url", ""),
+        "is_update": is_update,
+        "created": True,
+    }
+    _check_rate_limit(headers, result)
+    return result
+
+
 WRITE_TOOLS = {
     "github_create_review": create_review,
     "github_add_pr_comment": add_pr_comment,
     "github_add_comment": add_comment,
     "github_create_pull_request": create_pull_request,
+    "github_create_branch": create_branch,
+    "github_create_or_update_file": create_or_update_file,
 }

--- a/plugins/gitlab/instance_test.go
+++ b/plugins/gitlab/instance_test.go
@@ -161,13 +161,16 @@ func TestResolveInstanceUnknown(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
-	if pt := parseTime("2026-03-10T14:00:00Z"); pt == nil {
-		t.Error("parseTime(RFC3339) returned nil")
+	if pt, err := parseTime("2026-03-10T14:00:00Z"); pt == nil || err != nil {
+		t.Errorf("parseTime(RFC3339) = %v, %v", pt, err)
 	}
-	if pt := parseTime("2026-03-10"); pt == nil {
-		t.Error("parseTime(date) returned nil")
+	if pt, err := parseTime("2026-03-10"); pt == nil || err != nil {
+		t.Errorf("parseTime(date) = %v, %v", pt, err)
 	}
-	if pt := parseTime("not-a-date"); pt != nil {
-		t.Error("parseTime(invalid) should return nil")
+	if pt, err := parseTime("not-a-date"); pt != nil || err == nil {
+		t.Error("parseTime(invalid) should return nil and error")
+	}
+	if pt, err := parseTime(""); pt != nil || err != nil {
+		t.Errorf("parseTime(empty) = %v, %v; want nil, nil", pt, err)
 	}
 }

--- a/plugins/gitlab/main.go
+++ b/plugins/gitlab/main.go
@@ -38,6 +38,8 @@ func main() {
 
 	// Write tools
 	p.Handle("gitlab_create_merge_request", toolCreateMergeRequest)
+	p.Handle("gitlab_create_branch", toolCreateBranch)
+	p.Handle("gitlab_create_or_update_file", toolCreateOrUpdateFile)
 	p.Handle("gitlab_create_mr_discussion", toolCreateMRDiscussion)
 	p.Handle("gitlab_add_mr_note", toolAddMRNote)
 

--- a/plugins/gitlab/main.go
+++ b/plugins/gitlab/main.go
@@ -32,6 +32,9 @@ func main() {
 	p.Handle("gitlab_my_issues", toolMyIssues)
 	p.Handle("gitlab_get_todos", toolGetTodos)
 	p.Handle("gitlab_list_merge_requests", toolListMergeRequests)
+	p.Handle("gitlab_get_file_contents", toolGetFileContents)
+	p.Handle("gitlab_search_projects", toolSearchProjects)
+	p.Handle("gitlab_search_code", toolSearchCode)
 
 	// Write tools
 	p.Handle("gitlab_create_merge_request", toolCreateMergeRequest)

--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -279,6 +279,9 @@ tools:
         description: "created_by_me or assigned_to_me"
       author_username:
         type: string
+      assignee_username:
+        type: string
+        description: "Filter by assignee username"
       reviewer_username:
         type: string
       project_id:

--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -15,6 +15,10 @@ services:
     prefix: "none"
   http:
     base_url: "${GITLAB_URL}"
+    # Required for internal/on-prem GitLab instances on private networks.
+    # Cloud metadata endpoints (169.254.169.254 etc.) remain blocked by
+    # the core's safedialer regardless of this setting.
+    allow_private_ips: true
 
 context_files:
   - context.md

--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -306,6 +306,62 @@ tools:
         type: integer
         default: 20
 
+  - name: gitlab_get_file_contents
+    access: read
+    description: >
+      Get file contents from a repository. Returns decoded text for
+      files (capped at 50KB) or metadata only for large/binary files.
+    params:
+      instance:
+        type: string
+      project_id:
+        type: string
+        required: true
+        description: "Project ID or path (e.g. 'group/project')"
+      path:
+        type: string
+        required: true
+        description: "Path to file in the repository"
+      ref:
+        type: string
+        description: "Branch, tag, or commit SHA (default: main)"
+
+  - name: gitlab_search_projects
+    access: read
+    description: >
+      Search for projects by name or description. Returns project
+      metadata including path, default branch, and activity.
+    params:
+      instance:
+        type: string
+      query:
+        type: string
+        required: true
+        description: "Search query"
+      max_results:
+        type: integer
+        default: 30
+
+  - name: gitlab_search_code
+    access: read
+    description: >
+      Search for code within a project. Returns matching file paths,
+      line numbers, and code snippets.
+    params:
+      instance:
+        type: string
+      project_id:
+        type: string
+        required: true
+        description: "Project ID or path (e.g. 'group/project')"
+      query:
+        type: string
+        required: true
+        description: "Search query"
+      max_results:
+        type: integer
+        default: 30
+
   - name: gitlab_create_merge_request
     access: write
     description: >

--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -161,6 +161,8 @@ tools:
         description: "Username of author"
       labels:
         type: array
+        items:
+          type: string
       milestone:
         type: string
       search:
@@ -246,6 +248,8 @@ tools:
         description: "GitLab instance name (optional if only one configured)"
       labels:
         type: array
+        items:
+          type: string
         description: "Filter by labels"
       sort:
         type: string
@@ -282,6 +286,8 @@ tools:
         description: "Limit to a specific project"
       labels:
         type: array
+        items:
+          type: string
       milestone:
         type: string
       search:
@@ -329,6 +335,8 @@ tools:
         description: "MR description body"
       labels:
         type: array
+        items:
+          type: string
         description: "Labels to apply"
       remove_source_branch:
         type: boolean

--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -324,7 +324,7 @@ tools:
         description: "Path to file in the repository"
       ref:
         type: string
-        description: "Branch, tag, or commit SHA (default: main)"
+        description: "Branch, tag, or commit SHA (default: project default branch)"
 
   - name: gitlab_search_projects
     access: read
@@ -404,6 +404,64 @@ tools:
         type: boolean
         default: false
         description: "Create as draft MR (prepends 'Draft: ' to title)"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without creating (default: true)"
+
+  - name: gitlab_create_branch
+    access: write
+    description: >
+      Create a new branch from a source branch. Validates branch name
+      against git check-ref-format rules. Defaults to dry_run=true.
+    params:
+      instance:
+        type: string
+      project_id:
+        type: string
+        required: true
+        description: "Project ID or path (e.g. 'group/project')"
+      branch_name:
+        type: string
+        required: true
+        description: "Name for the new branch"
+      source_branch:
+        type: string
+        default: "main"
+        description: "Branch to create from (default: main)"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without creating (default: true)"
+
+  - name: gitlab_create_or_update_file
+    access: write
+    description: >
+      Create or update a file in a repository. Checks if the file
+      exists to determine create vs update. Content is plain text.
+      Defaults to dry_run=true.
+    params:
+      instance:
+        type: string
+      project_id:
+        type: string
+        required: true
+        description: "Project ID or path (e.g. 'group/project')"
+      path:
+        type: string
+        required: true
+        description: "File path in the repository"
+      content:
+        type: string
+        required: true
+        description: "File content (plain text)"
+      message:
+        type: string
+        required: true
+        description: "Commit message"
+      branch:
+        type: string
+        description: "Target branch (default: project default branch)"
       dry_run:
         type: boolean
         default: true

--- a/plugins/gitlab/tools.go
+++ b/plugins/gitlab/tools.go
@@ -43,7 +43,7 @@ func toolGetCommits(params, _ json.RawMessage) (any, error) {
 	if p.RefName == "" {
 		p.RefName = "main"
 	}
-	if p.MaxResults == 0 {
+	if p.MaxResults <= 0 {
 		p.MaxResults = 20
 	}
 
@@ -62,10 +62,18 @@ func toolGetCommits(params, _ json.RawMessage) (any, error) {
 		ListOptions: gogitlab.ListOptions{PerPage: perPage},
 	}
 	if p.Since != "" {
-		opts.Since = parseTime(p.Since)
+		t, err := parseTime(p.Since)
+		if err != nil {
+			return nil, fmt.Errorf("invalid since: %w", err)
+		}
+		opts.Since = t
 	}
 	if p.Until != "" {
-		opts.Until = parseTime(p.Until)
+		t, err := parseTime(p.Until)
+		if err != nil {
+			return nil, fmt.Errorf("invalid until: %w", err)
+		}
+		opts.Until = t
 	}
 	if p.Path != "" {
 		opts.Path = &p.Path
@@ -119,7 +127,7 @@ func toolGetCommitDiff(params, _ json.RawMessage) (any, error) {
 	if p.Format == "" {
 		p.Format = "json"
 	}
-	if p.MaxFiles == 0 {
+	if p.MaxFiles <= 0 {
 		p.MaxFiles = 20
 	}
 
@@ -133,7 +141,8 @@ func toolGetCommitDiff(params, _ json.RawMessage) (any, error) {
 		return nil, fmt.Errorf("get commit diff: %w", err)
 	}
 
-	truncatedFiles := len(diffs) > p.MaxFiles
+	totalFiles := len(diffs)
+	truncatedFiles := totalFiles > p.MaxFiles
 	if truncatedFiles {
 		diffs = diffs[:p.MaxFiles]
 	}
@@ -162,7 +171,7 @@ func toolGetCommitDiff(params, _ json.RawMessage) (any, error) {
 		"commit_id":   p.CommitSHA,
 		"format":      p.Format,
 		"diffs":       diffList,
-		"total_files": len(diffs),
+		"total_files": totalFiles,
 	}
 	if truncatedFiles {
 		result["files_truncated"] = true
@@ -362,7 +371,7 @@ func toolGetProjectPipelines(params, _ json.RawMessage) (any, error) {
 	if p.ProjectID == "" {
 		return nil, fmt.Errorf("project_id is required")
 	}
-	if p.MaxResults == 0 {
+	if p.MaxResults <= 0 {
 		p.MaxResults = 10
 	}
 
@@ -437,7 +446,7 @@ func toolGetProjectIssues(params, _ json.RawMessage) (any, error) {
 	if p.ProjectID == "" {
 		return nil, fmt.Errorf("project_id is required")
 	}
-	if p.MaxResults == 0 {
+	if p.MaxResults <= 0 {
 		p.MaxResults = 20
 	}
 	if p.OrderBy == "" {
@@ -482,16 +491,32 @@ func toolGetProjectIssues(params, _ json.RawMessage) (any, error) {
 		opts.Search = &p.Search
 	}
 	if p.CreatedAfter != "" {
-		opts.CreatedAfter = parseTime(p.CreatedAfter)
+		t, err := parseTime(p.CreatedAfter)
+		if err != nil {
+			return nil, fmt.Errorf("invalid created_after: %w", err)
+		}
+		opts.CreatedAfter = t
 	}
 	if p.CreatedBefore != "" {
-		opts.CreatedBefore = parseTime(p.CreatedBefore)
+		t, err := parseTime(p.CreatedBefore)
+		if err != nil {
+			return nil, fmt.Errorf("invalid created_before: %w", err)
+		}
+		opts.CreatedBefore = t
 	}
 	if p.UpdatedAfter != "" {
-		opts.UpdatedAfter = parseTime(p.UpdatedAfter)
+		t, err := parseTime(p.UpdatedAfter)
+		if err != nil {
+			return nil, fmt.Errorf("invalid updated_after: %w", err)
+		}
+		opts.UpdatedAfter = t
 	}
 	if p.UpdatedBefore != "" {
-		opts.UpdatedBefore = parseTime(p.UpdatedBefore)
+		t, err := parseTime(p.UpdatedBefore)
+		if err != nil {
+			return nil, fmt.Errorf("invalid updated_before: %w", err)
+		}
+		opts.UpdatedBefore = t
 	}
 
 	issues, _, err := client.Issues.ListProjectIssues(p.ProjectID, opts)
@@ -574,7 +599,7 @@ func toolMyIssues(params, _ json.RawMessage) (any, error) {
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, fmt.Errorf("parse params: %w", err)
 	}
-	if p.MaxResults == 0 {
+	if p.MaxResults <= 0 {
 		p.MaxResults = 30
 	}
 	if p.OrderBy == "" {
@@ -642,7 +667,7 @@ func toolGetTodos(params, _ json.RawMessage) (any, error) {
 	if p.State == "" {
 		p.State = "pending"
 	}
-	if p.MaxResults == 0 {
+	if p.MaxResults <= 0 {
 		p.MaxResults = 20
 	}
 	if p.Page < 1 {
@@ -764,7 +789,7 @@ func toolListMergeRequests(params, _ json.RawMessage) (any, error) {
 	if p.State == "" {
 		p.State = "opened"
 	}
-	if p.MaxResults == 0 {
+	if p.MaxResults <= 0 {
 		p.MaxResults = 20
 	}
 	if p.OrderBy == "" {
@@ -939,13 +964,16 @@ func issueToMap(i *gogitlab.Issue) map[string]any {
 	return m
 }
 
-func parseTime(s string) *time.Time {
+func parseTime(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
 	for _, layout := range []string{time.RFC3339, "2006-01-02"} {
 		if t, err := time.Parse(layout, s); err == nil {
-			return &t
+			return &t, nil
 		}
 	}
-	return nil
+	return nil, fmt.Errorf("invalid date format %q (expected RFC3339 or YYYY-MM-DD)", s)
 }
 
 var userIDCache sync.Map
@@ -1071,7 +1099,7 @@ func toolSearchProjects(params, _ json.RawMessage) (any, error) {
 	if p.Query == "" {
 		return nil, fmt.Errorf("query is required")
 	}
-	if p.MaxResults == 0 {
+	if p.MaxResults <= 0 {
 		p.MaxResults = 30
 	}
 
@@ -1137,7 +1165,7 @@ func toolSearchCode(params, _ json.RawMessage) (any, error) {
 	if p.Query == "" {
 		return nil, fmt.Errorf("query is required")
 	}
-	if p.MaxResults == 0 {
+	if p.MaxResults <= 0 {
 		p.MaxResults = 30
 	}
 

--- a/plugins/gitlab/tools.go
+++ b/plugins/gitlab/tools.go
@@ -226,7 +226,6 @@ func toolGetMergeRequest(params, _ json.RawMessage) (any, error) {
 		"title":         mr.Title,
 		"description":   mr.Description,
 		"state":         mr.State,
-		"author":        mr.Author.Username,
 		"source_branch": mr.SourceBranch,
 		"target_branch": mr.TargetBranch,
 		"web_url":       mr.WebURL,
@@ -236,6 +235,9 @@ func toolGetMergeRequest(params, _ json.RawMessage) (any, error) {
 		"updated_at":    timeStr(mr.UpdatedAt),
 		"draft":         mr.Draft,
 		"comments":      comments,
+	}
+	if mr.Author != nil {
+		result["author"] = mr.Author.Username
 	}
 
 	if mr.DiffRefs.BaseSha != "" {

--- a/plugins/gitlab/tools.go
+++ b/plugins/gitlab/tools.go
@@ -316,9 +316,13 @@ func toolGetPipelineJobs(params, _ json.RawMessage) (any, error) {
 
 		if p.IncludeLogs && j.Status == "failed" {
 			trace, _, traceErr := client.Jobs.GetTraceFile(p.ProjectID, j.ID)
-			if traceErr == nil && trace != nil {
-				data, readErr := io.ReadAll(trace)
-				if readErr == nil && len(data) > 0 {
+			if traceErr != nil {
+				jd["logs_error"] = traceErr.Error()
+			} else if trace != nil {
+				data, readErr := io.ReadAll(io.LimitReader(trace, int64(maxLogBytes)+1))
+				if readErr != nil {
+					jd["logs_error"] = readErr.Error()
+				} else if len(data) > 0 {
 					logStr := string(data)
 					if len(logStr) > maxLogBytes {
 						logStr = logStr[:maxLogBytes] + "\n... [TRUNCATED]"

--- a/plugins/gitlab/tools.go
+++ b/plugins/gitlab/tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"time"
 
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
@@ -802,6 +803,13 @@ func listProjectMRs(client *gogitlab.Client, p listMergeRequestsParams, perPage 
 	if p.AuthorUsername != "" {
 		opts.AuthorUsername = &p.AuthorUsername
 	}
+	if p.AssigneeUsername != "" {
+		uid, err := resolveUserID(client, p.AssigneeUsername)
+		if err != nil {
+			return nil, err
+		}
+		opts.AssigneeID = gogitlab.AssigneeID(uid)
+	}
 	if p.ReviewerUsername != "" {
 		opts.ReviewerUsername = &p.ReviewerUsername
 	}
@@ -841,6 +849,13 @@ func listGlobalMRs(client *gogitlab.Client, p listMergeRequestsParams, perPage i
 	}
 	if p.AuthorUsername != "" {
 		opts.AuthorUsername = &p.AuthorUsername
+	}
+	if p.AssigneeUsername != "" {
+		uid, err := resolveUserID(client, p.AssigneeUsername)
+		if err != nil {
+			return nil, err
+		}
+		opts.AssigneeID = gogitlab.AssigneeID(uid)
 	}
 	if p.ReviewerUsername != "" {
 		opts.ReviewerUsername = &p.ReviewerUsername
@@ -931,6 +946,25 @@ func parseTime(s string) *time.Time {
 		}
 	}
 	return nil
+}
+
+var userIDCache sync.Map
+
+func resolveUserID(client *gogitlab.Client, username string) (int64, error) {
+	if id, ok := userIDCache.Load(username); ok {
+		return id.(int64), nil
+	}
+	users, _, err := client.Users.ListUsers(&gogitlab.ListUsersOptions{
+		Username: &username,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("lookup user %q: %w", username, err)
+	}
+	if len(users) == 0 {
+		return 0, fmt.Errorf("user %q not found", username)
+	}
+	userIDCache.Store(username, users[0].ID)
+	return users[0].ID, nil
 }
 
 func timeStr(t *time.Time) string {

--- a/plugins/gitlab/tools.go
+++ b/plugins/gitlab/tools.go
@@ -979,7 +979,8 @@ func parseTime(s string) (*time.Time, error) {
 var userIDCache sync.Map
 
 func resolveUserID(client *gogitlab.Client, username string) (int64, error) {
-	if id, ok := userIDCache.Load(username); ok {
+	cacheKey := client.BaseURL().Host + "/" + username
+	if id, ok := userIDCache.Load(cacheKey); ok {
 		return id.(int64), nil
 	}
 	users, _, err := client.Users.ListUsers(&gogitlab.ListUsersOptions{
@@ -991,7 +992,7 @@ func resolveUserID(client *gogitlab.Client, username string) (int64, error) {
 	if len(users) == 0 {
 		return 0, fmt.Errorf("user %q not found", username)
 	}
-	userIDCache.Store(username, users[0].ID)
+	userIDCache.Store(cacheKey, users[0].ID)
 	return users[0].ID, nil
 }
 

--- a/plugins/gitlab/tools.go
+++ b/plugins/gitlab/tools.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
@@ -930,4 +932,207 @@ func timeStr(t *time.Time) string {
 		return ""
 	}
 	return t.Format(time.RFC3339)
+}
+
+// --- gitlab_get_file_contents ---
+
+const maxFileContentBytes = 50000
+
+type getFileContentsParams struct {
+	instanceParam
+	ProjectID string `json:"project_id"`
+	Path      string `json:"path"`
+	Ref       string `json:"ref"`
+}
+
+func toolGetFileContents(params, _ json.RawMessage) (any, error) {
+	var p getFileContentsParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.ProjectID == "" {
+		return nil, fmt.Errorf("project_id is required")
+	}
+	if err := validatePath(p.Path); err != nil {
+		return nil, err
+	}
+
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &gogitlab.GetFileOptions{}
+	if p.Ref != "" {
+		opts.Ref = &p.Ref
+	}
+
+	file, _, err := client.RepositoryFiles.GetFile(p.ProjectID, p.Path, opts)
+	if err != nil {
+		return nil, fmt.Errorf("get file: %w", err)
+	}
+
+	result := map[string]any{
+		"file_name":      file.FileName,
+		"file_path":      file.FilePath,
+		"size":           file.Size,
+		"encoding":       file.Encoding,
+		"ref":            file.Ref,
+		"blob_id":        file.BlobID,
+		"last_commit_id": file.LastCommitID,
+	}
+
+	if file.Size > maxFileContentBytes {
+		result["content_available"] = false
+		return result, nil
+	}
+
+	if file.Encoding == "base64" && file.Content != "" {
+		decoded, decodeErr := io.ReadAll(io.LimitReader(
+			base64.NewDecoder(base64.StdEncoding, strings.NewReader(file.Content)),
+			maxFileContentBytes+1,
+		))
+		if decodeErr != nil {
+			result["content_available"] = false
+			return result, nil //nolint:nilerr // graceful degradation for undecodable content
+		}
+		for _, b := range decoded[:min(len(decoded), 1024)] {
+			if b == 0 {
+				result["content_available"] = false
+				result["binary"] = true
+				return result, nil
+			}
+		}
+		text := string(decoded)
+		if len(decoded) > maxFileContentBytes {
+			text = strings.ToValidUTF8(text[:maxFileContentBytes], "") + fmt.Sprintf("\n[TRUNCATED at %dKB]", maxFileContentBytes/1000)
+		}
+		result["content"] = text
+	} else {
+		result["content"] = file.Content
+	}
+
+	return result, nil
+}
+
+// --- gitlab_search_projects ---
+
+type searchProjectsParams struct {
+	instanceParam
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results"`
+}
+
+func toolSearchProjects(params, _ json.RawMessage) (any, error) {
+	var p searchProjectsParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.Query == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+	if p.MaxResults == 0 {
+		p.MaxResults = 30
+	}
+
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
+	}
+
+	perPage := int64(p.MaxResults)
+	if perPage > 100 {
+		perPage = 100
+	}
+
+	projects, _, err := client.Projects.ListProjects(&gogitlab.ListProjectsOptions{
+		Search:      &p.Query,
+		ListOptions: gogitlab.ListOptions{PerPage: perPage},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search projects: %w", err)
+	}
+
+	var items []map[string]any
+	for _, proj := range projects {
+		m := map[string]any{
+			"id":                  proj.ID,
+			"path_with_namespace": proj.PathWithNamespace,
+			"description":         proj.Description,
+			"web_url":             proj.WebURL,
+			"default_branch":      proj.DefaultBranch,
+			"archived":            proj.Archived,
+			"star_count":          proj.StarCount,
+			"forks_count":         proj.ForksCount,
+		}
+		if proj.LastActivityAt != nil {
+			m["last_activity_at"] = proj.LastActivityAt.Format(time.RFC3339)
+		}
+		items = append(items, m)
+	}
+
+	return map[string]any{
+		"count": len(items),
+		"items": items,
+	}, nil
+}
+
+// --- gitlab_search_code ---
+
+type searchCodeParams struct {
+	instanceParam
+	ProjectID  string `json:"project_id"`
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results"`
+}
+
+func toolSearchCode(params, _ json.RawMessage) (any, error) {
+	var p searchCodeParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.ProjectID == "" {
+		return nil, fmt.Errorf("project_id is required")
+	}
+	if p.Query == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+	if p.MaxResults == 0 {
+		p.MaxResults = 30
+	}
+
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
+	}
+
+	perPage := int64(p.MaxResults)
+	if perPage > 100 {
+		perPage = 100
+	}
+
+	blobs, _, err := client.Search.BlobsByProject(p.ProjectID, p.Query, &gogitlab.SearchOptions{
+		ListOptions: gogitlab.ListOptions{PerPage: perPage},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search code: %w", err)
+	}
+
+	var items []map[string]any
+	for _, blob := range blobs {
+		items = append(items, map[string]any{
+			"basename":   blob.Basename,
+			"data":       blob.Data,
+			"path":       blob.Path,
+			"filename":   blob.Filename,
+			"ref":        blob.Ref,
+			"startline":  blob.Startline,
+			"project_id": blob.ProjectID,
+		})
+	}
+
+	return map[string]any{
+		"count": len(items),
+		"items": items,
+	}, nil
 }

--- a/plugins/gitlab/tools_test.go
+++ b/plugins/gitlab/tools_test.go
@@ -552,3 +552,161 @@ func TestToolGetMergeRequest(t *testing.T) {
 		t.Errorf("comment body = %v", comments[0]["body"])
 	}
 }
+
+// --- gitlab_get_file_contents ---
+
+func TestToolGetFileContents(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/repository/files/") {
+			// Content is base64-encoded "summary: Test plan\n"
+			jsonResponse(w, `{
+				"file_name": "main.fmf",
+				"file_path": "tests/main.fmf",
+				"size": 19,
+				"encoding": "base64",
+				"ref": "main",
+				"blob_id": "abc123",
+				"last_commit_id": "def456",
+				"content": "c3VtbWFyeTogVGVzdCBwbGFuCg=="
+			}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	result, err := toolGetFileContents(mustJSON(t, map[string]any{
+		"project_id": "team/proj",
+		"path":       "tests/main.fmf",
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolGetFileContents: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["file_name"] != "main.fmf" {
+		t.Errorf("file_name = %v", m["file_name"])
+	}
+	content, ok := m["content"].(string)
+	if !ok {
+		t.Fatalf("content type = %T", m["content"])
+	}
+	if !strings.Contains(content, "summary: Test plan") {
+		t.Errorf("content = %q, want to contain 'summary: Test plan'", content)
+	}
+}
+
+func TestToolGetFileContentsRequiresProjectAndPath(t *testing.T) {
+	_, err := toolGetFileContents(mustJSON(t, map[string]any{
+		"project_id": "team/proj",
+	}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+	if !strings.Contains(err.Error(), "path is required") {
+		t.Errorf("error = %v, want 'path is required'", err)
+	}
+
+	_, err = toolGetFileContents(mustJSON(t, map[string]any{
+		"path": "file.txt",
+	}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing project_id")
+	}
+}
+
+// --- gitlab_search_projects ---
+
+func TestToolSearchProjects(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v4/projects" && r.URL.Query().Get("search") != "" {
+			jsonResponse(w, `[{
+				"id": 42,
+				"path_with_namespace": "team/tests",
+				"description": "Test repo",
+				"web_url": "https://gitlab.example.com/team/tests",
+				"default_branch": "main",
+				"archived": false,
+				"star_count": 5,
+				"forks_count": 1
+			}]`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	result, err := toolSearchProjects(mustJSON(t, map[string]any{
+		"query": "tests",
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolSearchProjects: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["count"] != 1 {
+		t.Errorf("count = %v, want 1", m["count"])
+	}
+	items := m["items"].([]map[string]any)
+	if items[0]["path_with_namespace"] != "team/tests" {
+		t.Errorf("path = %v", items[0]["path_with_namespace"])
+	}
+}
+
+func TestToolSearchProjectsRequiresQuery(t *testing.T) {
+	_, err := toolSearchProjects(mustJSON(t, map[string]any{}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing query")
+	}
+}
+
+// --- gitlab_search_code ---
+
+func TestToolSearchCode(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/search") && r.URL.Query().Get("scope") == "blobs" {
+			jsonResponse(w, `[{
+				"basename": "test",
+				"data": "def test_login():",
+				"path": "tests/test_auth.py",
+				"filename": "test_auth.py",
+				"ref": "main",
+				"startline": 42,
+				"project_id": 1
+			}]`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	result, err := toolSearchCode(mustJSON(t, map[string]any{
+		"project_id": "team/proj",
+		"query":      "test_login",
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolSearchCode: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["count"] != 1 {
+		t.Errorf("count = %v, want 1", m["count"])
+	}
+	items := m["items"].([]map[string]any)
+	if items[0]["filename"] != "test_auth.py" {
+		t.Errorf("filename = %v", items[0]["filename"])
+	}
+}
+
+func TestToolSearchCodeRequiresProjectAndQuery(t *testing.T) {
+	_, err := toolSearchCode(mustJSON(t, map[string]any{
+		"project_id": "p",
+	}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing query")
+	}
+
+	_, err = toolSearchCode(mustJSON(t, map[string]any{
+		"query": "test",
+	}), nil)
+	if err == nil {
+		t.Fatal("expected error for missing project_id")
+	}
+}

--- a/plugins/gitlab/tools_write.go
+++ b/plugins/gitlab/tools_write.go
@@ -438,6 +438,11 @@ func toolCreateOrUpdateFile(params, _ json.RawMessage) (any, error) {
 	if strings.TrimSpace(p.CommitMessage) == "" {
 		return nil, fmt.Errorf("message is required")
 	}
+	if p.Branch != "" {
+		if err := validateBranch(p.Branch); err != nil {
+			return nil, fmt.Errorf("branch: %w", err)
+		}
+	}
 	client, err := resolveInstance(p.Instance)
 	if err != nil {
 		return nil, err

--- a/plugins/gitlab/tools_write.go
+++ b/plugins/gitlab/tools_write.go
@@ -3,12 +3,50 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"regexp"
 	"strings"
 
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 const maxBodyLen = 65000
+
+var validBranch = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._/-]*[a-zA-Z0-9])?$`)
+
+func validateBranch(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("branch name is required")
+	}
+	if !validBranch.MatchString(name) {
+		return fmt.Errorf("invalid branch name: %q", name)
+	}
+	if strings.Contains(name, "..") || strings.Contains(name, "//") {
+		return fmt.Errorf("invalid branch name: %q (contains .. or //)", name)
+	}
+	if strings.HasSuffix(name, ".lock") {
+		return fmt.Errorf("invalid branch name: %q (ends with .lock)", name)
+	}
+	if strings.Contains(name, "/.") {
+		return fmt.Errorf("invalid branch name: %q (component starts with '.')", name)
+	}
+	return nil
+}
+
+func validatePath(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("path is required")
+	}
+	for _, seg := range strings.Split(path, "/") {
+		if seg == ".." {
+			return fmt.Errorf("path traversal in path: %q", path)
+		}
+	}
+	if strings.HasPrefix(path, "/") {
+		return fmt.Errorf("absolute path not allowed: %q", path)
+	}
+	return nil
+}
 
 func isDryRun(v *bool) bool {
 	return v == nil || *v
@@ -154,6 +192,11 @@ func toolAddMRNote(params, _ json.RawMessage) (any, error) {
 		return nil, fmt.Errorf("body exceeds %d character limit (%d chars)", maxBodyLen, len([]rune(p.Body)))
 	}
 
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
+	}
+
 	if isDryRun(p.DryRun) {
 		runes := []rune(p.Body)
 		if len(runes) > 200 {
@@ -166,11 +209,6 @@ func toolAddMRNote(params, _ json.RawMessage) (any, error) {
 			"mr_iid":       p.MrIID,
 			"body_preview": string(runes),
 		}, nil
-	}
-
-	client, err := resolveInstance(p.Instance)
-	if err != nil {
-		return nil, err
 	}
 
 	note, _, err := client.Notes.CreateMergeRequestNote(
@@ -302,6 +340,170 @@ func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
 		"source_branch": mr.SourceBranch,
 		"target_branch": mr.TargetBranch,
 		"created":       true,
+	}, nil
+}
+
+// --- gitlab_create_branch ---
+
+type createBranchParams struct {
+	instanceParam
+	ProjectID    string `json:"project_id"`
+	BranchName   string `json:"branch_name"`
+	SourceBranch string `json:"source_branch"`
+	DryRun       *bool  `json:"dry_run"`
+}
+
+func toolCreateBranch(params, _ json.RawMessage) (any, error) {
+	var p createBranchParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.ProjectID == "" {
+		return nil, fmt.Errorf("project_id is required")
+	}
+	if err := validateBranch(p.BranchName); err != nil {
+		return nil, err
+	}
+	if p.SourceBranch == "" {
+		p.SourceBranch = "main"
+	}
+	if err := validateBranch(p.SourceBranch); err != nil {
+		return nil, fmt.Errorf("source_branch: %w", err)
+	}
+
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
+	}
+
+	if isDryRun(p.DryRun) {
+		return map[string]any{
+			"dry_run":       true,
+			"action":        "gitlab_create_branch",
+			"project_id":    p.ProjectID,
+			"branch_name":   p.BranchName,
+			"source_branch": p.SourceBranch,
+		}, nil
+	}
+
+	branch, _, err := client.Branches.CreateBranch(p.ProjectID, &gogitlab.CreateBranchOptions{
+		Branch: &p.BranchName,
+		Ref:    &p.SourceBranch,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create branch: %w", err)
+	}
+
+	result := map[string]any{
+		"name":       branch.Name,
+		"web_url":    branch.WebURL,
+		"created":    true,
+		"project_id": p.ProjectID,
+	}
+	if branch.Commit != nil {
+		result["commit_id"] = branch.Commit.ShortID
+	}
+	return result, nil
+}
+
+// --- gitlab_create_or_update_file ---
+
+type createOrUpdateFileParams struct {
+	instanceParam
+	ProjectID     string `json:"project_id"`
+	Path          string `json:"path"`
+	Content       string `json:"content"`
+	CommitMessage string `json:"message"`
+	Branch        string `json:"branch"`
+	DryRun        *bool  `json:"dry_run"`
+}
+
+func toolCreateOrUpdateFile(params, _ json.RawMessage) (any, error) {
+	var p createOrUpdateFileParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.ProjectID == "" {
+		return nil, fmt.Errorf("project_id is required")
+	}
+	if err := validatePath(p.Path); err != nil {
+		return nil, err
+	}
+	if p.Content == "" {
+		return nil, fmt.Errorf("content is required")
+	}
+	if len(p.Content) > 1_000_000 {
+		return nil, fmt.Errorf("content exceeds 1MB limit (%d bytes)", len(p.Content))
+	}
+	if strings.TrimSpace(p.CommitMessage) == "" {
+		return nil, fmt.Errorf("message is required")
+	}
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
+	}
+
+	getOpts := &gogitlab.GetFileOptions{}
+	if p.Branch != "" {
+		getOpts.Ref = &p.Branch
+	}
+	_, getResp, getErr := client.RepositoryFiles.GetFile(p.ProjectID, p.Path, getOpts)
+	isUpdate := getErr == nil
+	if getErr != nil {
+		is404 := getResp != nil && getResp.StatusCode == http.StatusNotFound
+		if !is404 {
+			return nil, fmt.Errorf("check if file exists: %w", getErr)
+		}
+	}
+
+	if isDryRun(p.DryRun) {
+		m := map[string]any{
+			"dry_run":         true,
+			"action":          "gitlab_create_or_update_file",
+			"project_id":      p.ProjectID,
+			"path":            p.Path,
+			"branch":          p.Branch,
+			"is_update":       isUpdate,
+			"message_preview": p.CommitMessage,
+		}
+		if len(p.CommitMessage) > 200 {
+			m["message_preview"] = p.CommitMessage[:200]
+		}
+		return m, nil
+	}
+
+	updateOpts := &gogitlab.UpdateFileOptions{
+		Content:       &p.Content,
+		CommitMessage: &p.CommitMessage,
+	}
+	createOpts := &gogitlab.CreateFileOptions{
+		Content:       &p.Content,
+		CommitMessage: &p.CommitMessage,
+	}
+	if p.Branch != "" {
+		updateOpts.Branch = &p.Branch
+		createOpts.Branch = &p.Branch
+	}
+
+	if isUpdate {
+		_, _, err = client.RepositoryFiles.UpdateFile(p.ProjectID, p.Path, updateOpts)
+	} else {
+		_, _, err = client.RepositoryFiles.CreateFile(p.ProjectID, p.Path, createOpts)
+	}
+	if err != nil {
+		action := "create"
+		if isUpdate {
+			action = "update"
+		}
+		return nil, fmt.Errorf("%s file: %w", action, err)
+	}
+
+	return map[string]any{
+		"file_path":  p.Path,
+		"branch":     p.Branch,
+		"is_update":  isUpdate,
+		"project_id": p.ProjectID,
+		"created":    true,
 	}, nil
 }
 

--- a/plugins/gitlab/tools_write_test.go
+++ b/plugins/gitlab/tools_write_test.go
@@ -775,3 +775,189 @@ func TestFetchDiffRefsEmptySHAs(t *testing.T) {
 		t.Errorf("error = %q, want to contain 'has no diff refs'", err.Error())
 	}
 }
+
+// --- gitlab_create_branch ---
+
+func TestCreateBranchDryRun(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP calls in dry run")
+		http.NotFound(w, r)
+	})
+
+	result, err := toolCreateBranch(mustJSON(t, map[string]any{
+		"project_id":    "team/proj",
+		"branch_name":   "feature-x",
+		"source_branch": "main",
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateBranch: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["dry_run"] != true {
+		t.Errorf("dry_run = %v, want true", m["dry_run"])
+	}
+	if m["action"] != "gitlab_create_branch" {
+		t.Errorf("action = %v", m["action"])
+	}
+}
+
+func TestCreateBranchExecute(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/repository/branches") {
+			jsonResponse(w, `{
+				"name": "feature-x",
+				"web_url": "https://gitlab.example.com/team/proj/-/tree/feature-x",
+				"commit": {"short_id": "abc123"}
+			}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	dryRun := false
+	result, err := toolCreateBranch(mustJSON(t, map[string]any{
+		"project_id":  "team/proj",
+		"branch_name": "feature-x",
+		"dry_run":     dryRun,
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateBranch: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["created"] != true {
+		t.Errorf("created = %v, want true", m["created"])
+	}
+	if m["name"] != "feature-x" {
+		t.Errorf("name = %v", m["name"])
+	}
+}
+
+func TestCreateBranchValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+		errMsg string
+	}{
+		{"missing project_id", map[string]any{"branch_name": "x"}, "project_id is required"},
+		{"missing branch_name", map[string]any{"project_id": "p"}, "branch name is required"},
+		{"double dot", map[string]any{"project_id": "p", "branch_name": "a..b"}, "contains .. or //"},
+		{"dot lock", map[string]any{"project_id": "p", "branch_name": "test.lock"}, "ends with .lock"},
+		{"dot component", map[string]any{"project_id": "p", "branch_name": "feat/.hidden"}, "component starts with"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := toolCreateBranch(mustJSON(t, tc.params), nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tc.errMsg)
+			}
+		})
+	}
+}
+
+func TestCreateBranchSingleChar(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP calls in dry run")
+		http.NotFound(w, r)
+	})
+
+	result, err := toolCreateBranch(mustJSON(t, map[string]any{
+		"project_id":  "team/proj",
+		"branch_name": "v",
+	}), nil)
+	if err != nil {
+		t.Fatalf("single-char branch should be valid: %v", err)
+	}
+	m := result.(map[string]any)
+	if m["dry_run"] != true {
+		t.Errorf("dry_run = %v", m["dry_run"])
+	}
+}
+
+// --- gitlab_create_or_update_file ---
+
+func TestCreateOrUpdateFileDryRunNew(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/repository/files/") {
+			w.WriteHeader(404)
+			jsonResponse(w, `{"message": "404 File Not Found"}`)
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+
+	result, err := toolCreateOrUpdateFile(mustJSON(t, map[string]any{
+		"project_id": "team/proj",
+		"path":       "tests/new.py",
+		"content":    "print(1)",
+		"message":    "add test",
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateOrUpdateFile: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["dry_run"] != true {
+		t.Errorf("dry_run = %v, want true", m["dry_run"])
+	}
+	if m["is_update"] != false {
+		t.Errorf("is_update = %v, want false (new file)", m["is_update"])
+	}
+}
+
+func TestCreateOrUpdateFileDryRunUpdate(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/repository/files/") {
+			jsonResponse(w, `{"file_name": "existing.py", "content": "old", "encoding": "base64"}`)
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+
+	result, err := toolCreateOrUpdateFile(mustJSON(t, map[string]any{
+		"project_id": "team/proj",
+		"path":       "existing.py",
+		"content":    "updated",
+		"message":    "update",
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateOrUpdateFile: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["is_update"] != true {
+		t.Errorf("is_update = %v, want true", m["is_update"])
+	}
+}
+
+func TestCreateOrUpdateFileValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+		errMsg string
+	}{
+		{"missing project_id", map[string]any{"path": "f", "content": "x", "message": "m"}, "project_id is required"},
+		{"missing path", map[string]any{"project_id": "p", "content": "x", "message": "m"}, "path is required"},
+		{"path traversal", map[string]any{"project_id": "p", "path": "../../etc/passwd", "content": "x", "message": "m"}, "path traversal"},
+		{"absolute path", map[string]any{"project_id": "p", "path": "/etc/passwd", "content": "x", "message": "m"}, "absolute path"},
+		{"missing content", map[string]any{"project_id": "p", "path": "f", "message": "m"}, "content is required"},
+		{"missing message", map[string]any{"project_id": "p", "path": "f", "content": "x"}, "message is required"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := toolCreateOrUpdateFile(mustJSON(t, tc.params), nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tc.errMsg)
+			}
+		})
+	}
+}

--- a/plugins/jira/handler.py
+++ b/plugins/jira/handler.py
@@ -319,15 +319,20 @@ def _init(msg):
     """Handle init message: store config, detect Cloud vs Server."""
     global config, is_cloud, sprint_field
     config = msg.get("config", {})
-    is_cloud, auth_ok = _detect_cloud()
-    if not auth_ok:
-        log(
-            "WARNING: authentication failed (HTTP 401/403). "
-            "If both JIRA_EMAIL and JIRA_TOKEN are set but this is "
-            "a Jira Server/DC instance, set JIRA_AUTH_TYPE=server-token "
-            "to use bearer auth instead of basic auth. "
-            "If this is Jira Cloud, verify your API token."
-        )
+    auth_type = config.get("auth_type", "auto")
+    if auth_type == "cloud":
+        is_cloud, auth_ok = True, True
+        log("init: JIRA_AUTH_TYPE=cloud, skipping cloud detection")
+    else:
+        is_cloud, auth_ok = _detect_cloud()
+        if not auth_ok:
+            log(
+                "WARNING: authentication failed (HTTP 401/403). "
+                "If both JIRA_EMAIL and JIRA_TOKEN are set but this is "
+                "a Jira Server/DC instance, set JIRA_AUTH_TYPE=server-token "
+                "to use bearer auth instead of basic auth. "
+                "If this is Jira Cloud, verify your API token."
+            )
     sprint_field = _detect_sprint_field()
     log(f"init: cloud={is_cloud}, sprint_field={sprint_field}, url={config.get('jira_url', '?')}")
 

--- a/plugins/jira/handler.py
+++ b/plugins/jira/handler.py
@@ -196,8 +196,8 @@ def invalidate_cache(*_issue_keys):
     """
     try:
         cache_flush()
-    except Exception:
-        pass  # best-effort — don't mask a successful write
+    except Exception as e:
+        log(f"cache invalidation failed (best-effort): {e}")
 
 
 def file_write(path, content, encoding="text", permissions="0600", mkdir=True):

--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -32,6 +32,7 @@ services:
 
 config:
   jira_url: "${JIRA_URL}"
+  auth_type: "${JIRA_AUTH_TYPE:-auto}"
 
 tools:
   - name: jira_get_myself

--- a/plugins/jira/tests/test_handler.py
+++ b/plugins/jira/tests/test_handler.py
@@ -125,6 +125,49 @@ class TestDetectCloud:
             assert auth_ok is True
 
 
+class TestInitCloudShortcut:
+    """Test _init() cloud detection shortcut via config auth_type."""
+
+    def test_cloud_skips_detect(self):
+        """auth_type=cloud skips _detect_cloud() entirely."""
+        with (
+            patch.object(handler, "_detect_cloud") as mock_detect,
+            patch.object(handler, "_detect_sprint_field", return_value="sprint"),
+        ):
+            handler._init({"config": {"auth_type": "cloud"}})
+            mock_detect.assert_not_called()
+            assert handler.is_cloud is True
+
+    def test_auto_calls_detect(self):
+        """auth_type=auto (default) calls _detect_cloud()."""
+        with (
+            patch.object(handler, "_detect_cloud", return_value=(False, True)) as mock_detect,
+            patch.object(handler, "_detect_sprint_field", return_value="sprint"),
+        ):
+            handler._init({"config": {"auth_type": "auto"}})
+            mock_detect.assert_called_once()
+            assert handler.is_cloud is False
+
+    def test_missing_auth_type_calls_detect(self):
+        """No auth_type in config defaults to auto (calls _detect_cloud)."""
+        with (
+            patch.object(handler, "_detect_cloud", return_value=(True, True)) as mock_detect,
+            patch.object(handler, "_detect_sprint_field", return_value="sprint"),
+        ):
+            handler._init({"config": {}})
+            mock_detect.assert_called_once()
+
+    def test_server_token_calls_detect(self):
+        """auth_type=server-token still calls _detect_cloud() to preserve auth diagnostics."""
+        with (
+            patch.object(handler, "_detect_cloud", return_value=(False, True)) as mock_detect,
+            patch.object(handler, "_detect_sprint_field", return_value="sprint"),
+        ):
+            handler._init({"config": {"auth_type": "server-token"}})
+            mock_detect.assert_called_once()
+            assert handler.is_cloud is False
+
+
 class TestCacheDel:
     """Test cache_del() protocol message."""
 

--- a/plugins/testing-farm/handler.py
+++ b/plugins/testing-farm/handler.py
@@ -235,7 +235,7 @@ def testing_farm_about(_params):
 
     status, body, _ = http("GET", f"/{API_VERSION}/about")
     if status != 200:
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     cache_set("tf:about", body, ttl=3600)
     return body
@@ -249,7 +249,7 @@ def testing_farm_whoami(_params):
 
     status, body, _ = http("GET", f"/{API_VERSION}/me")
     if status != 200:
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     cache_set("tf:whoami", body, ttl=3600)
     return body
@@ -278,7 +278,7 @@ def testing_farm_list_requests(params):
 
     status, body, _ = http("GET", f"/{API_VERSION}/requests", query=query)
     if status != 200:
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     if not isinstance(body, list):
         return body
@@ -464,7 +464,7 @@ def testing_farm_list_composes(_params):
 
     status, body, _ = http("GET", f"/{API_VERSION}/composes")
     if status != 200:
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     # Trim to compose names only — the raw response includes metadata
     # (allowed_arches, tags, etc.) that wastes LLM context tokens.
@@ -494,7 +494,7 @@ def testing_farm_list_reservations(params):
 
     status, body, _ = http("GET", f"/{API_VERSION}/requests", query=query)
     if status != 200:
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     if not isinstance(body, list):
         return body
@@ -878,7 +878,7 @@ def testing_farm_reserve(params):
         "environments": [environment],
     }
 
-    if dry_run:
+    if dry_run is not False:
         return {
             "dry_run": True,
             "message": "Preview — set dry_run=false to submit",
@@ -888,7 +888,7 @@ def testing_farm_reserve(params):
 
     status, body, _ = http("POST", f"/{API_VERSION}/requests", body=payload)
     if status not in (200, 201):
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     return {
         "id": body.get("id", ""),
@@ -938,7 +938,7 @@ def testing_farm_submit_test(params):
     if timeout:
         payload["settings"] = {"pipeline": {"timeout": int(timeout) * 60}}
 
-    if dry_run:
+    if dry_run is not False:
         return {
             "dry_run": True,
             "message": "Preview — set dry_run=false to submit",
@@ -947,7 +947,7 @@ def testing_farm_submit_test(params):
 
     status, body, _ = http("POST", f"/{API_VERSION}/requests", body=payload)
     if status not in (200, 201):
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     return {
         "id": body.get("id", ""),
@@ -962,7 +962,7 @@ def testing_farm_cancel(params):
     _validate_request_id(request_id)
     dry_run = params.get("dry_run", True)
 
-    if dry_run:
+    if dry_run is not False:
         status, body, _ = http("GET", f"/{API_VERSION}/requests/{request_id}")
         if status != 200:
             raise Exception(f"Cannot fetch request {request_id} (HTTP {status}): {body}")
@@ -976,7 +976,7 @@ def testing_farm_cancel(params):
 
     status, body, _ = http("DELETE", f"/{API_VERSION}/requests/{request_id}")
     if status not in (200, 204):
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     # Invalidate cached data for this request.
     for prefix in ("tf:raw:", "tf:ssh:", "tf:results:"):

--- a/plugins/testing-farm/handler.py
+++ b/plugins/testing-farm/handler.py
@@ -16,6 +16,7 @@ import os
 import re
 import stat
 import sys
+import time
 import xml.etree.ElementTree as ET
 
 _next_id = 0
@@ -28,6 +29,15 @@ API_VERSION = "v0.1"
 
 TERMINAL_STATES = {"complete", "error", "canceled"}
 NON_TERMINAL_STATES = {"new", "queued", "running", "cancel-requested"}
+
+
+class ApiError(Exception):
+    """HTTP error from the Testing Farm API with a structured status code."""
+
+    def __init__(self, status, body):
+        self.status = status
+        super().__init__(f"API error (HTTP {status}): {body}")
+
 
 _UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
@@ -203,7 +213,7 @@ def _fetch_request(request_id):
 
     status, body, _ = http("GET", f"/{API_VERSION}/requests/{request_id}")
     if status != 200:
-        raise Exception(f"API error (HTTP {status}): {body}")
+        raise ApiError(status, body)
 
     state = body.get("state", "")
     if state in TERMINAL_STATES:
@@ -352,6 +362,98 @@ def testing_farm_get_request(params):
         out["summary"] = summary
 
     return out
+
+
+_CALL_BUDGET = 45
+_POLL_INTERVAL = 30
+_MAX_CONSECUTIVE_ERRORS = 5
+_TRANSIENT_STATUSES = {0, 429, 500, 502, 503, 504}
+
+
+def testing_farm_wait_for_result(params):
+    """Block until a request reaches a terminal state, polling periodically.
+
+    Returns the same format as testing_farm_get_request with additional
+    fields: waited, completed, poll_count. Respects the core's tool-call
+    timeout by returning before the 45-second call budget expires.
+    """
+    request_id = params["request_id"]
+    _validate_request_id(request_id)
+    timeout_minutes = max(1, min(int(params.get("timeout_minutes", 60)), 120))
+
+    start = time.monotonic()
+    deadline = start + timeout_minutes * 60
+    call_deadline = start + _CALL_BUDGET
+    poll_count = 0
+    consecutive_errors = 0
+    last_state = ""
+
+    while True:
+        now = time.monotonic()
+        if now >= deadline:
+            try:
+                result = testing_farm_get_request({"request_id": request_id})
+            except Exception:
+                result = {"id": request_id, "state": last_state or "unknown"}
+            result["waited"] = True
+            result["completed"] = False
+            result["timeout"] = True
+            result["poll_count"] = poll_count
+            result["message"] = (
+                f"Timed out after {timeout_minutes} minutes. "
+                f"Current state: {result.get('state', 'unknown')}. "
+                "The test may still complete -- use testing_farm_get_request to check."
+            )
+            return result
+
+        if now >= call_deadline:
+            try:
+                result = testing_farm_get_request({"request_id": request_id})
+            except Exception:
+                result = {"id": request_id, "state": last_state or "unknown"}
+            result["waited"] = True
+            result["completed"] = False
+            result["poll_count"] = poll_count
+            elapsed = (time.monotonic() - start) / 60
+            result["elapsed_minutes"] = round(elapsed, 1)
+            result["message"] = "Re-invoke to continue waiting."
+            return result
+
+        try:
+            body = _fetch_request(request_id)
+            consecutive_errors = 0
+            poll_count += 1
+            last_state = body.get("state", "")
+        except ApiError as e:
+            if e.status not in _TRANSIENT_STATUSES:
+                raise
+            consecutive_errors += 1
+            log(f"wait: transient error polling {request_id} ({consecutive_errors}/{_MAX_CONSECUTIVE_ERRORS}): {e}")
+            if consecutive_errors >= _MAX_CONSECUTIVE_ERRORS:
+                raise Exception(
+                    f"Aborting after {consecutive_errors} consecutive poll failures "
+                    f"(waited {round((time.monotonic() - start) / 60, 1)} min). Last error: {e}"
+                ) from e
+            for _ in range(_POLL_INTERVAL):
+                if time.monotonic() >= call_deadline or time.monotonic() >= deadline:
+                    break
+                time.sleep(1)
+            continue
+
+        if last_state in TERMINAL_STATES:
+            try:
+                result = testing_farm_get_request({"request_id": request_id})
+            except Exception:
+                result = {"id": request_id, "state": last_state or "unknown"}
+            result["waited"] = True
+            result["completed"] = True
+            result["poll_count"] = poll_count
+            return result
+
+        for _ in range(_POLL_INTERVAL):
+            if time.monotonic() >= call_deadline or time.monotonic() >= deadline:
+                break
+            time.sleep(1)
 
 
 def testing_farm_list_composes(_params):
@@ -896,6 +998,7 @@ TOOLS = {
     "testing_farm_whoami": testing_farm_whoami,
     "testing_farm_list_requests": testing_farm_list_requests,
     "testing_farm_get_request": testing_farm_get_request,
+    "testing_farm_wait_for_result": testing_farm_wait_for_result,
     "testing_farm_list_composes": testing_farm_list_composes,
     "testing_farm_list_reservations": testing_farm_list_reservations,
     "testing_farm_get_ssh": testing_farm_get_ssh,

--- a/plugins/testing-farm/plugin.yaml
+++ b/plugins/testing-farm/plugin.yaml
@@ -83,6 +83,27 @@ tools:
         required: true
         description: "Request ID (UUID)"
 
+  - name: testing_farm_wait_for_result
+    access: read
+    visibility: primary
+    description: >
+      Block until a test request reaches a terminal state (complete,
+      error, canceled), polling every 30 seconds. Returns the same
+      format as testing_farm_get_request plus waited/completed fields.
+      Each invocation blocks for up to 45 seconds (within the core's
+      tool-call timeout); re-invoke to continue waiting if the request
+      has not completed. Use this instead of manually polling
+      testing_farm_get_request in a loop.
+    params:
+      request_id:
+        type: string
+        required: true
+        description: "Request ID (UUID)"
+      timeout_minutes:
+        type: integer
+        default: 60
+        description: "Maximum time to wait in minutes (1-120, default 60)"
+
   - name: testing_farm_list_composes
     access: read
     description: >

--- a/plugins/testing-farm/tests/test_handler.py
+++ b/plugins/testing-farm/tests/test_handler.py
@@ -835,3 +835,152 @@ class TestGetSsh:
                 assert False, "Should have raised"
             except Exception as e:
                 assert "artifacts" in str(e).lower()
+
+
+# --- testing_farm_wait_for_result ---
+
+RUNNING_REQUEST = {
+    **SAMPLE_REQUEST,
+    "state": "running",
+    "result": {"overall": "unknown"},
+}
+
+
+class TestWaitForResult:
+    def test_already_complete(self):
+        """Request in terminal state on first check returns immediately."""
+        with _mock_cache_get(None), _mock_http(200, SAMPLE_REQUEST), _mock_cache_set():
+            result = handler.testing_farm_wait_for_result({"request_id": REQ_ID})
+        assert result["waited"] is True
+        assert result["completed"] is True
+        assert result["poll_count"] == 1
+        assert result["state"] == "complete"
+
+    def test_polls_until_complete(self):
+        """Non-terminal then terminal: polls until complete."""
+        responses = [
+            (200, RUNNING_REQUEST, {}),
+            (200, SAMPLE_REQUEST, {}),
+            (200, SAMPLE_REQUEST, {}),
+        ]
+        with (
+            _mock_cache_get(None),
+            patch.object(handler, "http", side_effect=responses),
+            _mock_cache_set(),
+            patch("time.monotonic", return_value=0.0),
+            patch("time.sleep"),
+        ):
+            result = handler.testing_farm_wait_for_result({"request_id": REQ_ID})
+        assert result["completed"] is True
+        assert result["poll_count"] >= 2
+
+    def test_call_budget_exceeded(self):
+        """Returns completed=False when call budget runs out."""
+        call_count = 0
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return 0.0
+            return 50.0
+
+        with (
+            _mock_cache_get(None),
+            _mock_http(200, RUNNING_REQUEST),
+            _mock_cache_set(),
+            patch("time.monotonic", side_effect=fake_monotonic),
+            patch("time.sleep"),
+        ):
+            result = handler.testing_farm_wait_for_result({"request_id": REQ_ID})
+        assert result["waited"] is True
+        assert result["completed"] is False
+        assert "Re-invoke" in result.get("message", "")
+
+    def test_timeout(self):
+        """Returns timeout=True when deadline expires before call budget."""
+        call_count = 0
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                return 0.0
+            return 70.0
+
+        responses = [
+            (200, RUNNING_REQUEST, {}),
+            (200, RUNNING_REQUEST, {}),
+            (200, RUNNING_REQUEST, {}),
+        ]
+        with (
+            _mock_cache_get(None),
+            patch.object(handler, "http", side_effect=responses),
+            _mock_cache_set(),
+            patch("time.monotonic", side_effect=fake_monotonic),
+            patch("time.sleep"),
+        ):
+            result = handler.testing_farm_wait_for_result({"request_id": REQ_ID, "timeout_minutes": 1})
+        assert result["waited"] is True
+        assert result["completed"] is False
+        assert result.get("timeout") is True
+
+    def test_transient_error_retry(self):
+        """Transient HTTP error is retried, next poll succeeds."""
+        responses = [
+            (502, {"error": "Bad Gateway"}, {}),
+            (502, {"error": "Bad Gateway"}, {}),
+            (200, SAMPLE_REQUEST, {}),
+            (200, SAMPLE_REQUEST, {}),
+        ]
+        with (
+            _mock_cache_get(None),
+            patch.object(handler, "http", side_effect=responses),
+            _mock_cache_set(),
+            patch("time.monotonic", return_value=0.0),
+            patch("time.sleep"),
+        ):
+            result = handler.testing_farm_wait_for_result({"request_id": REQ_ID})
+        assert result["completed"] is True
+
+    def test_consecutive_errors_abort(self):
+        """5 consecutive transient errors abort the wait."""
+        with (
+            _mock_cache_get(None),
+            _mock_http(502, {"error": "Bad Gateway"}),
+            _mock_cache_set(),
+            patch("time.monotonic", return_value=0.0),
+            patch("time.sleep"),
+        ):
+            try:
+                handler.testing_farm_wait_for_result({"request_id": REQ_ID})
+                assert False, "Should have raised"
+            except Exception as e:
+                assert "consecutive poll failures" in str(e)
+
+    def test_non_transient_error_propagates_immediately(self):
+        """HTTP 404 is NOT retried -- propagates immediately."""
+        with _mock_cache_get(None), _mock_http(404, {"error": "Not found"}):
+            try:
+                handler.testing_farm_wait_for_result({"request_id": REQ_ID})
+                assert False, "Should have raised"
+            except handler.ApiError as e:
+                assert e.status == 404
+                assert "consecutive" not in str(e)
+
+    def test_invalid_request_id(self):
+        """Invalid UUID raises immediately."""
+        try:
+            handler.testing_farm_wait_for_result({"request_id": "not-a-uuid"})
+            assert False, "Should have raised"
+        except Exception:
+            pass
+
+    def test_delegates_formatting(self):
+        """Terminal state result has same fields as get_request."""
+        with _mock_cache_get(None), _mock_http(200, SAMPLE_REQUEST), _mock_cache_set():
+            wait_result = handler.testing_farm_wait_for_result({"request_id": REQ_ID})
+        with _mock_cache_get(None), _mock_http(200, SAMPLE_REQUEST), _mock_cache_set():
+            get_result = handler.testing_farm_get_request({"request_id": REQ_ID})
+        for key in get_result:
+            assert key in wait_result, f"Missing key {key} in wait_for_result output"


### PR DESCRIPTION
New tool handlers for GitHub (7 read, 2 write), GitLab (3 read, 2 write), and Testing Farm
  (1 cooperative poll), plus core manifest schema improvements and hardening fixes across all
  four plugins.

  - GitHub/GitLab write tools: create_branch and create_or_update_file with branch name
  validation, dry_run defaults, and path traversal rejection
  - GitHub/GitLab read tools: file contents, code/repo search, PR listing, commit listing -
  with caching, truncation, and PII-minimized output
  - Testing Farm: wait_for_result cooperative poll tool with transient error handling and
  call-budget awareness
  - Core manifest: auto-fix array params missing items definition; extend ItemsDef with
  Properties/Required for nested object schemas
  - Hardening: nil-check MR Author, dry_run is not False guard, ApiError consistency, cache
  invalidation logging, parseTime error returns, MaxResults/MaxFiles bounds checks, trace
  read limiting, assignee_username wiring via user ID resolution