### PR TITLE
plugin: resolve relative auth credential paths

### DIFF
--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -1524,6 +1524,9 @@ func (m *Manager) resolveAuth(pluginName string, manifest *Manifest) auth.Provid
 		if path == "" {
 			return ""
 		}
+		if !filepath.IsAbs(path) && credDir != "" {
+			path = filepath.Join(credDir, path)
+		}
 		decrypted, err := m.decryptCredentialIfVault(pluginName, path)
 		if err != nil {
 			log.Printf("[%s] credential file decrypt failed, skipping: %v", pluginName, err)


### PR DESCRIPTION
Auth variants (JWT/service-account) that specify a relative CredentialsFile or PrivateKeyFile were passed straight to the vault decryption helper without first anchoring them to the plugin's credentials directory, so they ended up resolved against the process's current working directory instead of the intended per-plugin or per-credential-group location. Join relative paths with credDir before decrypting, matching the resolution already applied to the base credentials directory a few lines above.