### PR TITLE
manifest: omit "type" from schema when YAML does not specify one

### DIFF
--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -598,7 +598,10 @@ func (t *ToolDef) ParamsSchema() map[string]any {
 	var required []string
 
 	for name, p := range t.Params {
-		prop := map[string]any{"type": p.Type}
+		prop := make(map[string]any)
+		if p.Type != "" {
+			prop["type"] = p.Type
+		}
 		if p.Description != "" {
 			prop["description"] = p.Description
 		}
@@ -609,11 +612,17 @@ func (t *ToolDef) ParamsSchema() map[string]any {
 			prop["enum"] = p.Enum
 		}
 		if p.Type == "array" && p.Items != nil {
-			itemSchema := map[string]any{"type": p.Items.Type}
+			itemSchema := make(map[string]any)
+			if p.Items.Type != "" {
+				itemSchema["type"] = p.Items.Type
+			}
 			if len(p.Items.Properties) > 0 {
 				itemProps := make(map[string]any, len(p.Items.Properties))
 				for pn, pp := range p.Items.Properties {
-					iprop := map[string]any{"type": pp.Type}
+					iprop := make(map[string]any)
+					if pp.Type != "" {
+						iprop["type"] = pp.Type
+					}
 					if pp.Description != "" {
 						iprop["description"] = pp.Description
 					}

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -389,6 +389,86 @@ func TestParamsSchemaObjectItems(t *testing.T) {
 	}
 }
 
+func TestParamsSchemaOmitsEmptyType(t *testing.T) {
+	t.Run("top-level param without type", func(t *testing.T) {
+		tool := ToolDef{
+			Name: "test",
+			Params: map[string]ParamDef{
+				"value": {Description: "accepts any type"},
+			},
+		}
+		schema := tool.ParamsSchema()
+		props := schema["properties"].(map[string]any)
+		valueProp := props["value"].(map[string]any)
+		if _, hasType := valueProp["type"]; hasType {
+			t.Errorf("expected no 'type' key for untyped param, got %v", valueProp["type"])
+		}
+		if valueProp["description"] != "accepts any type" {
+			t.Errorf("description = %v", valueProp["description"])
+		}
+	})
+
+	t.Run("array items without type", func(t *testing.T) {
+		tool := ToolDef{
+			Name: "test",
+			Params: map[string]ParamDef{
+				"things": {
+					Type: "array",
+					Items: &ItemsDef{
+						Properties: map[string]ParamDef{
+							"name": {Type: "string"},
+						},
+					},
+				},
+			},
+		}
+		schema := tool.ParamsSchema()
+		props := schema["properties"].(map[string]any)
+		thingsProp := props["things"].(map[string]any)
+		items := thingsProp["items"].(map[string]any)
+		if _, hasType := items["type"]; hasType {
+			t.Errorf("expected no 'type' key for untyped items, got %v", items["type"])
+		}
+	})
+
+	t.Run("item property without type", func(t *testing.T) {
+		tool := ToolDef{
+			Name: "test",
+			Params: map[string]ParamDef{
+				"custom_fields": {
+					Type: "array",
+					Items: &ItemsDef{
+						Type: "object",
+						Properties: map[string]ParamDef{
+							"field_id": {Type: "string"},
+							"value":    {Description: "depends on field_type"},
+						},
+						Required: []string{"field_id", "value"},
+					},
+				},
+			},
+		}
+		schema := tool.ParamsSchema()
+		props := schema["properties"].(map[string]any)
+		cfProp := props["custom_fields"].(map[string]any)
+		items := cfProp["items"].(map[string]any)
+		itemProps := items["properties"].(map[string]any)
+
+		fieldIDProp := itemProps["field_id"].(map[string]any)
+		if fieldIDProp["type"] != "string" {
+			t.Errorf("field_id type = %v, want string", fieldIDProp["type"])
+		}
+
+		valueProp := itemProps["value"].(map[string]any)
+		if _, hasType := valueProp["type"]; hasType {
+			t.Errorf("expected no 'type' key for untyped item property, got %v", valueProp["type"])
+		}
+		if valueProp["description"] != "depends on field_type" {
+			t.Errorf("value description = %v", valueProp["description"])
+		}
+	})
+}
+
 func TestManifestAuthVariantOrder(t *testing.T) {
 	dir := t.TempDir()
 	handlerPath := filepath.Join(dir, "handler")

--- a/internal/plugin/validate_test.go
+++ b/internal/plugin/validate_test.go
@@ -189,6 +189,50 @@ func TestCompileBadSchema_ReturnsError(t *testing.T) {
 	})
 }
 
+func TestCompileSchemaWithUntypedProperty(t *testing.T) {
+	tool := ToolDef{
+		Name: "test",
+		Params: map[string]ParamDef{
+			"custom_fields": {
+				Type: "array",
+				Items: &ItemsDef{
+					Type: "object",
+					Properties: map[string]ParamDef{
+						"field_id": {Type: "string", Description: "field ID"},
+						"value":    {Description: "depends on field_type"},
+					},
+					Required: []string{"field_id", "value"},
+				},
+			},
+		},
+	}
+
+	cs, err := CompileParamsSchema("test", tool)
+	if err != nil {
+		t.Fatalf("compile should succeed for untyped property: %v", err)
+	}
+	if cs == nil {
+		t.Fatal("expected compiled schema")
+	}
+
+	valid := []struct {
+		name   string
+		params string
+	}{
+		{"string value", `{"custom_fields":[{"field_id":"cf_1","value":"text"}]}`},
+		{"numeric value", `{"custom_fields":[{"field_id":"cf_2","value":42}]}`},
+		{"object value", `{"custom_fields":[{"field_id":"cf_3","value":{"name":"x"}}]}`},
+		{"null value", `{"custom_fields":[{"field_id":"cf_4","value":null}]}`},
+	}
+	for _, tt := range valid {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := cs.Validate(json.RawMessage(tt.params)); err != nil {
+				t.Errorf("should accept %s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
 func TestValidateNilSchema(t *testing.T) {
 	var cs *CompiledSchema
 	if err := cs.Validate(json.RawMessage(`{"anything":"goes"}`)); err != nil {


### PR DESCRIPTION
ParamsSchema() unconditionally emitted "type": "" for parameters and item properties that omit the type field in YAML. An empty string is not a valid JSON Schema type, so the jsonschema compiler rejected the schema and permanently disabled the affected tool (e.g. jira_create_issue). Guard all three emission sites to only include "type" when non-empty, which is valid JSON Schema for "accept any type".