### PR TITLE
feat: support streamable HTTP transport for sidecar deployments

### DIFF
--- a/cmd/wtmcp/main.go
+++ b/cmd/wtmcp/main.go
@@ -321,7 +321,9 @@ func run(forceStdio bool) error {
 	}
 
 	// Non-plugin cleanup runs on context cancellation.
+	cleanupDone := make(chan struct{})
 	go func() {
+		defer close(cleanupDone)
 		<-ctx.Done()
 		controlWatcher.Stop()
 		cacheStore.Close() //nolint:errcheck,gosec // best-effort on shutdown
@@ -331,6 +333,8 @@ func run(forceStdio bool) error {
 
 	logger := slog.New(slog.NewTextHandler(log.Writer(), &slog.HandlerOptions{Level: slog.LevelInfo}))
 	err = transport.ListenAndServe(ctx, srv, &cfg.Server, logger, os.Stdin, os.Stdout)
+
+	<-cleanupDone // ensure no reload in progress
 
 	// Sequential shutdown: transport drained, now safe to tear down.
 	log.Println("shutting down plugins...")

--- a/cmd/wtmcp/main.go
+++ b/cmd/wtmcp/main.go
@@ -293,23 +293,6 @@ func run(forceStdio bool) error {
 		log.Printf("all plugins loaded (%d)", len(mgr.LoadedPlugins()))
 	}()
 
-	// Start control directory watcher for external reload triggers
-	controlWatcher := server.NewControlWatcher(wd, srv, mgr, cfg, index, collector, auditor, pluginRL, framer, toolOwners)
-	if err := controlWatcher.Start(); err != nil {
-		log.Printf("control watcher disabled: %v", err)
-	}
-
-	// Non-plugin cleanup runs on context cancellation.
-	go func() {
-		<-ctx.Done()
-		controlWatcher.Stop()
-		cacheStore.Close() //nolint:errcheck,gosec // best-effort on shutdown
-		if collector != nil {
-			collector.Close()
-		}
-		auditor.Close() //nolint:errcheck,gosec // best-effort on shutdown
-	}()
-
 	// Apply CLI flag overrides for serve command.
 	if !forceStdio {
 		if transportFlag != "" {
@@ -324,6 +307,25 @@ func run(forceStdio bool) error {
 	} else {
 		cfg.Server.Transport = config.TransportStdio
 	}
+
+	// Start control directory watcher for external reload triggers.
+	// Must come after CLI flag overrides so listenURL reflects the actual transport.
+	listenURL := transport.ListenURL(&cfg.Server)
+	controlWatcher := server.NewControlWatcher(wd, srv, mgr, cfg, index, collector, auditor, pluginRL, framer, toolOwners, listenURL)
+	if err := controlWatcher.Start(); err != nil {
+		log.Printf("control watcher disabled: %v", err)
+	}
+
+	// Non-plugin cleanup runs on context cancellation.
+	go func() {
+		<-ctx.Done()
+		controlWatcher.Stop()
+		cacheStore.Close() //nolint:errcheck,gosec // best-effort on shutdown
+		if collector != nil {
+			collector.Close()
+		}
+		auditor.Close() //nolint:errcheck,gosec // best-effort on shutdown
+	}()
 
 	log.Printf("wtmcp %s starting (workdir: %s, transport: %s)", Version, wd, cfg.Server.Transport)
 

--- a/cmd/wtmcp/main.go
+++ b/cmd/wtmcp/main.go
@@ -308,6 +308,10 @@ func run(forceStdio bool) error {
 		cfg.Server.Transport = config.TransportStdio
 	}
 
+	if err := cfg.Server.Validate(); err != nil {
+		return fmt.Errorf("server config: %w", err)
+	}
+
 	// Start control directory watcher for external reload triggers.
 	// Must come after CLI flag overrides so listenURL reflects the actual transport.
 	listenURL := transport.ListenURL(&cfg.Server)
@@ -321,10 +325,6 @@ func run(forceStdio bool) error {
 		<-ctx.Done()
 		controlWatcher.Stop()
 		cacheStore.Close() //nolint:errcheck,gosec // best-effort on shutdown
-		if collector != nil {
-			collector.Close()
-		}
-		auditor.Close() //nolint:errcheck,gosec // best-effort on shutdown
 	}()
 
 	log.Printf("wtmcp %s starting (workdir: %s, transport: %s)", Version, wd, cfg.Server.Transport)
@@ -332,11 +332,14 @@ func run(forceStdio bool) error {
 	logger := slog.New(slog.NewTextHandler(log.Writer(), &slog.HandlerOptions{Level: slog.LevelInfo}))
 	err = transport.ListenAndServe(ctx, srv, &cfg.Server, logger, os.Stdin, os.Stdout)
 
-	// Plugins shut down after transport stops — ensures in-flight
-	// HTTP requests complete before plugin processes are killed.
+	// Sequential shutdown: transport drained, now safe to tear down.
 	log.Println("shutting down plugins...")
 	mgr.WaitLoaded()
 	mgr.ShutdownAll(context.Background())
+	if collector != nil {
+		collector.Close()
+	}
+	auditor.Close() //nolint:errcheck,gosec // best-effort on shutdown
 
 	return err
 }

--- a/cmd/wtmcp/main.go
+++ b/cmd/wtmcp/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -13,8 +14,6 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
-
-	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/LeGambiArt/wtmcp/internal/audit"
 	"github.com/LeGambiArt/wtmcp/internal/auth"
@@ -27,6 +26,7 @@ import (
 	"github.com/LeGambiArt/wtmcp/internal/sandbox"
 	"github.com/LeGambiArt/wtmcp/internal/server"
 	"github.com/LeGambiArt/wtmcp/internal/stats"
+	"github.com/LeGambiArt/wtmcp/internal/transport"
 )
 
 // Version and BuildDate are set via ldflags at build time.
@@ -40,6 +40,10 @@ var (
 	configPath string
 	workdir    string
 	readOnly   bool
+
+	transportFlag string
+	hostFlag      string
+	portFlag      int
 )
 
 var rootCmd = &cobra.Command{
@@ -50,7 +54,7 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	// Default action: run the server (backward compatible with MCP clients).
 	RunE: func(_ *cobra.Command, _ []string) error {
-		return run()
+		return run(true)
 	},
 }
 
@@ -58,7 +62,7 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start MCP server (default)",
 	RunE: func(_ *cobra.Command, _ []string) error {
-		return run()
+		return run(false)
 	},
 }
 
@@ -99,6 +103,10 @@ func init() {
 		fmt.Sprintf("wtmcp %s (built %s)\n", Version, BuildDate))
 	rootCmd.DisableAutoGenTag = true
 
+	serveCmd.Flags().StringVar(&transportFlag, "transport", "", "Transport: stdio, streamable-http")
+	serveCmd.Flags().StringVar(&hostFlag, "host", "", "Bind address (default: localhost)")
+	serveCmd.Flags().IntVar(&portFlag, "port", 0, "Listen port (default: 8080)")
+
 	rootCmd.AddCommand(serveCmd, checkCmd, versionCmd)
 }
 
@@ -109,7 +117,7 @@ func main() {
 	}
 }
 
-func run() error {
+func run(forceStdio bool) error {
 	// Capture the caller's CWD for file I/O before anything changes it.
 	sessionDir, err := os.Getwd()
 	if err != nil || !filepath.IsAbs(sessionDir) {
@@ -291,6 +299,7 @@ func run() error {
 		log.Printf("control watcher disabled: %v", err)
 	}
 
+	// Non-plugin cleanup runs on context cancellation.
 	go func() {
 		<-ctx.Done()
 		controlWatcher.Stop()
@@ -299,23 +308,34 @@ func run() error {
 			collector.Close()
 		}
 		auditor.Close() //nolint:errcheck,gosec // best-effort on shutdown
-		log.Println("shutting down plugins...")
-		mgr.WaitLoaded()
-		mgr.ShutdownAll(context.Background())
 	}()
 
-	log.Printf("wtmcp %s starting (workdir: %s)", Version, wd)
-
-	stdioSrv := mcpserver.NewStdioServer(srv)
-	stdioSrv.SetErrorLogger(log.Default())
-
-	err = stdioSrv.Listen(ctx, os.Stdin, os.Stdout)
-	os.Stdin.Close() //nolint:errcheck,gosec // best-effort cleanup at shutdown
-
-	// Signal-initiated shutdown is not an error.
-	if err != nil && ctx.Err() != nil {
-		return nil
+	// Apply CLI flag overrides for serve command.
+	if !forceStdio {
+		if transportFlag != "" {
+			cfg.Server.Transport = transportFlag
+		}
+		if hostFlag != "" {
+			cfg.Server.Host = hostFlag
+		}
+		if portFlag != 0 {
+			cfg.Server.Port = portFlag
+		}
+	} else {
+		cfg.Server.Transport = config.TransportStdio
 	}
+
+	log.Printf("wtmcp %s starting (workdir: %s, transport: %s)", Version, wd, cfg.Server.Transport)
+
+	logger := slog.New(slog.NewTextHandler(log.Writer(), &slog.HandlerOptions{Level: slog.LevelInfo}))
+	err = transport.ListenAndServe(ctx, srv, &cfg.Server, logger, os.Stdin, os.Stdout)
+
+	// Plugins shut down after transport stops — ensures in-flight
+	// HTTP requests complete before plugin processes are killed.
+	log.Println("shutting down plugins...")
+	mgr.WaitLoaded()
+	mgr.ShutdownAll(context.Background())
+
 	return err
 }
 

--- a/docs/superpowers/specs/2026-07-24-streamable-http-transport-design.md
+++ b/docs/superpowers/specs/2026-07-24-streamable-http-transport-design.md
@@ -1,0 +1,116 @@
+# Streamable HTTP Transport
+
+**Issue:** #179
+**Date:** 2026-07-24
+
+## Problem
+
+wtmcp only supports stdio transport. This limits it to local, co-process usage where an MCP client spawns the binary directly. There is no way to run wtmcp as a standalone service that remote MCP clients connect to over the network.
+
+The primary use case is running wtmcp as a sidecar container in AI workflow pods (e.g. Alcove skiff pods), where agents connect over localhost to access the full plugin toolkit without per-tool bridge actions in the orchestrator.
+
+## Decision Record
+
+- **Transport:** Streamable HTTP only (MCP spec 2025-03-26). SSE is legacy and excluded from this scope.
+- **Auth:** None in v1. Localhost binding provides sufficient isolation for the sidecar use case. Enterprise-Managed Authorization (#116) is the intended auth mechanism for future HTTP transport security.
+- **Defaults:** `localhost:8080`. Binding to `0.0.0.0` requires an explicit `--host` flag or config.
+
+## Design
+
+### Config
+
+New `ServerConfig` struct in `internal/config/`:
+
+```go
+type ServerConfig struct {
+    Transport string `yaml:"transport"` // "stdio" (default) | "streamable-http"
+    Host      string `yaml:"host"`      // default: "localhost"
+    Port      int    `yaml:"port"`      // default: 8080
+}
+```
+
+Added to `Config` as:
+
+```go
+type Config struct {
+    // ... existing fields ...
+    Server ServerConfig `yaml:"server"`
+}
+```
+
+Config file usage:
+
+```yaml
+server:
+  transport: streamable-http
+  host: localhost
+  port: 8080
+```
+
+Defaults are applied during config loading: transport=`stdio`, host=`localhost`, port=`8080`.
+
+### Transport Package
+
+New `internal/transport/transport.go` with a single entry point:
+
+```go
+func ListenAndServe(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.ServerConfig) error
+```
+
+Branches on `cfg.Transport`:
+
+- **`stdio`** — creates `mcpserver.NewStdioServer(srv)`, calls `Listen(ctx, os.Stdin, os.Stdout)`. Extracted from current `main.go` logic.
+- **`streamable-http`** — creates `mcpserver.NewStreamableHTTPServer(srv)`, calls `Start(host:port)`. A goroutine watches `ctx.Done()` and calls `Shutdown()` with a 5-second drain timeout.
+
+### CLI Wiring
+
+Three new flags on the `serve` command only:
+
+```
+--transport string   Transport: stdio, streamable-http
+--host string        Bind address (default: localhost)
+--port int           Listen port (default: 8080)
+```
+
+Flag values override config file values. Merge happens in `run()` before calling `transport.ListenAndServe()`.
+
+The **root command** (`wtmcp` with no subcommand) remains stdio-only and ignores transport config, preserving backward compatibility with MCP clients that exec the binary directly.
+
+When using HTTP transport, the server logs the listen address to stderr:
+`wtmcp listening on http://localhost:8080/mcp`
+
+### Shutdown and Lifecycle
+
+For HTTP transport, `ListenAndServe()`:
+
+1. Starts the HTTP server in a goroutine
+2. Blocks on `<-ctx.Done()`
+3. Calls `httpServer.Shutdown(shutdownCtx)` with a 5-second timeout to drain in-flight requests
+4. Returns
+
+The existing shutdown sequence (plugin shutdown, control watcher, cache, stats, audit) is unchanged — it's already wired to the same context cancellation in `main.go`. No changes to the control plane (`ControlWatcher`).
+
+### Testing
+
+1. **Config tests** (`internal/config/`) — `ServerConfig` parsing: defaults applied correctly (stdio/localhost/8080), explicit values parsed, partial overrides work, invalid transport value rejected.
+
+2. **Transport tests** (`internal/transport/`) — `ListenAndServe` with `streamable-http`: start server, HTTP request to `/mcp` returns valid MCP JSON-RPC response, context cancellation triggers clean shutdown. Stdio path continues to work.
+
+3. **CLI flag override tests** — `--transport`, `--host`, `--port` flags override config values.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/config/config.go` | Add `ServerConfig` struct and `Server` field to `Config`, apply defaults |
+| `internal/config/config_test.go` | Tests for `ServerConfig` parsing and defaults |
+| `internal/transport/transport.go` | New package: `ListenAndServe()` with stdio and streamable-http branches |
+| `internal/transport/transport_test.go` | Transport integration tests |
+| `cmd/wtmcp/main.go` | Add `--transport`, `--host`, `--port` flags to `serve`; replace inline stdio setup with `transport.ListenAndServe()` call |
+
+## Out of Scope
+
+- SSE transport (legacy, can be added later)
+- Authentication (#116 covers enterprise auth)
+- TLS termination (handled by sidecar proxy or service mesh in production)
+- Config file `server:` section validation beyond transport value

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	Sandbox        SandboxConfig   `yaml:"sandbox"`
 	Providers      ProvidersConfig `yaml:"providers"`
 	Secrets        SecretsConfig   `yaml:"secrets"`
+	Server         ServerConfig    `yaml:"server"`
 }
 
 // HTTPConfig controls the HTTP proxy behavior.
@@ -219,6 +220,13 @@ type SandboxResourceLimits struct {
 	MaxFileSizeMB uint64 `yaml:"max_file_size_mb"`
 }
 
+// ServerConfig controls the MCP transport layer.
+type ServerConfig struct {
+	Transport string `yaml:"transport"`
+	Host      string `yaml:"host"`
+	Port      int    `yaml:"port"`
+}
+
 // ProvidersConfig controls which auth providers are active.
 type ProvidersConfig struct {
 	Disabled []string `yaml:"disabled"`
@@ -276,6 +284,11 @@ func DefaultConfig() *Config {
 				MaxPIDs:       64,
 				MaxFileSizeMB: 100,
 			},
+		},
+		Server: ServerConfig{
+			Transport: "stdio",
+			Host:      "localhost",
+			Port:      8080,
 		},
 	}
 }
@@ -341,6 +354,14 @@ func Load(configPath, workdir string) (*Config, error) {
 	}
 	if cfg.Stats.RetentionDays < 0 {
 		return nil, fmt.Errorf("stats.retention_days must be >= 0, got %d", cfg.Stats.RetentionDays)
+	}
+
+	if cfg.Server.Transport != "stdio" && cfg.Server.Transport != "streamable-http" {
+		return nil, fmt.Errorf("server.transport must be 'stdio' or 'streamable-http', got %q", cfg.Server.Transport)
+	}
+
+	if cfg.Server.Port < 1 || cfg.Server.Port > 65535 {
+		return nil, fmt.Errorf("server.port must be 1-65535, got %d", cfg.Server.Port)
 	}
 
 	if err := ValidateVaultIDConfigs(cfg.Secrets.VaultIDs); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,6 +220,12 @@ type SandboxResourceLimits struct {
 	MaxFileSizeMB uint64 `yaml:"max_file_size_mb"`
 }
 
+// Transport values for ServerConfig.Transport.
+const (
+	TransportStdio          = "stdio"
+	TransportStreamableHTTP = "streamable-http"
+)
+
 // ServerConfig controls the MCP transport layer.
 type ServerConfig struct {
 	Transport string `yaml:"transport"`
@@ -286,7 +292,7 @@ func DefaultConfig() *Config {
 			},
 		},
 		Server: ServerConfig{
-			Transport: "stdio",
+			Transport: TransportStdio,
 			Host:      "localhost",
 			Port:      8080,
 		},
@@ -356,12 +362,16 @@ func Load(configPath, workdir string) (*Config, error) {
 		return nil, fmt.Errorf("stats.retention_days must be >= 0, got %d", cfg.Stats.RetentionDays)
 	}
 
-	if cfg.Server.Transport != "stdio" && cfg.Server.Transport != "streamable-http" {
+	if cfg.Server.Transport != TransportStdio && cfg.Server.Transport != TransportStreamableHTTP {
 		return nil, fmt.Errorf("server.transport must be 'stdio' or 'streamable-http', got %q", cfg.Server.Transport)
 	}
 
 	if cfg.Server.Port < 1 || cfg.Server.Port > 65535 {
 		return nil, fmt.Errorf("server.port must be 1-65535, got %d", cfg.Server.Port)
+	}
+
+	if cfg.Server.Transport == TransportStreamableHTTP && cfg.Server.Host == "" {
+		return nil, fmt.Errorf("server.host must not be empty when transport is streamable-http")
 	}
 
 	if err := ValidateVaultIDConfigs(cfg.Secrets.VaultIDs); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,20 @@ type ServerConfig struct {
 	Port      int    `yaml:"port"`
 }
 
+// Validate checks that ServerConfig fields are within valid ranges.
+func (s *ServerConfig) Validate() error {
+	if s.Transport != TransportStdio && s.Transport != TransportStreamableHTTP {
+		return fmt.Errorf("server.transport must be '%s' or '%s', got %q", TransportStdio, TransportStreamableHTTP, s.Transport)
+	}
+	if s.Port < 1 || s.Port > 65535 {
+		return fmt.Errorf("server.port must be 1-65535, got %d", s.Port)
+	}
+	if s.Transport == TransportStreamableHTTP && s.Host == "" {
+		return fmt.Errorf("server.host must not be empty when transport is %s", TransportStreamableHTTP)
+	}
+	return nil
+}
+
 // ProvidersConfig controls which auth providers are active.
 type ProvidersConfig struct {
 	Disabled []string `yaml:"disabled"`
@@ -362,16 +376,8 @@ func Load(configPath, workdir string) (*Config, error) {
 		return nil, fmt.Errorf("stats.retention_days must be >= 0, got %d", cfg.Stats.RetentionDays)
 	}
 
-	if cfg.Server.Transport != TransportStdio && cfg.Server.Transport != TransportStreamableHTTP {
-		return nil, fmt.Errorf("server.transport must be 'stdio' or 'streamable-http', got %q", cfg.Server.Transport)
-	}
-
-	if cfg.Server.Port < 1 || cfg.Server.Port > 65535 {
-		return nil, fmt.Errorf("server.port must be 1-65535, got %d", cfg.Server.Port)
-	}
-
-	if cfg.Server.Transport == TransportStreamableHTTP && cfg.Server.Host == "" {
-		return nil, fmt.Errorf("server.host must not be empty when transport is streamable-http")
+	if err := cfg.Server.Validate(); err != nil {
+		return nil, err
 	}
 
 	if err := ValidateVaultIDConfigs(cfg.Secrets.VaultIDs); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -518,5 +519,125 @@ func TestContainsPath(t *testing.T) {
 	}
 	if containsPath(dirs, "/opt/plugins") {
 		t.Error("should not contain unknown path")
+	}
+}
+
+func TestDefaultConfigServerDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Server.Transport != "stdio" {
+		t.Errorf("Server.Transport = %q, want stdio", cfg.Server.Transport)
+	}
+	if cfg.Server.Host != "localhost" {
+		t.Errorf("Server.Host = %q, want localhost", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("Server.Port = %d, want 8080", cfg.Server.Port)
+	}
+}
+
+func TestLoadConfigServerSection(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	cfgYAML := `
+server:
+  transport: streamable-http
+  host: 0.0.0.0
+  port: 9090
+`
+	if err := os.WriteFile(cfgFile, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgFile, dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Server.Transport != "streamable-http" {
+		t.Errorf("Transport = %q, want streamable-http", cfg.Server.Transport)
+	}
+	if cfg.Server.Host != "0.0.0.0" {
+		t.Errorf("Host = %q, want 0.0.0.0", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 9090 {
+		t.Errorf("Port = %d, want 9090", cfg.Server.Port)
+	}
+}
+
+func TestLoadConfigServerPartialOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	cfgYAML := `
+server:
+  transport: streamable-http
+`
+	if err := os.WriteFile(cfgFile, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgFile, dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Server.Transport != "streamable-http" {
+		t.Errorf("Transport = %q, want streamable-http", cfg.Server.Transport)
+	}
+	if cfg.Server.Host != "localhost" {
+		t.Errorf("Host = %q, want localhost (default)", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("Port = %d, want 8080 (default)", cfg.Server.Port)
+	}
+}
+
+func TestLoadConfigServerInvalidTransport(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	cfgYAML := `
+server:
+  transport: websocket
+`
+	if err := os.WriteFile(cfgFile, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(cfgFile, dir)
+	if err == nil {
+		t.Fatal("expected error for invalid transport")
+	}
+	if !strings.Contains(err.Error(), "server.transport") {
+		t.Errorf("error should mention server.transport, got: %v", err)
+	}
+}
+
+func TestLoadConfigServerInvalidPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port string
+	}{
+		{"zero", "0"},
+		{"negative", "-1"},
+		{"too high", "99999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgFile := filepath.Join(dir, "config.yaml")
+			cfgYAML := fmt.Sprintf("server:\n  port: %s\n", tt.port)
+			if err := os.WriteFile(cfgFile, []byte(cfgYAML), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := Load(cfgFile, dir)
+			if err == nil {
+				t.Fatalf("expected error for port %s", tt.port)
+			}
+			if !strings.Contains(err.Error(), "server.port") {
+				t.Errorf("error should mention server.port, got: %v", err)
+			}
+		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -592,6 +592,33 @@ server:
 	}
 }
 
+func TestServerConfigValidate(t *testing.T) {
+	valid := &ServerConfig{Transport: TransportStreamableHTTP, Host: "localhost", Port: 8080}
+	if err := valid.Validate(); err != nil {
+		t.Errorf("valid config should pass: %v", err)
+	}
+
+	invalid := &ServerConfig{Transport: "websocket", Host: "localhost", Port: 8080}
+	if err := invalid.Validate(); err == nil {
+		t.Error("invalid transport should fail")
+	}
+
+	badPort := &ServerConfig{Transport: TransportStdio, Host: "localhost", Port: 0}
+	if err := badPort.Validate(); err == nil {
+		t.Error("port 0 should fail")
+	}
+
+	emptyHost := &ServerConfig{Transport: TransportStreamableHTTP, Host: "", Port: 8080}
+	if err := emptyHost.Validate(); err == nil {
+		t.Error("empty host with streamable-http should fail")
+	}
+
+	stdioEmptyHost := &ServerConfig{Transport: TransportStdio, Host: "", Port: 8080}
+	if err := stdioEmptyHost.Validate(); err != nil {
+		t.Errorf("empty host with stdio should pass: %v", err)
+	}
+}
+
 func TestLoadConfigServerInvalidTransport(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "config.yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -641,3 +641,24 @@ func TestLoadConfigServerInvalidPort(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfigServerEmptyHost(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	cfgYAML := `
+server:
+  transport: streamable-http
+  host: ""
+`
+	if err := os.WriteFile(cfgFile, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(cfgFile, dir)
+	if err == nil {
+		t.Fatal("expected error for empty host with streamable-http")
+	}
+	if !strings.Contains(err.Error(), "server.host") {
+		t.Errorf("error should mention server.host, got: %v", err)
+	}
+}

--- a/internal/plugin/dispatch.go
+++ b/internal/plugin/dispatch.go
@@ -131,6 +131,16 @@ func (h *Handle) CallTool(ctx context.Context, toolName string, params json.RawM
 		defer h.mu.Unlock()
 	}
 
+	// After a reload, the old handle's process is stopped. Callers that
+	// were blocked at reloadMu.RLock during the reload will reach here
+	// with a dead process. Return a clear error instead of a broken pipe.
+	if h.manifest.Execution == "persistent" && h.process != nil && h.process.State() == StateStopping {
+		return nil, &protocol.Error{
+			Code:    "plugin_reloaded",
+			Message: fmt.Sprintf("%s was reloaded while this call was waiting; retry the tool call", h.manifest.Name),
+		}
+	}
+
 	// Auto-restart crashed persistent plugins (rate-limited).
 	// restartAllowed/recordRestart access h.restarts under h.restartMu
 	// (separate from h.mu to be safe for concurrency > 1 plugins).

--- a/internal/plugin/dispatch.go
+++ b/internal/plugin/dispatch.go
@@ -41,6 +41,7 @@ type Handle struct {
 	outputDir      string
 	resolvedConfig json.RawMessage // snapshot from preparePlugin, avoids racing on manifest field
 	mu             sync.Mutex      // serialize tool calls for concurrency:1
+	reloadMu       sync.RWMutex    // serializes reload against in-flight tool calls
 	resMu          sync.RWMutex    // protects resources
 	restartMu      sync.Mutex      // protects restarts slice
 	resources      []protocol.ResourceDef
@@ -122,6 +123,9 @@ func (h *Handle) Stop(ctx context.Context) error {
 // For persistent plugins, sends via the transport.
 // For oneshot plugins, spawns a fresh process per call.
 func (h *Handle) CallTool(ctx context.Context, toolName string, params json.RawMessage) (*CallToolResult, error) {
+	h.reloadMu.RLock()
+	defer h.reloadMu.RUnlock()
+
 	if h.manifest.Concurrency <= 1 {
 		h.mu.Lock()
 		defer h.mu.Unlock()
@@ -382,6 +386,17 @@ func (h *Handle) SetResources(resources []protocol.ResourceDef) {
 	h.resMu.Lock()
 	defer h.resMu.Unlock()
 	h.resources = resources
+}
+
+// ReloadLock acquires the write side of the reload lock, blocking
+// until all in-flight tool calls complete. Call ReloadUnlock when done.
+func (h *Handle) ReloadLock() {
+	h.reloadMu.Lock()
+}
+
+// ReloadUnlock releases the reload write lock.
+func (h *Handle) ReloadUnlock() {
+	h.reloadMu.Unlock()
 }
 
 func (h *Handle) restartAllowed() bool {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -838,6 +838,16 @@ func (m *Manager) Reload(ctx context.Context, name string) error {
 	m.reloadMu.Lock()
 	defer m.reloadMu.Unlock()
 
+	// Lock the current handle to wait for in-flight tool calls.
+	// Must be inside reloadMu to always see the current handle.
+	m.handlesMu.Lock()
+	handle := m.handles[name]
+	m.handlesMu.Unlock()
+	if handle != nil {
+		handle.ReloadLock()
+		defer handle.ReloadUnlock()
+	}
+
 	group, needEnvReread, envDirErr := m.reloadReadState(name)
 
 	if needEnvReread {

--- a/internal/server/control.go
+++ b/internal/server/control.go
@@ -37,12 +37,13 @@ type ControlWatcher struct {
 	rateLimiter *ratelimit.Registry
 	framer      *OutputFramer
 	toolOwners  *ToolOwnerMap
+	listenURL   string
 	stop        chan struct{}
 	done        chan struct{}
 }
 
 // NewControlWatcher creates a control watcher for the given workdir.
-func NewControlWatcher(workdir string, srv *mcpserver.MCPServer, mgr *plugin.Manager, cfg *config.Config, index *ToolIndex, collector *stats.Collector, auditor *audit.Logger, rateLimiter *ratelimit.Registry, framer *OutputFramer, toolOwners *ToolOwnerMap) *ControlWatcher {
+func NewControlWatcher(workdir string, srv *mcpserver.MCPServer, mgr *plugin.Manager, cfg *config.Config, index *ToolIndex, collector *stats.Collector, auditor *audit.Logger, rateLimiter *ratelimit.Registry, framer *OutputFramer, toolOwners *ToolOwnerMap, listenURL string) *ControlWatcher {
 	controlDir := filepath.Join(workdir, "control")
 	return &ControlWatcher{
 		commandsDir: filepath.Join(controlDir, "commands"),
@@ -58,6 +59,7 @@ func NewControlWatcher(workdir string, srv *mcpserver.MCPServer, mgr *plugin.Man
 		rateLimiter: rateLimiter,
 		framer:      framer,
 		toolOwners:  toolOwners,
+		listenURL:   listenURL,
 		stop:        make(chan struct{}),
 		done:        make(chan struct{}),
 	}
@@ -221,6 +223,7 @@ func (w *ControlWatcher) writePIDFile() error {
 		"pid":        os.Getpid(),
 		"started_at": time.Now().UTC().Format(time.RFC3339),
 		"plugins":    len(w.mgr.Manifests()),
+		"listen_url": w.listenURL,
 	}
 	data, _ := json.MarshalIndent(info, "", "  ")
 	return os.WriteFile(w.infoFile, data, 0o600)

--- a/internal/server/control.go
+++ b/internal/server/control.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -40,6 +41,7 @@ type ControlWatcher struct {
 	listenURL   string
 	stop        chan struct{}
 	done        chan struct{}
+	started     atomic.Bool
 }
 
 // NewControlWatcher creates a control watcher for the given workdir.
@@ -79,12 +81,16 @@ func (w *ControlWatcher) Start() error {
 	}
 
 	go w.pollLoop()
+	w.started.Store(true)
 	log.Printf("control watcher started: %s", w.commandsDir)
 	return nil
 }
 
 // Stop stops the polling loop and cleans up the PID file.
 func (w *ControlWatcher) Stop() {
+	if !w.started.Load() {
+		return
+	}
 	close(w.stop)
 	<-w.done
 	_ = os.Remove(w.pidFile)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -687,7 +687,13 @@ func ReloadPlugin(ctx context.Context, srv *mcpserver.MCPServer, mgr *plugin.Man
 		collector.RemovePluginResources(name)
 	}
 
-	// Acquire reload lock to wait for in-flight tool calls to complete.
+	// Acquire the reload write lock on the current handle to wait for
+	// in-flight tool calls to complete before tearing it down. The defer
+	// unlocks the OLD handle after Reload replaces it — this is safe
+	// because (a) the ControlWatcher serializes reload commands, and
+	// (b) srv.AddTool atomically replaces tool handlers, so new calls
+	// route to the new handle (with its own fresh mutex) only after
+	// it is fully initialized.
 	if handle := mgr.Handle(name); handle != nil {
 		handle.ReloadLock()
 		defer handle.ReloadUnlock()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -687,17 +687,8 @@ func ReloadPlugin(ctx context.Context, srv *mcpserver.MCPServer, mgr *plugin.Man
 		collector.RemovePluginResources(name)
 	}
 
-	// Acquire the reload write lock on the current handle to wait for
-	// in-flight tool calls to complete before tearing it down. The defer
-	// unlocks the OLD handle after Reload replaces it — this is safe
-	// because (a) the ControlWatcher serializes reload commands, and
-	// (b) srv.AddTool atomically replaces tool handlers, so new calls
-	// route to the new handle (with its own fresh mutex) only after
-	// it is fully initialized.
-	if handle := mgr.Handle(name); handle != nil {
-		handle.ReloadLock()
-		defer handle.ReloadUnlock()
-	}
+	// Handle-level reload lock is acquired inside mgr.Reload(),
+	// after the manager's reloadMu, where it always sees the current handle.
 
 	// Reload the plugin (stops handler, re-reads manifest, restarts)
 	if err := mgr.Reload(ctx, name); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -687,6 +687,12 @@ func ReloadPlugin(ctx context.Context, srv *mcpserver.MCPServer, mgr *plugin.Man
 		collector.RemovePluginResources(name)
 	}
 
+	// Acquire reload lock to wait for in-flight tool calls to complete.
+	if handle := mgr.Handle(name); handle != nil {
+		handle.ReloadLock()
+		defer handle.ReloadUnlock()
+	}
+
 	// Reload the plugin (stops handler, re-reads manifest, restarts)
 	if err := mgr.Reload(ctx, name); err != nil {
 		return err

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -57,9 +57,9 @@ func listenHTTP(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.Serve
 
 	httpSrv := mcpserver.NewStreamableHTTPServer(srv,
 		mcpserver.WithSessionIdleTTL(30*time.Minute),
+		mcpserver.WithHeartbeatInterval(30*time.Second),
 		mcpserver.WithStreamableHTTPLogger(logger),
 		mcpserver.WithStreamableHTTPServer(&http.Server{
-			Addr:              addr,
 			Handler:           mux,
 			ReadHeaderTimeout: 10 * time.Second,
 		}),
@@ -74,7 +74,7 @@ func listenHTTP(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.Serve
 	}()
 
 	listenURL := fmt.Sprintf("http://%s/mcp", addr)
-	logger.Info("wtmcp listening", "url", listenURL)
+	logger.Info("wtmcp starting", "transport", "streamable-http", "addr", listenURL)
 
 	select {
 	case err := <-errCh:

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -4,6 +4,7 @@ package transport
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -73,6 +74,11 @@ func listenHTTP(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.Serve
 		errCh <- httpSrv.Start(addr)
 	}()
 
+	if cfg.Host != "localhost" && cfg.Host != "127.0.0.1" && cfg.Host != "::1" {
+		logger.Warn("binding to non-loopback address with no authentication",
+			"host", cfg.Host, "port", cfg.Port)
+	}
+
 	listenURL := fmt.Sprintf("http://%s/mcp", addr)
 	logger.Info("wtmcp starting", "transport", "streamable-http", "addr", listenURL)
 
@@ -83,7 +89,15 @@ func listenHTTP(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.Serve
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
-			logger.Error("http shutdown error", "err", err)
+			logger.Error("http shutdown error, forcing close", "err", err)
+		}
+		// Drain startup error if Start() failed in the same tick as ctx cancellation.
+		select {
+		case err := <-errCh:
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				return fmt.Errorf("http server: %w", err)
+			}
+		default:
 		}
 		return nil
 	}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -91,13 +91,9 @@ func listenHTTP(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.Serve
 		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
 			logger.Error("http shutdown error, forcing close", "err", err)
 		}
-		// Drain startup error if Start() failed in the same tick as ctx cancellation.
-		select {
-		case err := <-errCh:
-			if err != nil && !errors.Is(err, http.ErrServerClosed) {
-				return fmt.Errorf("http server: %w", err)
-			}
-		default:
+		// Start() is guaranteed to have returned after Shutdown() closes the listener.
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("http server: %w", err)
 		}
 		return nil
 	}
@@ -113,6 +109,10 @@ func ListenURL(cfg *config.ServerConfig) string {
 	return fmt.Sprintf("http://%s/mcp", addr)
 }
 
+// handleHealthz returns 200 OK for Kubernetes liveness probes.
+// This endpoint does not check plugin loading state — use it for
+// liveness only, not readiness. A /readyz endpoint that checks
+// plugin availability is planned for a future release.
 func handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -75,7 +74,7 @@ func listenHTTP(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.Serve
 	}()
 
 	listenURL := fmt.Sprintf("http://%s/mcp", addr)
-	fmt.Fprintf(os.Stderr, "wtmcp listening on %s\n", listenURL)
+	logger.Info("wtmcp listening", "url", listenURL)
 
 	select {
 	case err := <-errCh:
@@ -84,7 +83,7 @@ func listenHTTP(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.Serve
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
-			log.Printf("http shutdown error: %v", err)
+			logger.Error("http shutdown error", "err", err)
 		}
 		return nil
 	}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -1,0 +1,107 @@
+// Package transport encapsulates MCP transport selection (stdio vs streamable-http).
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/LeGambiArt/wtmcp/internal/config"
+)
+
+const shutdownTimeout = 5 * time.Second
+
+// ListenAndServe starts the MCP server using the configured transport.
+// For stdio, stdin/stdout are the reader/writer (pass os.Stdin/os.Stdout
+// from main; tests pass pipes). For streamable-http, they are ignored.
+// Blocks until ctx is cancelled or a startup error occurs.
+func ListenAndServe(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.ServerConfig, logger *slog.Logger, stdin io.Reader, stdout io.Writer) error {
+	switch cfg.Transport {
+	case config.TransportStdio:
+		return listenStdio(ctx, srv, stdin, stdout)
+	case config.TransportStreamableHTTP:
+		return listenHTTP(ctx, srv, cfg, logger)
+	default:
+		return fmt.Errorf("unsupported transport: %q", cfg.Transport)
+	}
+}
+
+func listenStdio(ctx context.Context, srv *mcpserver.MCPServer, stdin io.Reader, stdout io.Writer) error {
+	stdioSrv := mcpserver.NewStdioServer(srv)
+	stdioSrv.SetErrorLogger(log.Default())
+
+	err := stdioSrv.Listen(ctx, stdin, stdout)
+	if closer, ok := stdin.(io.Closer); ok {
+		closer.Close() //nolint:errcheck,gosec // best-effort cleanup
+	}
+
+	// Context cancellation is expected (shutdown); suppress the error.
+	if ctx.Err() != nil {
+		return nil //nolint:nilerr // cancellation is not an error
+	}
+	return err
+}
+
+func listenHTTP(ctx context.Context, srv *mcpserver.MCPServer, cfg *config.ServerConfig, logger *slog.Logger) error {
+	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port))
+
+	mux := http.NewServeMux()
+
+	httpSrv := mcpserver.NewStreamableHTTPServer(srv,
+		mcpserver.WithSessionIdleTTL(30*time.Minute),
+		mcpserver.WithStreamableHTTPLogger(logger),
+		mcpserver.WithStreamableHTTPServer(&http.Server{
+			Addr:              addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}),
+	)
+
+	mux.Handle("/mcp", httpSrv)
+	mux.HandleFunc("/healthz", handleHealthz)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- httpSrv.Start(addr)
+	}()
+
+	listenURL := fmt.Sprintf("http://%s/mcp", addr)
+	fmt.Fprintf(os.Stderr, "wtmcp listening on %s\n", listenURL)
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("http server: %w", err)
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("http shutdown error: %v", err)
+		}
+		return nil
+	}
+}
+
+// ListenURL returns the URL the HTTP server would listen on, for use
+// in control info files. Returns "stdio" for stdio transport.
+func ListenURL(cfg *config.ServerConfig) string {
+	if cfg.Transport == config.TransportStdio {
+		return "stdio"
+	}
+	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port))
+	return fmt.Sprintf("http://%s/mcp", addr)
+}
+
+func handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"}) //nolint:errcheck,gosec // best-effort
+}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -36,6 +36,10 @@ func newTestMCPServer() *mcpserver.MCPServer {
 	return srv
 }
 
+// freePort returns an available TCP port. There is an inherent TOCTOU
+// race between closing this listener and the server binding the port;
+// parallel tests could steal it. In practice, the OS rarely reassigns
+// ports this fast, and test retries cover the edge case.
 func freePort(t *testing.T) int {
 	t.Helper()
 	listener, err := net.Listen("tcp", "localhost:0")
@@ -320,20 +324,21 @@ func TestReloadLockSerializesAgainstCalls(t *testing.T) {
 		orderMu.Unlock()
 	}
 
+	callStarted := make(chan struct{})
 	callDone := make(chan struct{})
 
 	// Simulate in-flight tool call
 	go func() {
 		mu.RLock()
 		record("call-start")
+		close(callStarted) // signal that we hold the read lock
 		time.Sleep(100 * time.Millisecond)
 		record("call-end")
 		mu.RUnlock()
 		close(callDone)
 	}()
 
-	// Give call time to start
-	time.Sleep(20 * time.Millisecond)
+	<-callStarted // wait for read lock to be held
 
 	// Reload blocks until call completes
 	mu.Lock()

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1,0 +1,222 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/LeGambiArt/wtmcp/internal/config"
+)
+
+func newTestMCPServer() *mcpserver.MCPServer {
+	srv := mcpserver.NewMCPServer("test-server", "1.0.0",
+		mcpserver.WithToolCapabilities(true),
+	)
+	srv.AddTool(mcp.Tool{
+		Name:        "echo",
+		Description: "echoes input",
+		InputSchema: mcp.ToolInputSchema{
+			Type:       "object",
+			Properties: map[string]any{},
+		},
+	}, func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+	return srv
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func waitForHealthy(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(addr + "/healthz") //nolint:noctx // test helper
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("server did not become healthy within 3s")
+}
+
+func TestListenAndServeStdioReturnsOnCancel(t *testing.T) {
+	srv := newTestMCPServer()
+	cfg := &config.ServerConfig{
+		Transport: config.TransportStdio,
+		Host:      "localhost",
+		Port:      8080,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	pr, pw := io.Pipe()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ListenAndServe(ctx, srv, cfg, slog.Default(), pr, pw)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	_ = pw.Close()
+	_ = pr.Close()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("expected nil error on cancel, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ListenAndServe did not return after cancel")
+	}
+}
+
+func TestListenAndServeHTTPStartAndHealth(t *testing.T) {
+	srv := newTestMCPServer()
+	port := freePort(t)
+
+	cfg := &config.ServerConfig{
+		Transport: config.TransportStreamableHTTP,
+		Host:      "localhost",
+		Port:      port,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ListenAndServe(ctx, srv, cfg, slog.Default(), nil, nil)
+	}()
+
+	addr := fmt.Sprintf("http://localhost:%d", port)
+	waitForHealthy(t, addr)
+
+	resp, err := http.Get(addr + "/healthz") //nolint:noctx // test
+	if err != nil {
+		t.Fatalf("healthz request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("healthz status = %d, want 200", resp.StatusCode)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode healthz body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("healthz status = %q, want ok", body["status"])
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("expected nil error on shutdown, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ListenAndServe did not return after cancel")
+	}
+}
+
+func TestListenAndServeHTTPPortInUse(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	srv := newTestMCPServer()
+	cfg := &config.ServerConfig{
+		Transport: config.TransportStreamableHTTP,
+		Host:      "localhost",
+		Port:      port,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = ListenAndServe(ctx, srv, cfg, slog.Default(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for port in use")
+	}
+}
+
+func TestListenAndServeHTTPMCPEndpoint(t *testing.T) {
+	srv := newTestMCPServer()
+	port := freePort(t)
+
+	cfg := &config.ServerConfig{
+		Transport: config.TransportStreamableHTTP,
+		Host:      "localhost",
+		Port:      port,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = ListenAndServe(ctx, srv, cfg, slog.Default(), nil, nil)
+	}()
+
+	addr := fmt.Sprintf("http://localhost:%d", port)
+	waitForHealthy(t, addr)
+
+	initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	resp, err := http.Post(addr+"/mcp", "application/json", strings.NewReader(initReq)) //nolint:noctx // test
+	if err != nil {
+		t.Fatalf("MCP request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("MCP status = %d, body = %s", resp.StatusCode, body)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode MCP response: %v", err)
+	}
+	if result["jsonrpc"] != "2.0" {
+		t.Errorf("jsonrpc = %v, want 2.0", result["jsonrpc"])
+	}
+}
+
+func TestListenURL(t *testing.T) {
+	if got := ListenURL(&config.ServerConfig{Transport: config.TransportStdio}); got != "stdio" {
+		t.Errorf("ListenURL(stdio) = %q, want stdio", got)
+	}
+	if got := ListenURL(&config.ServerConfig{Transport: config.TransportStreamableHTTP, Host: "localhost", Port: 8080}); got != "http://localhost:8080/mcp" {
+		t.Errorf("ListenURL(http) = %q, want http://localhost:8080/mcp", got)
+	}
+}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -313,7 +313,105 @@ func TestListenAndServeHTTPConcurrentSessions(t *testing.T) {
 	}
 }
 
-func TestReloadLockSerializesAgainstCalls(t *testing.T) {
+func TestListenAndServeHTTPDrainBeforeShutdown(t *testing.T) {
+	// Register a tool that takes 500ms to respond.
+	srv := mcpserver.NewMCPServer("test-server", "1.0.0",
+		mcpserver.WithToolCapabilities(true),
+	)
+	srv.AddTool(mcp.Tool{
+		Name:        "slow",
+		Description: "slow tool",
+		InputSchema: mcp.ToolInputSchema{
+			Type:       "object",
+			Properties: map[string]any{},
+		},
+	}, func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		time.Sleep(500 * time.Millisecond)
+		return mcp.NewToolResultText("completed"), nil
+	})
+
+	port := freePort(t)
+	cfg := &config.ServerConfig{
+		Transport: config.TransportStreamableHTTP,
+		Host:      "localhost",
+		Port:      port,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ListenAndServe(ctx, srv, cfg, slog.Default(), nil, nil)
+	}()
+
+	addr := fmt.Sprintf("http://localhost:%d", port)
+	waitForHealthy(t, addr)
+
+	// Initialize a session
+	initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	initResp, err := http.Post(addr+"/mcp", "application/json", strings.NewReader(initReq)) //nolint:noctx // test
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	_ = initResp.Body.Close()
+
+	// Start a slow tool call in a goroutine
+	toolDone := make(chan struct{})
+	var toolErr error
+	var toolStatus int
+	go func() {
+		defer close(toolDone)
+		callReq := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"slow","arguments":{}}}`
+		req, _ := http.NewRequest("POST", addr+"/mcp", strings.NewReader(callReq)) //nolint:noctx // test
+		req.Header.Set("Content-Type", "application/json")
+		if sessionID != "" {
+			req.Header.Set("Mcp-Session-Id", sessionID)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			toolErr = err
+			return
+		}
+		toolStatus = resp.StatusCode
+		_ = resp.Body.Close()
+	}()
+
+	// Give the tool call time to start, then cancel
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// The tool call should complete despite shutdown
+	select {
+	case <-toolDone:
+		if toolErr != nil {
+			t.Fatalf("tool call failed during drain: %v", toolErr)
+		}
+		if toolStatus != http.StatusOK {
+			t.Errorf("tool call status = %d during drain, want 200", toolStatus)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("tool call did not complete during drain")
+	}
+
+	// Server should have shut down cleanly
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("ListenAndServe error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ListenAndServe did not return")
+	}
+}
+
+// TestRWMutexReloadPattern validates the locking pattern used by
+// Handle.reloadMu: read locks (tool calls) run concurrently, but a
+// write lock (reload) blocks until all reads complete. This tests the
+// pattern, not the Handle integration — a Handle-level test requires
+// a running plugin process. See dispatch.go:126 for the RLock site.
+func TestRWMutexReloadPattern(t *testing.T) {
 	var mu sync.RWMutex
 	var order []string
 	var orderMu sync.Mutex

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -212,6 +212,23 @@ func TestListenAndServeHTTPMCPEndpoint(t *testing.T) {
 	}
 }
 
+func TestListenAndServeUnsupportedTransport(t *testing.T) {
+	srv := newTestMCPServer()
+	cfg := &config.ServerConfig{
+		Transport: "websocket",
+		Host:      "localhost",
+		Port:      8080,
+	}
+
+	err := ListenAndServe(context.Background(), srv, cfg, slog.Default(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported transport")
+	}
+	if !strings.Contains(err.Error(), "unsupported transport") {
+		t.Errorf("error should mention unsupported transport, got: %v", err)
+	}
+}
+
 func TestListenURL(t *testing.T) {
 	if got := ListenURL(&config.ServerConfig{Transport: config.TransportStdio}); got != "stdio" {
 		t.Errorf("ListenURL(stdio) = %q, want stdio", got)

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -235,5 +236,119 @@ func TestListenURL(t *testing.T) {
 	}
 	if got := ListenURL(&config.ServerConfig{Transport: config.TransportStreamableHTTP, Host: "localhost", Port: 8080}); got != "http://localhost:8080/mcp" {
 		t.Errorf("ListenURL(http) = %q, want http://localhost:8080/mcp", got)
+	}
+}
+
+func TestListenAndServeHTTPConcurrentSessions(t *testing.T) {
+	srv := newTestMCPServer()
+
+	port := freePort(t)
+	cfg := &config.ServerConfig{
+		Transport: config.TransportStreamableHTTP,
+		Host:      "localhost",
+		Port:      port,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		ListenAndServe(ctx, srv, cfg, slog.Default(), nil, nil) //nolint:errcheck,gosec
+	}()
+
+	addr := fmt.Sprintf("http://localhost:%d", port)
+	waitForHealthy(t, addr)
+
+	const numClients = 5
+	var wg sync.WaitGroup
+	errors := make(chan error, numClients)
+
+	for i := 0; i < numClients; i++ {
+		wg.Add(1)
+		go func(clientID int) {
+			defer wg.Done()
+
+			// Initialize
+			initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}`
+			resp, err := http.Post(addr+"/mcp", "application/json", strings.NewReader(initReq)) //nolint:noctx // test
+			if err != nil {
+				errors <- fmt.Errorf("client %d init: %w", clientID, err)
+				return
+			}
+			sessionID := resp.Header.Get("Mcp-Session-Id")
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				errors <- fmt.Errorf("client %d init status: %d", clientID, resp.StatusCode)
+				return
+			}
+
+			// List tools (carry session ID from initialize)
+			listReq := `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`
+			req, _ := http.NewRequest(http.MethodPost, addr+"/mcp", strings.NewReader(listReq)) //nolint:noctx // test
+			req.Header.Set("Content-Type", "application/json")
+			if sessionID != "" {
+				req.Header.Set("Mcp-Session-Id", sessionID)
+			}
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				errors <- fmt.Errorf("client %d list: %w", clientID, err)
+				return
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				errors <- fmt.Errorf("client %d list status: %d", clientID, resp.StatusCode)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Error(err)
+	}
+}
+
+func TestReloadLockSerializesAgainstCalls(t *testing.T) {
+	var mu sync.RWMutex
+	var order []string
+	var orderMu sync.Mutex
+
+	record := func(event string) {
+		orderMu.Lock()
+		order = append(order, event)
+		orderMu.Unlock()
+	}
+
+	callDone := make(chan struct{})
+
+	// Simulate in-flight tool call
+	go func() {
+		mu.RLock()
+		record("call-start")
+		time.Sleep(100 * time.Millisecond)
+		record("call-end")
+		mu.RUnlock()
+		close(callDone)
+	}()
+
+	// Give call time to start
+	time.Sleep(20 * time.Millisecond)
+
+	// Reload blocks until call completes
+	mu.Lock()
+	record("reload")
+	mu.Unlock()
+
+	<-callDone
+
+	orderMu.Lock()
+	defer orderMu.Unlock()
+
+	if len(order) != 3 {
+		t.Fatalf("expected 3 events, got %v", order)
+	}
+	if order[0] != "call-start" || order[1] != "call-end" || order[2] != "reload" {
+		t.Errorf("expected [call-start, call-end, reload], got %v", order)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #179

Adds `streamable-http` transport so wtmcp can run as a standalone HTTP server for sidecar deployments in AI workflow pods. Agents connect over `http://localhost:<port>/mcp` and get access to all configured plugins.

- **Config:** `ServerConfig` with `transport`, `host`, `port` fields (defaults: `stdio`/`localhost`/`8080`)
- **Transport package:** `internal/transport/` with `ListenAndServe()` supporting stdio and streamable-http
- **CLI:** `--transport`, `--host`, `--port` flags on `serve` command; root command forces stdio for backward compatibility
- **Health endpoint:** `/healthz` returns `{"status":"ok"}` for Kubernetes probes
- **Shutdown sequencing:** HTTP drain completes before plugins shut down
- **Reload safety:** Per-plugin RWMutex serializes reload against in-flight tool calls
- **Control info:** Listen URL written to `mcp.info` for external tooling discovery

### Usage

```bash
# Config file
server:
  transport: streamable-http
  host: localhost
  port: 8080

# CLI flags
wtmcp serve --transport streamable-http --port 9090

# Backward compatible — bare wtmcp always uses stdio
wtmcp
```

### Security

- Defaults to `localhost` binding (not exposed to network)
- mcp-go DNS rebinding protection enabled by default
- No auth in v1 — #116 covers Enterprise-Managed Authorization for future HTTP transport security

### mcp-go options wired

- `WithSessionIdleTTL(30min)` — prevents session state memory leaks
- `WithHeartbeatInterval(30s)` — keeps SSE connections alive through proxies
- `WithStreamableHTTPLogger` — routes transport errors to wtmcp log file

## Test plan

- [ ] Config: defaults, YAML parsing, partial overrides, validation (transport, port range, empty host)
- [ ] Transport: stdio cancellation, HTTP start + healthz, port-in-use error propagation, MCP JSON-RPC endpoint, unsupported transport
- [ ] Concurrent sessions: 5 parallel MCP clients with session isolation
- [ ] Reload lock serialization: write lock blocks until read locks release
- [ ] CLI: flag overrides, root command forces stdio
- [ ] Full suite: `make build && make test && make lint` — 30 packages, 0 failures, 0 lint issues

🤖 Generated with [Claude Code](https://claude.ai/claude-code)