### PR TITLE
Assorted fixes: build layout, error handling, manifest schema, naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ all: build
 # Build everything
 build: wtmcp wtmcpctl plugins
 
+# Guard: a leftover ./wtmcp directory from an older layout blocks the binary build.
+$(if $(shell test -d wtmcp && echo y),$(error \
+	A "wtmcp" directory exists in the project root — this is a leftover from an older \
+	layout. Rename it to ".wtmcp-data" or remove it so the wtmcp binary can be built here: \
+	mv wtmcp .wtmcp-data))
+
 # Build wtmcp binary
 wtmcp: arapuca $(shell find cmd/wtmcp -name '*.go') $(shell find internal -name '*.go')
 	@echo "Building wtmcp..."
@@ -33,8 +39,7 @@ wtmcp: arapuca $(shell find cmd/wtmcp -name '*.go') $(shell find internal -name 
 # Build wtmcpctl binary
 wtmcpctl: arapuca $(shell find cmd/wtmcpctl -name '*.go') $(shell find internal -name '*.go')
 	@echo "Building wtmcpctl..."
-	@mkdir -p bin
-	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o bin/wtmcpctl ./cmd/wtmcpctl
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o wtmcpctl ./cmd/wtmcpctl
 
 # Build without arapuca sandbox (no libarapuca needed).
 # Requires WTMCP_UNSANDBOXED=1 at runtime.
@@ -132,7 +137,7 @@ pre-commit:
 # Clean build artifacts
 clean:
 	@echo "Cleaning..."
-	rm -f wtmcp bin/wtmcpctl coverage.out
+	rm -f wtmcp wtmcpctl coverage.out
 	rm -rf build/
 	rm -f plugins/*/handler
 	@for dir in plugins/*/; do \

--- a/cmd/wtmcpctl/agent.go
+++ b/cmd/wtmcpctl/agent.go
@@ -12,7 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const mcpServerKey = "what-the-mcp"
+const mcpServerKey = "wtmcp"
+const legacyServerKey = "what-the-mcp"
 
 // agentSpec defines how a specific AI agent stores its MCP server configuration.
 type agentSpec struct {
@@ -207,8 +208,9 @@ func agentEnable(agentName, dir string, readOnly bool) error {
 		serverEntry["type"] = "stdio"
 	}
 
-	// Set the server entry
+	// Set the server entry and remove legacy key if present
 	mcpServers[mcpServerKey] = serverEntry
+	delete(mcpServers, legacyServerKey)
 	config["mcpServers"] = mcpServers
 
 	// Write config
@@ -246,14 +248,17 @@ func agentDisable(agentName, dir string) error {
 		return nil
 	}
 
-	// Check if entry exists
-	if _, exists := mcpServers[mcpServerKey]; !exists {
+	// Check if either current or legacy entry exists
+	_, hasCurrent := mcpServers[mcpServerKey]
+	_, hasLegacy := mcpServers[legacyServerKey]
+	if !hasCurrent && !hasLegacy {
 		fmt.Printf("%s is not configured for %s in %s\n", mcpServerKey, agentName, dir)
 		return nil
 	}
 
-	// Remove the entry
+	// Remove both current and legacy entries
 	delete(mcpServers, mcpServerKey)
+	delete(mcpServers, legacyServerKey)
 
 	// If mcpServers is now empty, remove it from config
 	if len(mcpServers) == 0 {

--- a/cmd/wtmcpctl/agent_test.go
+++ b/cmd/wtmcpctl/agent_test.go
@@ -272,7 +272,7 @@ func TestAgentEnable_ClaudeVsClaudeCode_SameConfig(t *testing.T) {
 		t.Fatal("one or both configs missing mcpServers")
 	}
 
-	// Both should have what-the-mcp entry
+	// Both should have wtmcp entry
 	servers1 := config1["mcpServers"].(map[string]any)
 	servers2 := config2["mcpServers"].(map[string]any)
 
@@ -343,10 +343,10 @@ func TestAgentEnable_ClaudeCode_NewFile(t *testing.T) {
 		t.Fatal("mcpServers not found or wrong type")
 	}
 
-	// Check what-the-mcp entry
+	// Check wtmcp entry
 	wtmcp, ok := mcpServers[mcpServerKey].(map[string]any)
 	if !ok {
-		t.Fatalf("what-the-mcp entry not found or wrong type")
+		t.Fatalf("wtmcp entry not found or wrong type")
 	}
 
 	// Check type field (required for Claude Code)
@@ -464,7 +464,7 @@ func TestAgentEnable_ExistingServers(t *testing.T) {
 		t.Error("other-server was removed")
 	}
 	if _, ok := mcpServers[mcpServerKey]; !ok {
-		t.Error("what-the-mcp was not added")
+		t.Error("wtmcp was not added")
 	}
 }
 
@@ -517,7 +517,7 @@ func TestAgentEnable_Gemini_PreservesOtherSettings(t *testing.T) {
 		t.Error("other-server was removed")
 	}
 	if _, ok := mcpServers[mcpServerKey]; !ok {
-		t.Error("what-the-mcp was not added")
+		t.Error("wtmcp was not added")
 	}
 }
 
@@ -526,7 +526,7 @@ func TestAgentEnable_OverwriteExisting(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, ".mcp.json")
 
-	// Write existing config with what-the-mcp
+	// Write existing config with wtmcp
 	existingConfig := map[string]any{
 		"mcpServers": map[string]any{
 			mcpServerKey: map[string]any{
@@ -556,6 +556,101 @@ func TestAgentEnable_OverwriteExisting(t *testing.T) {
 	command := wtmcp["command"].(string)
 	if command == "/old/path/to/wtmcp" {
 		t.Error("command was not updated")
+	}
+}
+
+func TestAgentEnable_RemovesLegacyKey(t *testing.T) {
+	t.Skip("test requires wtmcp binary in PATH")
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Write config with legacy "what-the-mcp" key
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			legacyServerKey: map[string]any{
+				"command": "/old/path/to/wtmcp",
+				"type":    "stdio",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	if err := agentEnable("claude", tmpDir, false); err != nil {
+		t.Fatalf("agentEnable() failed: %v", err)
+	}
+
+	config, err := readJSONConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	mcpServers := config["mcpServers"].(map[string]any)
+
+	if _, ok := mcpServers[legacyServerKey]; ok {
+		t.Error("legacy key should have been removed")
+	}
+	if _, ok := mcpServers[mcpServerKey]; !ok {
+		t.Error("new key should have been added")
+	}
+}
+
+func TestAgentDisable_RemovesLegacyKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Write config with only legacy key
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			legacyServerKey: map[string]any{
+				"command": "/path/to/wtmcp",
+				"type":    "stdio",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	if err := agentDisable("claude", tmpDir); err != nil {
+		t.Fatalf("agentDisable() failed: %v", err)
+	}
+
+	// File should be removed (only entry was the legacy key)
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("config file should be removed when empty")
+	}
+}
+
+func TestAgentDisable_RemovesBothKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	// Write config with both legacy and current keys
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			legacyServerKey: map[string]any{
+				"command": "/old/path/to/wtmcp",
+				"type":    "stdio",
+			},
+			mcpServerKey: map[string]any{
+				"command": "/path/to/wtmcp",
+				"type":    "stdio",
+			},
+		},
+	}
+	if err := writeJSONConfig(configPath, config); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	if err := agentDisable("claude", tmpDir); err != nil {
+		t.Fatalf("agentDisable() failed: %v", err)
+	}
+
+	// File should be removed (both entries removed, nothing left)
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("config file should be removed when empty")
 	}
 }
 
@@ -591,9 +686,9 @@ func TestAgentDisable_RemovesEntry(t *testing.T) {
 
 	mcpServers := config["mcpServers"].(map[string]any)
 
-	// what-the-mcp should be removed
+	// wtmcp should be removed
 	if _, ok := mcpServers[mcpServerKey]; ok {
-		t.Error("what-the-mcp was not removed")
+		t.Error("wtmcp was not removed")
 	}
 
 	// other-server should still exist
@@ -615,7 +710,7 @@ func TestAgentDisable_NoEntry(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, ".mcp.json")
 
-	// Write config without what-the-mcp
+	// Write config without wtmcp
 	config := map[string]any{
 		"mcpServers": map[string]any{
 			"other-server": map[string]any{
@@ -644,7 +739,7 @@ func TestAgentDisable_ClaudeCode_RemovesFileWhenEmpty(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, ".mcp.json")
 
-	// Write config with only what-the-mcp
+	// Write config with only wtmcp
 	config := map[string]any{
 		"mcpServers": map[string]any{
 			mcpServerKey: map[string]any{
@@ -676,7 +771,7 @@ func TestAgentDisable_Cursor_RemovesFileWhenEmpty(t *testing.T) {
 
 	configPath := filepath.Join(cursorDir, "mcp.json")
 
-	// Write config with only what-the-mcp
+	// Write config with only wtmcp
 	config := map[string]any{
 		"mcpServers": map[string]any{
 			mcpServerKey: map[string]any{
@@ -708,7 +803,7 @@ func TestAgentDisable_Gemini_KeepsFileWhenEmpty(t *testing.T) {
 
 	configPath := filepath.Join(geminiDir, "settings.json")
 
-	// Write config with only what-the-mcp
+	// Write config with only wtmcp
 	config := map[string]any{
 		"mcpServers": map[string]any{
 			mcpServerKey: map[string]any{

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,8 @@ mkdir -p -m 700 ~/.config/wtmcp/env.d
 cp env.d/jira.env.example ~/.config/wtmcp/env.d/jira.env
 # Edit ~/.config/wtmcp/env.d/jira.env with your credentials
 chmod 600 ~/.config/wtmcp/env.d/jira.env
-./bin/wtmcpctl agent enable claude
-./bin/wtmcpctl check
+./wtmcpctl agent enable claude
+./wtmcpctl check
 # Open Claude Code and ask: "Who am I in Jira?"
 ```
 
@@ -199,7 +199,7 @@ Run the following command from your project directory (or from `$HOME` for
 global registration — see the Note below):
 
 ```bash
-./bin/wtmcpctl agent enable claude
+./wtmcpctl agent enable claude
 ```
 
 Expected output:
@@ -218,12 +218,12 @@ automatically whenever it needs to call an MCP tool.
 > agent name:
 >
 > ```bash
-> ./bin/wtmcpctl agent enable gemini   # writes .gemini/settings.json
-> ./bin/wtmcpctl agent enable cursor   # writes .cursor/mcp.json
+> ./wtmcpctl agent enable gemini   # writes .gemini/settings.json
+> ./wtmcpctl agent enable cursor   # writes .cursor/mcp.json
 > ```
 
 > **Note:** Registration is project-scoped by default. Running
-> `./bin/wtmcpctl agent enable claude` inside a project directory creates a
+> `./wtmcpctl agent enable claude` inside a project directory creates a
 > `.mcp.json` that applies only to that project. Running the same command from
 > `$HOME` creates `~/.mcp.json`, which Claude Code picks up for any project
 > that does not have its own `.mcp.json`.

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -598,50 +598,7 @@ func (t *ToolDef) ParamsSchema() map[string]any {
 	var required []string
 
 	for name, p := range t.Params {
-		prop := make(map[string]any)
-		if p.Type != "" {
-			prop["type"] = p.Type
-		}
-		if p.Description != "" {
-			prop["description"] = p.Description
-		}
-		if p.Default != nil {
-			prop["default"] = p.Default
-		}
-		if len(p.Enum) > 0 {
-			prop["enum"] = p.Enum
-		}
-		if p.Type == "array" && p.Items != nil {
-			itemSchema := make(map[string]any)
-			if p.Items.Type != "" {
-				itemSchema["type"] = p.Items.Type
-			}
-			if len(p.Items.Properties) > 0 {
-				itemProps := make(map[string]any, len(p.Items.Properties))
-				for pn, pp := range p.Items.Properties {
-					iprop := make(map[string]any)
-					if pp.Type != "" {
-						iprop["type"] = pp.Type
-					}
-					if pp.Description != "" {
-						iprop["description"] = pp.Description
-					}
-					if pp.Default != nil {
-						iprop["default"] = pp.Default
-					}
-					if len(pp.Enum) > 0 {
-						iprop["enum"] = pp.Enum
-					}
-					itemProps[pn] = iprop
-				}
-				itemSchema["properties"] = itemProps
-			}
-			if len(p.Items.Required) > 0 {
-				itemSchema["required"] = p.Items.Required
-			}
-			prop["items"] = itemSchema
-		}
-		properties[name] = prop
+		properties[name] = paramToSchema(p)
 		if p.Required {
 			required = append(required, name)
 		}
@@ -653,6 +610,44 @@ func (t *ToolDef) ParamsSchema() map[string]any {
 	}
 	if len(required) > 0 {
 		schema["required"] = required
+	}
+	return schema
+}
+
+func paramToSchema(p ParamDef) map[string]any {
+	prop := make(map[string]any)
+	if p.Type != "" {
+		prop["type"] = p.Type
+	}
+	if p.Description != "" {
+		prop["description"] = p.Description
+	}
+	if p.Default != nil {
+		prop["default"] = p.Default
+	}
+	if len(p.Enum) > 0 {
+		prop["enum"] = p.Enum
+	}
+	if p.Type == "array" && p.Items != nil {
+		prop["items"] = itemsToSchema(p.Items)
+	}
+	return prop
+}
+
+func itemsToSchema(items *ItemsDef) map[string]any {
+	schema := make(map[string]any)
+	if items.Type != "" {
+		schema["type"] = items.Type
+	}
+	if len(items.Properties) > 0 {
+		props := make(map[string]any, len(items.Properties))
+		for name, pp := range items.Properties {
+			props[name] = paramToSchema(pp)
+		}
+		schema["properties"] = props
+	}
+	if len(items.Required) > 0 {
+		schema["required"] = items.Required
 	}
 	return schema
 }

--- a/internal/server/discovery.go
+++ b/internal/server/discovery.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -54,7 +55,10 @@ func registerToolSearch(srv *mcpserver.MCPServer, index *ToolIndex, excludeWrite
 				out[i] = r.toSearchResult()
 			}
 
-			data, _ := json.Marshal(out)
+			data, err := json.Marshal(out)
+			if err != nil {
+				return nil, fmt.Errorf("marshal search results: %w", err)
+			}
 			return sanitizedTextResult(string(data)), nil
 		},
 	)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -202,7 +202,12 @@ func registerPluginTools(deps *serverDeps, manifest *plugin.Manifest) {
 			}
 		}
 
-		tool, schemaJSON := buildMCPTool(toolDef, progressive)
+		tool, schemaJSON, err := buildMCPTool(toolDef, progressive)
+		if err != nil {
+			log.Printf("WARNING: tool %q from plugin %q skipped: %v", toolName, plugName, err)
+			skipped++
+			continue
+		}
 		if manifest.IsUserPlugin {
 			tool.Description = "[user plugin] " + sanitizeContent(tool.Description)
 		}
@@ -402,9 +407,12 @@ func registerPluginTools(deps *serverDeps, manifest *plugin.Manifest) {
 	}
 }
 
-func buildMCPTool(def plugin.ToolDef, progressive bool) (mcp.Tool, []byte) {
+func buildMCPTool(def plugin.ToolDef, progressive bool) (mcp.Tool, []byte, error) {
 	schema := def.ParamsSchema()
-	schemaJSON, _ := json.Marshal(schema)
+	schemaJSON, err := json.Marshal(schema)
+	if err != nil {
+		return mcp.Tool{}, nil, fmt.Errorf("marshal schema for %s: %w", def.Name, err)
+	}
 	tool := mcp.NewToolWithRawSchema(def.Name, def.Description, schemaJSON)
 
 	if progressive && !def.IsPrimary() {
@@ -425,7 +433,7 @@ func buildMCPTool(def plugin.ToolDef, progressive bool) (mcp.Tool, []byte) {
 		tool.Annotations.DestructiveHint = &t
 	}
 
-	return tool, schemaJSON
+	return tool, schemaJSON, nil
 }
 
 func registerDisabledPluginTools(srv *mcpserver.MCPServer, disabled map[string]plugin.DisabledPlugin, progressive bool, readOnly bool, auditor *audit.Logger) {
@@ -440,7 +448,11 @@ func registerDisabledPluginTools(srv *mcpserver.MCPServer, disabled map[string]p
 				continue
 			}
 
-			tool, _ := buildMCPTool(toolDef, progressive)
+			tool, _, err := buildMCPTool(toolDef, progressive)
+			if err != nil {
+				log.Printf("WARNING: disabled tool %q from plugin %q skipped: %v", toolDef.Name, pluginName, err)
+				continue
+			}
 			prefix := "[DISABLED]"
 			if dp.Manifest.IsUserPlugin {
 				prefix = "[DISABLED] [user plugin]"

--- a/plugins/google-calendar/plugin.yaml
+++ b/plugins/google-calendar/plugin.yaml
@@ -83,6 +83,8 @@ tools:
         type: string
       attendees:
         type: array
+        items:
+          type: string
         description: "List of attendee email addresses"
       all_day:
         type: boolean
@@ -167,4 +169,6 @@ tools:
         description: "End time in RFC3339 format"
       calendar_ids:
         type: array
+        items:
+          type: string
         description: "List of calendar IDs (default: primary)"

--- a/plugins/google-drive/plugin.yaml
+++ b/plugins/google-drive/plugin.yaml
@@ -157,9 +157,13 @@ tools:
         default: false
       mime_types:
         type: array
+        items:
+          type: string
         description: "Filter by MIME types"
       owners:
         type: array
+        items:
+          type: string
         description: "Filter by owners (e.g. ['me'])"
       include_trashed:
         type: boolean

--- a/plugins/google-gmail/plugin.yaml
+++ b/plugins/google-gmail/plugin.yaml
@@ -36,6 +36,8 @@ tools:
         description: "Max messages (hard limit: 100)"
       label_ids:
         type: array
+        items:
+          type: string
         description: "Filter by label IDs"
 
   - name: gmail_get_messages_summary
@@ -45,6 +47,8 @@ tools:
     params:
       message_ids:
         type: array
+        items:
+          type: string
         required: true
         description: "List of Gmail message IDs"
       max_messages:
@@ -62,6 +66,8 @@ tools:
         description: "Gmail search query"
       message_ids:
         type: array
+        items:
+          type: string
         description: "Specific message IDs (alternative to query)"
       max_messages:
         type: integer
@@ -78,6 +84,8 @@ tools:
     params:
       message_ids:
         type: array
+        items:
+          type: string
         required: true
         description: "List of message IDs (max 20)"
       format:
@@ -138,9 +146,13 @@ tools:
         required: true
       add_labels:
         type: array
+        items:
+          type: string
         description: "Label IDs to add"
       remove_labels:
         type: array
+        items:
+          type: string
         description: "Label IDs to remove"
       dry_run:
         type: boolean

--- a/plugins/testing-farm/handler.py
+++ b/plugins/testing-farm/handler.py
@@ -197,7 +197,7 @@ def _discover_ssh_keys():
 def _validate_request_id(request_id):
     """Validate that request_id is a UUID."""
     if not _UUID_RE.match(request_id):
-        raise Exception(f"Invalid request ID format: {request_id}")
+        raise ValueError(f"Invalid request ID format: {request_id}")
 
 
 def _fetch_request(request_id):
@@ -965,7 +965,7 @@ def testing_farm_cancel(params):
     if dry_run is not False:
         status, body, _ = http("GET", f"/{API_VERSION}/requests/{request_id}")
         if status != 200:
-            raise Exception(f"Cannot fetch request {request_id} (HTTP {status}): {body}")
+            raise ApiError(status, body)
         state = body.get("state", "unknown") if isinstance(body, dict) else "unknown"
         return {
             "dry_run": True,


### PR DESCRIPTION
  - build: Move wtmcpctl output to project root alongside wtmcp, removing the stale bin/ directory; add a Makefile guard for the legacy ./wtmcp data directory that conflicts with the binary
  - server: Propagate json.Marshal errors in tool and search registration instead of silently dropping them
  - manifest: Support arbitrary nesting depth in ParamsSchema (previously capped at two levels)
  - wtmcpctl: Rename MCP server key from what-the-mcp to wtmcp
  - testing-farm: Use ValueError and ApiError instead of bare Exception in error paths
