### PR TITLE
feat(gitlab): add target_project_id to gitlab_create_merge_request

### DIFF
--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -389,6 +389,9 @@ tools:
         type: string
         required: true
         description: "Branch to merge into"
+      target_project_id:
+        type: string
+        description: "Target project ID or path for cross-project (fork-to-upstream) MRs. When set, project_id is the fork and this is the upstream project. A path value is resolved to a numeric ID via a live API call, even in dry-run mode."
       title:
         type: string
         required: true

--- a/plugins/gitlab/tools_write.go
+++ b/plugins/gitlab/tools_write.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
@@ -13,6 +14,9 @@ import (
 const maxBodyLen = 65000
 
 var validBranch = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._/-]*[a-zA-Z0-9])?$`)
+
+// validProjectPath matches GitLab namespace paths (max 255 chars enforced separately).
+var validProjectPath = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*[a-zA-Z0-9]$`)
 
 func validateBranch(name string) error {
 	if strings.TrimSpace(name) == "" {
@@ -236,6 +240,7 @@ type createMergeRequestParams struct {
 	ProjectID          string   `json:"project_id"`
 	SourceBranch       string   `json:"source_branch"`
 	TargetBranch       string   `json:"target_branch"`
+	TargetProjectID    string   `json:"target_project_id"`
 	Title              string   `json:"title"`
 	Description        string   `json:"description"`
 	Labels             []string `json:"labels"`
@@ -276,6 +281,29 @@ func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
 		return nil, err
 	}
 
+	// Resolve target_project_id to a numeric ID if provided.
+	// When the value is a path string (not a numeric ID), a live GET /projects/:path
+	// is issued to resolve it — this occurs even in dry-run mode.
+	var targetProjectID *int64
+	if tid := strings.TrimSpace(p.TargetProjectID); tid != "" {
+		if n, err := strconv.ParseInt(tid, 10, 64); err == nil {
+			if n <= 0 {
+				return nil, fmt.Errorf("target_project_id: numeric ID must be positive")
+			}
+			targetProjectID = &n
+		} else {
+			if len(tid) > 255 || !validProjectPath.MatchString(tid) {
+				return nil, fmt.Errorf("target_project_id: invalid project path %q", tid)
+			}
+			proj, _, err := client.Projects.GetProject(tid, nil)
+			if err != nil {
+				return nil, fmt.Errorf("target_project_id: project not found or not accessible")
+			}
+			n := proj.ID
+			targetProjectID = &n
+		}
+	}
+
 	if isDryRun(p.DryRun) {
 		m := map[string]any{
 			"dry_run":       true,
@@ -284,6 +312,9 @@ func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
 			"source_branch": p.SourceBranch,
 			"target_branch": p.TargetBranch,
 			"title":         title,
+		}
+		if targetProjectID != nil {
+			m["target_project_id"] = *targetProjectID
 		}
 		if p.Description != "" {
 			runes := []rune(p.Description)
@@ -308,9 +339,10 @@ func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
 	}
 
 	opts := &gogitlab.CreateMergeRequestOptions{
-		Title:        &title,
-		SourceBranch: &p.SourceBranch,
-		TargetBranch: &p.TargetBranch,
+		Title:           &title,
+		SourceBranch:    &p.SourceBranch,
+		TargetBranch:    &p.TargetBranch,
+		TargetProjectID: targetProjectID,
 	}
 	if p.RemoveSourceBranch != nil {
 		opts.RemoveSourceBranch = p.RemoveSourceBranch
@@ -331,7 +363,7 @@ func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
 		return nil, fmt.Errorf("create merge request: %w", err)
 	}
 
-	return map[string]any{
+	result := map[string]any{
 		"iid":           mr.IID,
 		"project_id":    p.ProjectID,
 		"title":         mr.Title,
@@ -340,7 +372,11 @@ func toolCreateMergeRequest(params, _ json.RawMessage) (any, error) {
 		"source_branch": mr.SourceBranch,
 		"target_branch": mr.TargetBranch,
 		"created":       true,
-	}, nil
+	}
+	if mr.TargetProjectID != 0 {
+		result["target_project_id"] = mr.TargetProjectID
+	}
+	return result, nil
 }
 
 // --- gitlab_create_branch ---

--- a/plugins/gitlab/tools_write_test.go
+++ b/plugins/gitlab/tools_write_test.go
@@ -279,6 +279,31 @@ func TestCreateMergeRequestValidation(t *testing.T) {
 			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main", "title": "t", "description": strings.Repeat("x", maxBodyLen+1)},
 			errMsg: "description exceeds",
 		},
+		{
+			name:   "target_project_id zero",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main", "title": "t", "target_project_id": "0"},
+			errMsg: "numeric ID must be positive",
+		},
+		{
+			name:   "target_project_id negative",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main", "title": "t", "target_project_id": "-1"},
+			errMsg: "numeric ID must be positive",
+		},
+		{
+			name:   "target_project_id invalid path",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main", "title": "t", "target_project_id": "bad path!"},
+			errMsg: "invalid project path",
+		},
+		{
+			name:   "target_project_id path starts with dash",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main", "title": "t", "target_project_id": "-bad/path"},
+			errMsg: "invalid project path",
+		},
+		{
+			name:   "target_project_id too long",
+			params: map[string]any{"project_id": "p", "source_branch": "feat", "target_branch": "main", "title": "t", "target_project_id": strings.Repeat("a", 256)},
+			errMsg: "invalid project path",
+		},
 	}
 
 	for _, tc := range tests {
@@ -291,6 +316,32 @@ func TestCreateMergeRequestValidation(t *testing.T) {
 				t.Errorf("error = %q, want to contain %q", err.Error(), tc.errMsg)
 			}
 		})
+	}
+}
+
+func TestCreateMergeRequestDryRunNumericTargetProject(t *testing.T) {
+	setupGitLabTest(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP calls when target_project_id is numeric")
+		http.NotFound(w, r)
+	})
+
+	result, err := toolCreateMergeRequest(mustJSON(t, map[string]any{
+		"project_id":        "group/fork",
+		"source_branch":     "fix-branch",
+		"target_branch":     "main",
+		"title":             "Fix something",
+		"target_project_id": "42",
+	}), nil)
+	if err != nil {
+		t.Fatalf("toolCreateMergeRequest: %v", err)
+	}
+
+	m := result.(map[string]any)
+	if m["dry_run"] != true {
+		t.Errorf("dry_run = %v, want true", m["dry_run"])
+	}
+	if m["target_project_id"] != int64(42) {
+		t.Errorf("target_project_id = %v (%T), want int64(42)", m["target_project_id"], m["target_project_id"])
 	}
 }
 


### PR DESCRIPTION
The tool only supported same-project MRs. The typical fork-to-upstream workflow (push to your fork, open MR against the upstream) didn't work because there was no way to specify the target project.

This adds an optional `target_project_id` param. Pass your fork as `project_id` and the upstream as `target_project_id` -- either a numeric ID or a path like `redhat/centos-stream/rpms/audit`, the tool resolves it either way.

A few things worth noting:

- Paths are validated (regex + 255 char cap) before hitting the API
- Negative/zero numeric IDs are rejected early
- Lookup failures return a generic error -- no 404 vs 403 distinction to avoid leaking whether a project exists
- If you pass a path, one live GET happens even in dry-run mode to resolve it to a numeric ID; this is documented in the tool description
- The resolved `target_project_id` shows up in both the dry-run preview and the live response

Tested end-to-end against a real GitLab fork (CentOS Stream audit package).