### PR TITLE
gitlab: add commit_files tool for atomic multi-file commits

### DIFF
--- a/plugins/gitlab/main.go
+++ b/plugins/gitlab/main.go
@@ -42,6 +42,7 @@ func main() {
 	p.Handle("gitlab_create_or_update_file", toolCreateOrUpdateFile)
 	p.Handle("gitlab_create_mr_discussion", toolCreateMRDiscussion)
 	p.Handle("gitlab_add_mr_note", toolAddMRNote)
+	p.Handle("gitlab_commit_files", toolCommitFiles)
 
 	if err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "handler: %v\n", err)

--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -477,6 +477,45 @@ tools:
         default: true
         description: "Preview without creating (default: true)"
 
+  - name: gitlab_commit_files
+    access: write
+    description: >
+      Commit multiple files in a single atomic commit. Pass files as an
+      array of {path, content} objects. Shell scripts (.sh) automatically
+      get executable permission (100755). Defaults to dry_run=true.
+    params:
+      instance:
+        type: string
+      project_id:
+        type: string
+        required: true
+        description: "Project ID or path (e.g. 'group/project')"
+      branch:
+        type: string
+        required: true
+        description: "Target branch for the commit"
+      files:
+        type: array
+        required: true
+        description: "Array of {path, content} objects to commit"
+        items:
+          type: object
+          properties:
+            path:
+              type: string
+              description: "File path in the repository"
+            content:
+              type: string
+              description: "File content (plain text)"
+      message:
+        type: string
+        required: true
+        description: "Commit message"
+      dry_run:
+        type: boolean
+        default: true
+        description: "Preview without committing (default: true)"
+
   - name: gitlab_create_mr_discussion
     access: write
     description: >

--- a/plugins/gitlab/tools_write.go
+++ b/plugins/gitlab/tools_write.go
@@ -548,6 +548,130 @@ func toolCreateOrUpdateFile(params, _ json.RawMessage) (any, error) {
 	}, nil
 }
 
+// --- gitlab_commit_files ---
+
+type commitFileEntry struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+type commitFilesParams struct {
+	instanceParam
+	ProjectID string            `json:"project_id"`
+	Branch    string            `json:"branch"`
+	Files     []commitFileEntry `json:"files"`
+	Message   string            `json:"message"`
+	DryRun    *bool             `json:"dry_run"`
+}
+
+func toolCommitFiles(params, _ json.RawMessage) (any, error) {
+	var p commitFilesParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if p.ProjectID == "" {
+		return nil, fmt.Errorf("project_id is required")
+	}
+	if len(p.Files) == 0 {
+		return nil, fmt.Errorf("files is required and must be a non-empty array")
+	}
+	if strings.TrimSpace(p.Message) == "" {
+		return nil, fmt.Errorf("message is required")
+	}
+	if p.Branch != "" {
+		if err := validateBranch(p.Branch); err != nil {
+			return nil, fmt.Errorf("branch: %w", err)
+		}
+	}
+
+	for i, f := range p.Files {
+		if err := validatePath(f.Path); err != nil {
+			return nil, fmt.Errorf("files[%d]: %w", i, err)
+		}
+		if f.Content == "" {
+			return nil, fmt.Errorf("files[%d]: content is required", i)
+		}
+		if len(f.Content) > 1_000_000 {
+			return nil, fmt.Errorf("files[%d]: content exceeds 1MB limit (%d bytes)", i, len(f.Content))
+		}
+	}
+
+	// Build file summary with modes for dry_run and result
+	type fileSummary struct {
+		Path string `json:"path"`
+		Mode string `json:"mode"`
+	}
+	fileSummaries := make([]fileSummary, len(p.Files))
+	for i, f := range p.Files {
+		mode := "100644"
+		if strings.HasSuffix(f.Path, ".sh") {
+			mode = "100755"
+		}
+		fileSummaries[i] = fileSummary{Path: f.Path, Mode: mode}
+	}
+
+	if isDryRun(p.DryRun) {
+		return map[string]any{
+			"dry_run":    true,
+			"action":     "gitlab_commit_files",
+			"project_id": p.ProjectID,
+			"branch":     p.Branch,
+			"message":    p.Message,
+			"file_count": len(p.Files),
+			"files":      fileSummaries,
+		}, nil
+	}
+
+	client, err := resolveInstance(p.Instance)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check which files exist to determine create vs update action
+	actions := make([]*gogitlab.CommitActionOptions, len(p.Files))
+	for i, f := range p.Files {
+		action := gogitlab.FileCreate
+		getOpts := &gogitlab.GetFileOptions{}
+		if p.Branch != "" {
+			getOpts.Ref = &p.Branch
+		}
+		_, getResp, getErr := client.RepositoryFiles.GetFile(p.ProjectID, f.Path, getOpts)
+		if getErr == nil {
+			action = gogitlab.FileUpdate
+		} else if getResp == nil || getResp.StatusCode != http.StatusNotFound {
+			return nil, fmt.Errorf("check if file %q exists: %w", f.Path, getErr)
+		}
+
+		content := f.Content
+		isExecutable := strings.HasSuffix(f.Path, ".sh")
+		actions[i] = &gogitlab.CommitActionOptions{
+			Action:          &action,
+			FilePath:        &f.Path,
+			Content:         &content,
+			ExecuteFilemode: &isExecutable,
+		}
+	}
+
+	opts := &gogitlab.CreateCommitOptions{
+		Branch:        &p.Branch,
+		CommitMessage: &p.Message,
+		Actions:       actions,
+	}
+
+	commit, _, err := client.Commits.CreateCommit(p.ProjectID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create commit: %w", err)
+	}
+
+	return map[string]any{
+		"commit":     commit.ShortID,
+		"branch":     p.Branch,
+		"project_id": p.ProjectID,
+		"file_count": len(p.Files),
+		"files":      fileSummaries,
+	}, nil
+}
+
 // --- helpers ---
 
 func fetchDiffRefs(client *gogitlab.Client, pid string, mrIID int64) (baseSHA, headSHA, startSHA string, err error) {


### PR DESCRIPTION
Mirror of github_commit_files — uses GitLab Commits API with actions array to push multiple files in a single commit. Shell scripts (.sh) get executable permission via ExecuteFilemode.