### PR TITLE
sandbox: add cgroup trampoline and AllowExec for Python plugins

### DIFF
--- a/cmd/wtmcp/cgroup_trampoline_linux.go
+++ b/cmd/wtmcp/cgroup_trampoline_linux.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// maybeCgroupTrampoline detects when the process cannot use cgroup
+// resource limits (either because the cgroup isn't writable, or
+// because controllers aren't delegated) and re-execs through
+// systemd-run --user --scope --property=Delegate=yes so the process
+// starts in a scope with delegated controllers.
+//
+// On success this function never returns (exec replaces the process).
+// Returns nil if no trampoline is needed, or an error if the
+// trampoline was needed but could not be performed.
+func maybeCgroupTrampoline() error {
+	// Guard against infinite re-exec.
+	if os.Getenv("WTMCP_CGROUP_REEXEC") == "1" {
+		return nil
+	}
+
+	cgPath, err := selfCgroupPath()
+	if err != nil {
+		log.Printf("cgroup trampoline: skipping, cannot read cgroup path: %v", err)
+		return nil
+	}
+
+	if isWritable(cgPath) && hasControllers(cgPath) {
+		return nil
+	}
+
+	log.Printf("cgroup trampoline: %s not usable by uid %d (writable=%v, controllers=%v), re-execing through systemd-run",
+		cgPath, os.Getuid(), isWritable(cgPath), hasControllers(cgPath))
+
+	return execTrampoline()
+}
+
+// selfCgroupPath reads /proc/self/cgroup and returns the filesystem
+// path for the cgroups v2 unified hierarchy entry.
+func selfCgroupPath() (string, error) {
+	f, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck // read-only file, nothing to recover
+
+	return parseCgroupV2Path(f)
+}
+
+func parseCgroupV2Path(r io.Reader) (string, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if rel, ok := strings.CutPrefix(scanner.Text(), "0::"); ok {
+			return "/sys/fs/cgroup" + rel, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading cgroup entries: %w", err)
+	}
+	return "", fmt.Errorf("no cgroups v2 entry")
+}
+
+// isWritable tests whether the current process can write to a path.
+func isWritable(path string) bool {
+	return unix.Access(path, unix.W_OK) == nil
+}
+
+// hasControllers checks whether the cgroup has any controllers
+// available for delegation (memory, pids, cpu).
+func hasControllers(cgPath string) bool {
+	data, err := os.ReadFile(filepath.Join(cgPath, "cgroup.controllers")) //nolint:gosec // cgPath comes from /proc/self/cgroup, not user input
+	if err != nil {
+		return false
+	}
+	return len(strings.TrimSpace(string(data))) > 0
+}
+
+// execTrampoline re-execs the current process through systemd-run.
+// Never returns on success.
+func execTrampoline() error {
+	systemdRun, err := exec.LookPath("systemd-run")
+	if err != nil {
+		return fmt.Errorf("systemd-run not found: %w", err)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot determine own executable: %w", err)
+	}
+
+	uid := os.Getuid()
+
+	// Ensure the user's systemd session bus is reachable.
+	// su/sudo don't set these, but systemd-run --user needs them.
+	xdgDir := os.Getenv("XDG_RUNTIME_DIR")
+	if xdgDir == "" {
+		xdgDir = fmt.Sprintf("/run/user/%d", uid)
+		if info, err := os.Stat(xdgDir); err != nil || !info.IsDir() {
+			return fmt.Errorf("XDG_RUNTIME_DIR not set and %s does not exist (user systemd session not active?)", xdgDir)
+		}
+		_ = os.Setenv("XDG_RUNTIME_DIR", xdgDir)
+	}
+	if os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+		busPath := filepath.Join(xdgDir, "bus")
+		if _, err := os.Stat(busPath); err == nil { //nolint:gosec // xdgDir is /run/user/<uid>, not user input
+			_ = os.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path="+busPath)
+		}
+	}
+
+	// --scope creates a transient scope unit: the child inherits
+	// the caller's environment, CWD, and stdio naturally (no relay).
+	args := []string{
+		"systemd-run",
+		"--user", "--scope", "--collect", "--quiet",
+		"-p", "KillMode=mixed",
+		"-p", "Delegate=yes",
+		"--",
+		self,
+	}
+	args = append(args, os.Args[1:]...)
+
+	_ = os.Setenv("WTMCP_CGROUP_REEXEC", "1")
+	env := os.Environ()
+
+	log.Printf("cgroup trampoline: exec %s", strings.Join(args, " ")) //nolint:gosec // args are constructed from constants + our own executable path
+
+	return syscall.Exec(systemdRun, args, env) //nolint:gosec // systemdRun comes from LookPath, args from constants
+}

--- a/cmd/wtmcp/cgroup_trampoline_linux_test.go
+++ b/cmd/wtmcp/cgroup_trampoline_linux_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/iotest"
+)
+
+func TestParseCgroupV2Path(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "v2 unified hierarchy",
+			input: "0::/user.slice/user-1000.slice/session-2.scope\n",
+			want:  "/sys/fs/cgroup/user.slice/user-1000.slice/session-2.scope",
+		},
+		{
+			name:  "v2 root cgroup",
+			input: "0::/\n",
+			want:  "/sys/fs/cgroup/",
+		},
+		{
+			name:  "v2 entry after v1 entries",
+			input: "1:cpu:/system\n2:memory:/system\n0::/user.slice\n",
+			want:  "/sys/fs/cgroup/user.slice",
+		},
+		{
+			name:    "v1 only",
+			input:   "1:cpu:/\n2:memory:/\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty file",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:  "v2 found before trailing v1",
+			input: "0::/early\n1:cpu:/late\n",
+			want:  "/sys/fs/cgroup/early",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCgroupV2Path(strings.NewReader(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseCgroupV2Path() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseCgroupV2Path() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("io error surfaces instead of misleading message", func(t *testing.T) {
+		ioErr := errors.New("simulated read error")
+		_, err := parseCgroupV2Path(iotest.ErrReader(ioErr))
+		if err == nil {
+			t.Fatal("expected error from broken reader")
+		}
+		if !errors.Is(err, ioErr) {
+			t.Errorf("error should wrap io error, got: %v", err)
+		}
+	})
+}
+
+func TestHasControllers(t *testing.T) {
+	t.Run("with controllers", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "cgroup.controllers"), []byte("cpu memory pids\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !hasControllers(dir) {
+			t.Error("hasControllers should return true when controllers are present")
+		}
+	})
+
+	t.Run("empty controllers", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "cgroup.controllers"), []byte("\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if hasControllers(dir) {
+			t.Error("hasControllers should return false when controllers file is empty")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		if hasControllers(t.TempDir()) {
+			t.Error("hasControllers should return false when file doesn't exist")
+		}
+	})
+}

--- a/cmd/wtmcp/cgroup_trampoline_other.go
+++ b/cmd/wtmcp/cgroup_trampoline_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package main
+
+func maybeCgroupTrampoline() error { return nil }

--- a/cmd/wtmcp/main.go
+++ b/cmd/wtmcp/main.go
@@ -120,6 +120,15 @@ func main() {
 }
 
 func run(forceStdio bool) error {
+	// Cgroup trampoline: when a non-root user inherits a root-owned
+	// cgroup (common after su/sudo), re-exec through systemd-run so
+	// the process starts in the user's cgroup tree where sandbox
+	// resource limits work. Must run before any resource allocation
+	// since syscall.Exec replaces the process without running defers.
+	if reexecErr := maybeCgroupTrampoline(); reexecErr != nil {
+		log.Printf("cgroup trampoline: %v (continuing without cgroup resource limits)", reexecErr)
+	}
+
 	// Capture the caller's CWD for file I/O before anything changes it.
 	sessionDir, err := os.Getwd()
 	if err != nil || !filepath.IsAbs(sessionDir) {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
-	github.com/sergio-correia/go-arapuca v0.2.2
+	github.com/sergio-correia/go-arapuca v0.2.4
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.6
 	gitlab.com/gitlab-org/api/client-go v1.46.0

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/sebdah/goldie/v2 v2.8.0 h1:dZb9wR8q5++oplmEiJT+U/5KyotVD+HNGCAc5gNr8r
 github.com/sebdah/goldie/v2 v2.8.0/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/sergio-correia/go-arapuca v0.2.2 h1:NinN0AqOgiMR9kRBHGJcisDACRmKvyy9Mto9az31SIc=
-github.com/sergio-correia/go-arapuca v0.2.2/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
+github.com/sergio-correia/go-arapuca v0.2.4 h1:8jmbiOBfh1pS156pETZ14o3mhhebDAl2xesxBqAvSbA=
+github.com/sergio-correia/go-arapuca v0.2.4/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/internal/sandbox/sandbox_arapuca.go
+++ b/internal/sandbox/sandbox_arapuca.go
@@ -80,13 +80,15 @@ func (m *Manager) buildProfile(info PluginInfo) arapuca.Profile {
 	write := []string{tmpDir, dataDir}
 
 	return arapuca.Profile{
-		ReadPaths:     read,
-		WritePaths:    write,
-		MaxMemoryMB:   limits.MaxMemoryMB,
-		MaxCPUPct:     limits.MaxCPUPct,
-		MaxPIDs:       limits.MaxPIDs,
-		MaxFileSizeMB: limits.MaxFileSizeMB,
-		UseNetNS:      true,
+		ReadPaths:        read,
+		WritePaths:       write,
+		MaxMemoryMB:      limits.MaxMemoryMB,
+		MaxCPUPct:        limits.MaxCPUPct,
+		MaxPIDs:          limits.MaxPIDs,
+		MaxFileSizeMB:    limits.MaxFileSizeMB,
+		AllowExec:        isPython(info.Handler),
+		CgroupBestEffort: true,
+		UseNetNS:         true,
 	}
 }
 

--- a/internal/sandbox/sandbox_arapuca_test.go
+++ b/internal/sandbox/sandbox_arapuca_test.go
@@ -184,6 +184,13 @@ func TestBuildProfilePythonPlugin(t *testing.T) {
 	if len(pyProfile.ReadPaths) <= len(goProfile.ReadPaths) {
 		t.Error("Python plugin should have more ReadPaths than Go plugin (interpreter)")
 	}
+
+	if !pyProfile.AllowExec {
+		t.Error("AllowExec must be true for Python handlers (interpreter needs execve)")
+	}
+	if goProfile.AllowExec {
+		t.Error("AllowExec must be false for non-Python handlers")
+	}
 }
 
 func contains(slice []string, s string) bool {


### PR DESCRIPTION
- Add cgroup trampoline that re-execs through systemd-run --user --scope when the user inherits a root-owned cgroup (common in SSH/su sessions), so sandbox resource limits work without manual systemd configuration
- Set AllowExec on sandbox profiles for Python plugin handlers so Landlock permits execve on the interpreter
- Set CgroupBestEffort so the sandbox degrades gracefully when cgroup controllers aren't delegated instead of hard-failing
- Bump arapuca to 0.2.7 and go-arapuca to 0.2.4 (provide the required FFI)