### PR TITLE
chore: bump Go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LeGambiArt/wtmcp
 
-go 1.26.5
+go 1.26.6
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
Fixes GO-2026-6218 (net/url quadratic), GO-2026-6091 (html/template JS regexp), GO-2026-6090 (crypto/tls post-handshake), and GO-2026-6089 (net/http HTTP/2 ReadHeaderTimeout).